### PR TITLE
Update dem stitcher api

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
  - boto3
  - asf_search>=3.0.4
  - pip:
-   - dem_stitcher
+   - git+https://github.com/ACCESS-Cloud-Based-InSAR/dem_stitcher.git
    - tqdm
    - lxml
    - click

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
  - anaconda
  - defaults
 dependencies:
- - python=3.8
+ - python>=3.8
  - isce2
  - jupyter
  - papermill

--- a/isce2_topsapp/localize_dem.py
+++ b/isce2_topsapp/localize_dem.py
@@ -74,7 +74,7 @@ def download_dem_for_isce2(extent: list,
 
     full_res_dem_path = full_res_dem_dir/'full_res.dem.wgs84'
     dem_array[np.isnan(dem_array)] = 0.
-    dem_profile['nodata'] = 0.
+    dem_profile['nodata'] = None
     dem_profile['driver'] = 'ISCE'
     with rasterio.open(full_res_dem_path, 'w', **dem_profile) as ds:
         ds.write(dem_array, 1)

--- a/isce2_topsapp/localize_dem.py
+++ b/isce2_topsapp/localize_dem.py
@@ -1,11 +1,12 @@
 from lxml import etree
 import rasterio
 from shapely.geometry import box
-from dem_stitcher.stitcher import download_dem
+from dem_stitcher.stitcher import stitch_dem
 from dem_stitcher.rio_tools import resample_by_multiple
 from pathlib import Path
 import subprocess
 import site
+import numpy as np
 
 
 def tag_dem_xml_as_ellipsoidal(dem_path: Path) -> str:
@@ -66,13 +67,17 @@ def download_dem_for_isce2(extent: list,
     extent_buffered = list(extent_geo.buffer(buffer).bounds)
     extent_buffered = list(map(lambda e: round(e, 3), extent_buffered))
 
-    full_res_dem_path = download_dem(extent_buffered,
-                                     dem_name,
-                                     full_res_dem_dir,
-                                     dst_file_name='full_res.dem.wgs84')
+    dem_array, dem_profile = stitch_dem(extent_buffered,
+                                        'glo_30',
+                                        dst_ellipsoidal_height=True,
+                                        max_workers=5)
 
-    with rasterio.open(full_res_dem_path) as ds:
-        dem_array, dem_profile = ds.read(1), ds.profile
+    full_res_dem_path = full_res_dem_dir/'full_res.dem.wgs84'
+    dem_array[np.isnan(dem_array)] = 0.
+    dem_profile['nodata'] = 0.
+    dem_profile['driver'] = 'ISCE'
+    with rasterio.open(full_res_dem_path, 'w', **dem_profile) as ds:
+        ds.write(dem_array, 1)
 
     dem_geocode_arr, dem_geocode_profile = resample_by_multiple(dem_array,
                                                                 dem_profile,
@@ -80,6 +85,7 @@ def download_dem_for_isce2(extent: list,
     dem_geocode_arr = dem_geocode_arr[0, ...]
     low_res_dem_path = (low_res_dem_dir/'low_res.dem.wgs84')
 
+    dem_geocode_profile['driver'] = 'ISCE'
     with rasterio.open(low_res_dem_path, 'w', **dem_geocode_profile) as ds:
         ds.write(dem_geocode_arr, 1)
 


### PR DESCRIPTION
Fixes #22.

@gracebato - I tried this branch using the problematic pair. I believe it fixes.

Important notes:

- uses 0 for nodata areas
- The `gdal` metadata `nodata` is set to None.

```
isce2_topsapp --reference-scenes S1B_IW_SLC__1SDV_20211004T161549_20211004T161616_028988_037594_4DF8 --secondary-scenes S1A_IW_SLC__1SDV_20210928T161630_20210928T161657_039884_04B811_264A
```

Gets browse imagery

![image](https://user-images.githubusercontent.com/5975894/141386723-73d85c89-f905-453b-822c-fb6f0fd7a305.png)
