### PR TITLE
Simplify product delivery

### DIFF
--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -93,15 +93,9 @@ def main():
     # Move final product to current working directory
     final_directory = prepare_for_delivery(nc_path, loc_data)
 
-    files = list(final_directory.glob('*'))
-    # ignore os files, if any
-    files = list(filter(lambda x: x.name[0] != '.', files))
     if args.bucket:
-        dataset_prefix = args.bucket_prefix
-        # final_directory is the product id
-        product_prefix = f'{dataset_prefix}/{final_directory.name}'
-        for file in files:
-            aws.upload_file_to_s3(file, args.bucket, product_prefix)
+        for file in final_directory.glob('S1-GUNW*'):
+            aws.upload_file_to_s3(file, args.bucket, args.bucket_prefix)
 
 
 if __name__ == '__main__':

--- a/isce2_topsapp/delivery_prep.py
+++ b/isce2_topsapp/delivery_prep.py
@@ -143,23 +143,20 @@ def format_metadata(nc_path: Path,
 
 def prepare_for_delivery(nc_path: Path,
                          all_metadata: dict) -> Path:
-
-    nc_filename = nc_path.name
-    gunw_id = nc_filename.split('.')[0]
+    gunw_id = nc_path.stem
 
     out_dir = Path(gunw_id)
     out_dir.mkdir(exist_ok=True)
 
-    browse_path = out_dir / 'browse.png'
+    browse_path = out_dir / f'{gunw_id}.png'
     gen_browse_imagery(nc_path, browse_path)
 
     metadata = format_metadata(nc_path, all_metadata)
-    metadata_path = out_dir / 'dataset.json'
+    metadata_path = out_dir / f'{gunw_id}.json'
     json.dump(metadata,
               open(metadata_path, 'w'),
               indent=2)
 
-    # move product to Netcdf Path
-    nc_path.rename(out_dir / nc_filename)
+    nc_path.rename(out_dir / f'{gunw_id}.nc')
 
     return out_dir


### PR DESCRIPTION
Currently, this plugin will upload files to S3 like:
```shell
$ aws s3 ls --recursive --no-sign-request s3://hyp3-isce-contentbucket-4xpualmsjg98/a90f0ce8-e68d-4484-9a80-bf223d0067b3/
a90f0ce8-e68d-4484-9a80-bf223d0067b3/S1-GUNW-A-R-064-20210723-20210711-015000-119W_33N-f4d6-v2_0_5/S1-GUNW-A-R-064-20210723-20210711-015000-119W_33N-f4d6-v2_0_5.nc
a90f0ce8-e68d-4484-9a80-bf223d0067b3/S1-GUNW-A-R-064-20210723-20210711-015000-119W_33N-f4d6-v2_0_5/browse.png
a90f0ce8-e68d-4484-9a80-bf223d0067b3/S1-GUNW-A-R-064-20210723-20210711-015000-119W_33N-f4d6-v2_0_5/dataset.json
```
You can see the JSON HyP3 API resonse for this example job here: [a90f0ce8-e68d-4484-9a80-bf223d0067b3](https://hyp3-isce.asf.alaska.edu/jobs/a90f0ce8-e68d-4484-9a80-bf223d0067b3)

This changes it so files will be uploaded like:
```shell
$ aws s3 ls --recursive --no-sign-request s3://hyp3-isce-contentbucket-4xpualmsjg98/a90f0ce8-e68d-4484-9a80-bf223d0067b3/
a90f0ce8-e68d-4484-9a80-bf223d0067b3/S1-GUNW-A-R-064-20210723-20210711-015000-119W_33N-f4d6-v2_0_5.nc
a90f0ce8-e68d-4484-9a80-bf223d0067b3/S1-GUNW-A-R-064-20210723-20210711-015000-119W_33N-f4d6-v2_0_5.png
a90f0ce8-e68d-4484-9a80-bf223d0067b3/S1-GUNW-A-R-064-20210723-20210711-015000-119W_33N-f4d6-v2_0_5.json
```

Namely:
* The files are all upload flat under the Job Id prefix
* All files are named like `[GUNW_ID].[EXT]` so that 
  * they are always associated together when downloaded, and 
  * you can reference any of them by just replacing the final extension (e.g., `nc_path.replace('.nc', '.json')` will get you the path to the metadata file) 


fixes #31 