### PR TITLE
Updating Pyproj and fixing Georeferencing

### DIFF
--- a/isce2_topsapp/packaging_utils/isce_functions.py
+++ b/isce2_topsapp/packaging_utils/isce_functions.py
@@ -315,7 +315,7 @@ def get_h5_dataset_coords(args):
         variable = geovariable[0]
         varname = variable.split('/')[-1]
         if varname == 'longitude' or varname == 'Longitude' or varname == 'lon' or varname == 'Lon' or  varname == 'lons' or varname == 'Lons':
-            lons = get_h5_dataset_2([h5_file,variable])
+            lons = get_h5_dataset([h5_file,variable])
             count+=1
             lons_map = geovariable[1]
         elif varname == 'latitude' or varname == 'Latitude' or varname == 'lat' or varname == 'Lat' or  varname == 'lats' or varname == 'Lats':
@@ -377,25 +377,7 @@ def get_h5_dataset(args):
     file_name=  args[0]
     path_variable = args[1]
     datafile = h5py.File(file_name,'r')
-    data = datafile[path_variable][:][::-1]
-
-    return data
-
-def get_h5_dataset_2(args):
-    '''
-        Extracts a hdf5 variable and return the content of it
-        INPUTS:
-        filename    str of the hdf5 file
-        variable    str describing the path within the hdf5 file: e.g. cube/dataset1
-    '''
-
-    import h5py
-    import numpy as np
-
-    file_name=  args[0]
-    path_variable = args[1]
-    datafile = h5py.File(file_name,'r')
-    data = datafile[path_variable][:][::]
+    data = datafile[path_variable][:]
 
     return data
 

--- a/isce2_topsapp/packaging_utils/isce_functions.py
+++ b/isce2_topsapp/packaging_utils/isce_functions.py
@@ -315,7 +315,7 @@ def get_h5_dataset_coords(args):
         variable = geovariable[0]
         varname = variable.split('/')[-1]
         if varname == 'longitude' or varname == 'Longitude' or varname == 'lon' or varname == 'Lon' or  varname == 'lons' or varname == 'Lons':
-            lons = get_h5_dataset([h5_file,variable])
+            lons = get_h5_dataset_2([h5_file,variable])
             count+=1
             lons_map = geovariable[1]
         elif varname == 'latitude' or varname == 'Latitude' or varname == 'lat' or varname == 'Lat' or  varname == 'lats' or varname == 'Lats':
@@ -378,6 +378,24 @@ def get_h5_dataset(args):
     path_variable = args[1]
     datafile = h5py.File(file_name,'r')
     data = datafile[path_variable][:][::-1]
+
+    return data
+
+def get_h5_dataset_2(args):
+    '''
+        Extracts a hdf5 variable and return the content of it
+        INPUTS:
+        filename    str of the hdf5 file
+        variable    str describing the path within the hdf5 file: e.g. cube/dataset1
+    '''
+
+    import h5py
+    import numpy as np
+
+    file_name=  args[0]
+    path_variable = args[1]
+    datafile = h5py.File(file_name,'r')
+    data = datafile[path_variable][:][::]
 
     return data
 

--- a/isce2_topsapp/packaging_utils/makeGeocube.py
+++ b/isce2_topsapp/packaging_utils/makeGeocube.py
@@ -145,48 +145,29 @@ def loadProduct(xmlname):
     return obj
 
 
-def getUTMZone(inps):
-    '''
-    Determine UTM zone for scene center. Can update to use majority of scene later.
-    '''
-
-    def latlon_to_zone_number(latitude, longitude):
-        if 56 <= latitude < 64 and 3 <= longitude < 12:
-            return 32
-
-        if 72 <= latitude <= 84 and longitude >= 0:
-            if longitude < 9:
-                return 31
-            elif longitude < 21:
-                return 33
-            elif longitude < 33:
-                return 35
-            elif longitude < 42:
-                return 37
-
-        return int((longitude + 180) / 6) + 1
-
-    def latitude_to_zone_letter(latitude):
-        ZONE_LETTERS = "CDEFGHJKLMNPQRSTUVWXX"
-        if -80 <= latitude <= 84:
-            return ZONE_LETTERS[int(latitude + 80) >> 3]
-        else:
-            return None
-
-    lat = inps.sceneCenter[0]
-    lon = inps.sceneCenter[1]
-
-    zone = latlon_to_zone_number(lat, lon)
-    inps.utmzone = str(zone) + latitude_to_zone_letter(lat)
-
-    if lat < 0:
-        pad = '+south'
+def convert_4326_to_utm(lon: float, lat: float) -> str:
+    """
+    Obtain UTM zone from (lon, lat) coordinate.
+    From: https://gis.stackexchange.com/a/269552
+    Parameters
+    ----------
+    lon : float
+        Longitude
+    lat : float
+        Latitude
+    Returns
+    -------
+    str:
+        epsg code, in the form `epsg:<epsg_num>`.
+    """
+    utm_band = str(int((np.floor((lon + 180) / 6) % 60) + 1))
+    if len(utm_band) == 1:
+        utm_band = '0'+utm_band
+    if lat >= 0:
+        epsg_code = '326' + utm_band
     else:
