### PR TITLE
require asf_search>=3.0.4

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,9 +20,9 @@ dependencies:
  - geopandas
  - pip
  - boto3
+ - asf_search>=3.0.4
  - pip:
    - dem_stitcher
-   - asf_search
    - tqdm
    - lxml
    - click


### PR DESCRIPTION
asf_search v3.0.4 resolves https://github.com/asfadmin/Discovery-asf_search/issues/46 , which was causing localize_slc.py to fail when run from an EC2 instance in AWS.