-        pad = ''
-
-    inps.utm = '+proj=utm +zone={0} {1} +ellps=WGS84 +datum=WGS84 +units=m +no_defs'.format(
-        zone, pad)
-    return inps.utm
+        epsg_code = '327' + utm_band
+    return int(epsg_code)
 
 
 def getMergedOrbit(product):
@@ -303,7 +284,11 @@ def estimateGridPoints(inps):
     inps.y0 = (int(np.min(pts[:, 1]) / inps.yspacing) - 2) * inps.yspacing
     inps.y1 = (int(np.max(pts[:, 1]) / inps.yspacing) + 3) * inps.yspacing
     inps.Ny = int(np.round((inps.y1 - inps.y0) / inps.yspacing)) + 1
-    inps.utmproj = pyproj.Proj(getUTMZone(inps))
+
+    lat = inps.sceneCenter[0]
+    lon = inps.sceneCenter[1]
+    utm_epsg = convert_4326_to_utm(lon, lat)
+    inps.utmproj = CRS.from_epsg(utm_epsg)
 
 
 @simple_time_tracker(_log)
@@ -349,7 +334,7 @@ def writeInputs(inps, fid):
     grp.create_dataset(
         'projection', data=[str(inps.proj).encode('utf-8')], dtype='S200')
     grp.create_dataset(
-        'localutm', data=[inps.utm.encode('utf-8')], dtype='S200')
+        'localutm', data=[str(inps.utmproj).encode('utf-8')], dtype='S200')
 
 
 @simple_time_tracker(_log)

--- a/isce2_topsapp/packaging_utils/makeGeocube.py
+++ b/isce2_topsapp/packaging_utils/makeGeocube.py
@@ -16,6 +16,8 @@ import shutil
 from time import time
 from functools import wraps
 from joblib import Parallel, delayed, dump, load
+from pathlib import Path
+from pyproj import CRS
 
 from iscesys.Component.ProductManager import ProductManager as PM
 from isceobj.Orbit.Orbit import Orbit
@@ -274,10 +276,9 @@ def estimateGridPoints(inps):
     '''
 
     #pdb.set_trace()
-    inps.proj4 = 'EPSG:{0}'.format(inps.epsg)
-    inps.proj = pyproj.Proj(init=inps.proj4)
+    inps.proj = CRS.from_epsg(int(inps.epsg))
     inps.ecef = pyproj.Proj(proj='geocent', ellps='WGS84', datum='WGS84')
-    inps.lla = pyproj.Proj(proj='latlong', ellps='WGS84', datum='WGS84')
+    inps.lla = CRS.from_epsg(4326)
 
     inps.earlyNear = inps.orbit.rdr2geo(inps.sensingStart, inps.nearRange)
     inps.lateNear = inps.orbit.rdr2geo(inps.sensingStop, inps.nearRange)
@@ -289,9 +290,9 @@ def estimateGridPoints(inps):
         inps.midtime, 0.5 * (inps.nearRange + inps.farRange))
 
     pts = []
+    pts_trans = pyproj.Transformer.from_proj(inps.lla, inps.proj, always_xy=True)
     for x in [inps.earlyNear, inps.lateNear, inps.earlyFar, inps.lateFar]:
-        pts.append(
-            list(pyproj.transform(inps.lla, inps.proj, x[1], x[0], x[2])))
+        pts.append(list(pts_trans.transform(x[1], x[0], x[2])))
 
     pts = np.array(pts)
 
@@ -346,7 +347,7 @@ def writeInputs(inps, fid):
     orb.create_dataset(
         'velocity', data=np.array([x.getVelocity() for x in inps.orbit]))
     grp.create_dataset(
-        'projection', data=[inps.proj4.encode('utf-8')], dtype='S200')
+        'projection', data=[str(inps.proj).encode('utf-8')], dtype='S200')
     grp.create_dataset(
         'localutm', data=[inps.utm.encode('utf-8')], dtype='S200')
 
@@ -408,10 +409,13 @@ class Cube(object):
         '''
 
         yval = self.inps.y1 - ii * self.inps.yspacing
-        #satutm = np.array( pyproj.transform( lla, utm, satllh[0], satllh[1], satllh[2]))
         self.latvector[ii] = yval
 
         logger.info("Running ROW: " + str(ii + 1) + " of " + str(self.inps.Ny))
+
+        tarproj_trans = pyproj.Transformer.from_proj(self.inps.proj, self.inps.lla, always_xy=True)
+        targxyz_trans = pyproj.Transformer.from_proj(self.inps.proj, self.inps.ecef, always_xy=True)
+        targutm_trans = pyproj.Transformer.from_proj(self.inps.proj, self.inps.utmproj, always_xy=True)
 
         for jj in range(self.inps.Nx):
             xval = self.inps.x0 + jj * self.inps.xspacing
@@ -419,13 +423,10 @@ class Cube(object):
                 self.lonvector[jj] = xval
 
             for ind, hh in enumerate(self.inps.heights):
-                targproj = pyproj.transform(self.inps.proj, self.inps.lla, xval,
-                                            yval, hh)
+                targproj = tarproj_trans.transform(xval, yval, hh)
                 targ = [targproj[1], targproj[0], targproj[2]]
-                targxyz = pyproj.transform(self.inps.proj, self.inps.ecef, xval,
-                                           yval, hh)
-                targutm = pyproj.transform(self.inps.proj, self.inps.utmproj,
-                                           xval, yval, hh)
+                targxyz = targxyz_trans.transform(xval, yval, hh)
+                targutm = targutm_trans.transform(xval, yval, hh)
                 targnorm = self.nvector(targproj)
 
                 try:
@@ -436,16 +437,19 @@ class Cube(object):
 
                 if mrng is not None:
 
+                    satllh_trans = pyproj.Transformer.from_proj(self.inps.ecef,
+                                                                self.inps.lla,
+                                                                always_xy=True)
+                    satutm_trans = pyproj.Transformer.from_proj(self.inps.lla,
+                                                                self.inps.utmproj,
+                                                                always_xy=True)
+
                     sv = self.inps.orbit.interpolateOrbit(
                         mtaz, method='hermite')
                     satpos = np.array(sv.getPosition())
                     satvel = np.array(sv.getVelocity())
-                    satllh = np.array(
-                        pyproj.transform(self.inps.ecef, self.inps.lla,
-                                         satpos[0], satpos[1], satpos[2]))
-                    satutm = np.array(
-                        pyproj.transform(self.inps.lla, self.inps.utmproj,
-                                         satllh[0], satllh[1], satllh[2]))
+                    satllh = np.array(satllh_trans.transform(satpos[0], satpos[1], satpos[2]))
+                    satutm = np.array(satutm_trans.transform(satllh[0], satllh[1], satllh[2]))
                     satnorm = self.nvector(satllh)
 
                     self.azimuthtime[ind, ii, jj] = (
@@ -614,15 +618,13 @@ def main():
     ##Get corners
     estimateGridPoints(inps)
 
-    ####Check for existing HDF5 file
-    if os.path.exists(inps.outh5):
-        logger.info('{0} file already exists'.format(inps.outh5))
-        raise Exception('Output file already exists')
-
     ###Create h5 file
-    fid = h5py.File(inps.outh5, 'w')
-
+    hdf5_path = Path(inps.outh5)
+    if hdf5_path.exists():
+        hdf5_path.unlink()
+    fid = h5py.File(hdf5_path, 'w')
     ###Record inputs
+
     writeInputs(inps, fid)
 
     ###Record summary


### PR DESCRIPTION
Resolves #46 in addition to:

- allowing `makeGeocube.py` to overwrite previous metadata files (for easier testing of this packaging)
- updates calls to pyproj to fix warning (this was suspected to be the source of the warning though was not).

The issue was with a non-standard geo-transform (see the issue ticket).

We can split this up into separate requests if desire (the addditional pieces are slightly unrelated).

The important change occurs in `isce_functions.py`, where during the update to the ISCE2 API, I remember the h5py API also required update and for some reason we used a non-sensical indexing. See the original file: https://github.com/aria-jpl/topsApp_pge/blob/develop/topsApp_utils/isce_functions.py#L382

Ultimately, in this request we are going to do the following additional test based on the linked issue ticket.

Compare the previous v2.0.4 product with this one:

reference scenes:
`S1B_IW_SLC__1SDV_20210809T015810_20210809T015838_028163_035C1C_1C8D`

secondary scenes:
`S1B_IW_SLC__1SDV_20210728T015742_20210728T015812_027988_0356CA_5433` 
`S1B_IW_SLC__1SDV_20210728T015809_20210728T015837_027988_0356CA_917C` `S1B_IW_SLC__1SDV_20210728T015835_20210728T015902_027988_0356CA_D3EB`

**Note**: this will be a highly tenuous comparison as for starters the newer version uses the GLO-30 DEM and the older version uses NED1.

However, this comparison (hopefully as a gist) could provide some help support for integration tests down the line.