### PR TITLE
Allow Earthdata credentials via environment variables

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,23 +5,24 @@ channels:
  - defaults
 dependencies:
  - python>=3.8
- - isce2
- - jupyter
- - papermill
- - ipykernel
- - rasterio
- - shapely
+ - pip
+ - asf_search>=3.0.4
+ - boto3
  - dateparser
- - jinja2
- - numpy
- - matplotlib
- - netcdf4
  - fiona
  - geopandas
- - pip
- - boto3
- - asf_search>=3.0.4
+ - ipykernel
+ - isce2
+ - jinja2
  - jsonschema==3.2.0
+ - jupyter
+ - matplotlib
+ - netcdf4
+ - numpy
+ - papermill
+ - pytest
+ - rasterio
+ - shapely
  - pip:
    - git+https://github.com/ACCESS-Cloud-Based-InSAR/dem_stitcher.git
    - tqdm

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -64,7 +64,7 @@ def ensure_earthdata_credentials(username: Optional[str] = None, password: Optio
     except (FileNotFoundError, netrc.NetrcParseError, TypeError):
         raise ValueError(
             f'Please provide valid Earthdata login credentials via {netrc_file}, '
-            f'the --username and --password CLI option, or '
+            f'the --username and --password CLI options, or '
             f'the EARTHDATA_USERNAME and EARTHDATA_PASSWORD environment variables.'
         )
 

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -46,8 +46,8 @@ def ensure_earthdata_credentials(username: Optional[str] = None, password: Optio
         * `netrc_file`
         * `username` and `password`
         * `EARTHDATA_USERNAME` and `EARTHDATA_PASSWORD` environment variables
-    and will be written ~/.netrc file if it doesn't already exist.
-    """
+     and will be written to the ~/.netrc file if it doesn't already exist.
+     """
     if username is None:
         username = os.getenv('EARTHDATA_USERNAME')
 

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -64,7 +64,7 @@ def ensure_earthdata_credentials(username: Optional[str] = None, password: Optio
     except (FileNotFoundError, netrc.NetrcParseError, TypeError):
         raise ValueError(
             f'Please provide valid Earthdata login credentials via {netrc_file}, '
-            f'the --username and --password CLI options, or '
+            f'username and password options, or '
             f'the EARTHDATA_USERNAME and EARTHDATA_PASSWORD environment variables.'
         )
 

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -70,7 +70,6 @@ def ensure_earthdata_credentials(username: Optional[str] = None, password: Optio
         )
 
 
-
 def main():
     parser = ArgumentParser()
     parser.add_argument('--username')

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -54,21 +54,20 @@ def ensure_earthdata_credentials(username: Optional[str] = None, password: Optio
     if password is None:
         password = os.getenv('EARTHDATA_PASSWORD', '')
 
-    if not netrc_file.exists():
+    if not netrc_file.exists() and username and password:
         netrc_file.write_text(f'machine {host} login {username} password {password}')
         netrc_file.chmod(0o000600)
 
     try:
         dot_netrc = netrc.netrc(netrc_file)
         username, _, password = dot_netrc.authenticators(host)
-    except (netrc.NetrcParseError, TypeError):
+    except (FileNotFoundError, netrc.NetrcParseError, TypeError):
         raise ValueError(
             f'Please provide valid Earthdata login credentials via {netrc_file}, '
             f'the --username and --password CLI option, or '
             f'the EARTHDATA_USERNAME and EARTHDATA_PASSWORD environment variables.'
         )
 
-    return username, password
 
 
 def main():

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -39,7 +39,7 @@ def localize_data(reference_scenes: list,
 
 
 def ensure_earthdata_credentials(username: Optional[str] = None, password: Optional[str] = None,
-                                 host: str = 'urs.earthdata.nasa.gov', netrc_file: Path = Path.home() / '.netrc'):
+                                 host: str = 'urs.earthdata.nasa.gov'):
     """Ensures Earthdata credentials are provided in ~/.netrc
 
      Earthdata username and password may be provided by, in order of preference, one of:
@@ -54,6 +54,7 @@ def ensure_earthdata_credentials(username: Optional[str] = None, password: Optio
     if password is None:
         password = os.getenv('EARTHDATA_PASSWORD')
 
+    netrc_file = Path.home() / '.netrc'
     if not netrc_file.exists() and username and password:
         netrc_file.write_text(f'machine {host} login {username} password {password}')
         netrc_file.chmod(0o000600)

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -49,10 +49,10 @@ def ensure_earthdata_credentials(username: Optional[str] = None, password: Optio
         * `EARTHDATA_USERNAME` and `EARTHDATA_PASSWORD` environment variables
     """
     if username is None:
-        username = os.getenv('EARTHDATA_USERNAME', '')
+        username = os.getenv('EARTHDATA_USERNAME')
 
     if password is None:
-        password = os.getenv('EARTHDATA_PASSWORD', '')
+        password = os.getenv('EARTHDATA_PASSWORD')
 
     if not netrc_file.exists() and username and password:
         netrc_file.write_text(f'machine {host} login {username} password {password}')

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -1,6 +1,6 @@
-import os
-import netrc
 import json
+import netrc
+import os
 from argparse import ArgumentParser
 from pathlib import Path
 from typing import Optional
@@ -9,7 +9,6 @@ from isce2_topsapp import (aws, download_aux_cal, download_dem_for_isce2,
                            download_orbits, download_slcs,
                            package_gunw_product, prepare_for_delivery,
                            topsapp_processing)
-
 from .json_encoder import MetadataEncoder
 
 
@@ -41,12 +40,13 @@ def localize_data(reference_scenes: list,
 
 def ensure_earthdata_credentials(username: Optional[str] = None, password: Optional[str] = None,
                                  host: str = 'urs.earthdata.nasa.gov', netrc_file: Path = Path.home() / '.netrc'):
-    """Ensures an Earthdata username and password are provided
+    """Ensures Earthdata credentials are provided in ~/.netrc
 
-     Earthdata username and password have been provided by, in order of preference, one of:
+     Earthdata username and password may be provided by, in order of preference, one of:
         * `netrc_file`
         * `username` and `password`
         * `EARTHDATA_USERNAME` and `EARTHDATA_PASSWORD` environment variables
+    and will be written ~/.netrc file if it doesn't already exist.
     """
     if username is None:
         username = os.getenv('EARTHDATA_USERNAME')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,76 +6,61 @@ from isce2_topsapp.__main__ import ensure_earthdata_credentials
 
 def test_main_check_earthdata_credentials(tmp_path):
     netrc = tmp_path / '.netrc'
-    netrc.write_text(f'machine foobar.nasa.gov login foo password bar')
+    netrc.write_text('machine foobar.nasa.gov login foo password bar')
 
-    username, password = ensure_earthdata_credentials(None, None, host='foobar.nasa.gov', netrc_file=netrc)
-    assert username == 'foo'
-    assert password == 'bar'
+    ensure_earthdata_credentials(None, None, host='foobar.nasa.gov', netrc_file=netrc)
+    assert netrc.read_text() == 'machine foobar.nasa.gov login foo password bar'
 
-    username, password = ensure_earthdata_credentials('biz', 'baz', host='foobar.nasa.gov', netrc_file=netrc)
-    assert username == 'foo'
-    assert password == 'bar'
+    ensure_earthdata_credentials('biz', 'baz', host='foobar.nasa.gov', netrc_file=netrc)
+    assert netrc.read_text() == 'machine foobar.nasa.gov login foo password bar'
 
     os.environ['EARTHDATA_USERNAME'] = 'fizz'
     os.environ['EARTHDATA_PASSWORD'] = 'buzz'
+    ensure_earthdata_credentials(None, None, host='foobar.nasa.gov', netrc_file=netrc)
+    assert netrc.read_text() == 'machine foobar.nasa.gov login foo password bar'
 
-    username, password = ensure_earthdata_credentials(None, None, host='foobar.nasa.gov', netrc_file=netrc)
-    assert username == 'foo'
-    assert password == 'bar'
-
-    username, password = ensure_earthdata_credentials('biz', 'baz', host='foobar.nasa.gov', netrc_file=netrc)
-    assert username == 'foo'
-    assert password == 'bar'
+    ensure_earthdata_credentials('biz', 'baz', host='foobar.nasa.gov', netrc_file=netrc)
+    assert netrc.read_text() == 'machine foobar.nasa.gov login foo password bar'
 
     with pytest.raises(ValueError):
-        _ = ensure_earthdata_credentials(None, None, host='another.nasa.gov', netrc_file=netrc)
+        ensure_earthdata_credentials(None, None, host='another.nasa.gov', netrc_file=netrc)
 
     with pytest.raises(ValueError):
-        _ = ensure_earthdata_credentials('biz', 'baz', host='another.nasa.gov', netrc_file=netrc)
-
+        ensure_earthdata_credentials('biz', 'baz', host='another.nasa.gov', netrc_file=netrc)
 
     netrc.unlink()
     del os.environ['EARTHDATA_USERNAME']
     del os.environ['EARTHDATA_PASSWORD']
     with pytest.raises(ValueError):
-        _ = ensure_earthdata_credentials(None, None, host='foobar.nasa.gov', netrc_file=netrc)
+        ensure_earthdata_credentials(None, None, host='foobar.nasa.gov', netrc_file=netrc)
 
-    netrc.unlink()
     with pytest.raises(ValueError):
         _ = ensure_earthdata_credentials('biz', None, host='foobar.nasa.gov', netrc_file=netrc)
 
-    netrc.unlink()
     with pytest.raises(ValueError):
         _ = ensure_earthdata_credentials(None, 'baz', host='foobar.nasa.gov', netrc_file=netrc)
 
-    netrc.unlink()
-    username, password = ensure_earthdata_credentials('biz', 'baz', host='foobar.nasa.gov', netrc_file=netrc)
-    assert username == 'biz'
-    assert password == 'baz'
+    ensure_earthdata_credentials('biz', 'baz', host='foobar.nasa.gov', netrc_file=netrc)
+    assert netrc.read_text() == 'machine foobar.nasa.gov login biz password baz'
 
     netrc.unlink()
     os.environ['EARTHDATA_USERNAME'] = 'fizz'
     os.environ['EARTHDATA_PASSWORD'] = 'buzz'
-    username, password = ensure_earthdata_credentials(None, None, host='foobar.nasa.gov', netrc_file=netrc)
-    assert username == 'fizz'
-    assert password == 'buzz'
+    ensure_earthdata_credentials(None, None, host='foobar.nasa.gov', netrc_file=netrc)
+    assert netrc.read_text() == 'machine foobar.nasa.gov login fizz password buzz'
 
     netrc.unlink()
-    username, password = ensure_earthdata_credentials('biz', 'baz', host='foobar.nasa.gov', netrc_file=netrc)
-    assert username == 'biz'
-    assert password == 'baz'
+    ensure_earthdata_credentials('biz', 'baz', host='foobar.nasa.gov', netrc_file=netrc)
+    assert netrc.read_text() == 'machine foobar.nasa.gov login biz password baz'
 
     netrc.unlink()
     del os.environ['EARTHDATA_PASSWORD']
     with pytest.raises(ValueError):
-        _ = ensure_earthdata_credentials(None, None, host='foobar.nasa.gov', netrc_file=netrc)
+        ensure_earthdata_credentials(None, None, host='foobar.nasa.gov', netrc_file=netrc)
+
+    ensure_earthdata_credentials('biz', 'baz', host='foobar.nasa.gov', netrc_file=netrc)
+    assert netrc.read_text() == 'machine foobar.nasa.gov login biz password baz'
 
     netrc.unlink()
-    username, password = ensure_earthdata_credentials('biz', 'baz', host='foobar.nasa.gov', netrc_file=netrc)
-    assert username == 'biz'
-    assert password == 'baz'
-
-    netrc.unlink()
-    username, password = ensure_earthdata_credentials(None, 'baz', host='foobar.nasa.gov', netrc_file=netrc)
-    assert username == 'fizz'
-    assert password == 'baz'
+    ensure_earthdata_credentials(None, 'baz', host='foobar.nasa.gov', netrc_file=netrc)
+    assert netrc.read_text() == 'machine foobar.nasa.gov login fizz password baz'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,81 @@
+import os
+
+import pytest
+from isce2_topsapp.__main__ import ensure_earthdata_credentials
+
+
+def test_main_check_earthdata_credentials(tmp_path):
+    netrc = tmp_path / '.netrc'
+    netrc.write_text(f'machine foobar.nasa.gov login foo password bar')
+
+    username, password = ensure_earthdata_credentials(None, None, host='foobar.nasa.gov', netrc_file=netrc)
+    assert username == 'foo'
+    assert password == 'bar'
+
+    username, password = ensure_earthdata_credentials('biz', 'baz', host='foobar.nasa.gov', netrc_file=netrc)
+    assert username == 'foo'
+    assert password == 'bar'
+
+    os.environ['EARTHDATA_USERNAME'] = 'fizz'
+    os.environ['EARTHDATA_PASSWORD'] = 'buzz'
+
+    username, password = ensure_earthdata_credentials(None, None, host='foobar.nasa.gov', netrc_file=netrc)
+    assert username == 'foo'
+    assert password == 'bar'
+
+    username, password = ensure_earthdata_credentials('biz', 'baz', host='foobar.nasa.gov', netrc_file=netrc)
+    assert username == 'foo'
+    assert password == 'bar'
+
+    with pytest.raises(ValueError):
+        _ = ensure_earthdata_credentials(None, None, host='another.nasa.gov', netrc_file=netrc)
+
+    with pytest.raises(ValueError):
+        _ = ensure_earthdata_credentials('biz', 'baz', host='another.nasa.gov', netrc_file=netrc)
+
+
+    netrc.unlink()
+    del os.environ['EARTHDATA_USERNAME']
+    del os.environ['EARTHDATA_PASSWORD']
+    with pytest.raises(ValueError):
+        _ = ensure_earthdata_credentials(None, None, host='foobar.nasa.gov', netrc_file=netrc)
+
+    netrc.unlink()
+    with pytest.raises(ValueError):
+        _ = ensure_earthdata_credentials('biz', None, host='foobar.nasa.gov', netrc_file=netrc)
+
+    netrc.unlink()
+    with pytest.raises(ValueError):
+        _ = ensure_earthdata_credentials(None, 'baz', host='foobar.nasa.gov', netrc_file=netrc)
+
+    netrc.unlink()
+    username, password = ensure_earthdata_credentials('biz', 'baz', host='foobar.nasa.gov', netrc_file=netrc)
+    assert username == 'biz'
+    assert password == 'baz'
+
+    netrc.unlink()
+    os.environ['EARTHDATA_USERNAME'] = 'fizz'
+    os.environ['EARTHDATA_PASSWORD'] = 'buzz'
+    username, password = ensure_earthdata_credentials(None, None, host='foobar.nasa.gov', netrc_file=netrc)
+    assert username == 'fizz'
+    assert password == 'buzz'
+
+    netrc.unlink()
+    username, password = ensure_earthdata_credentials('biz', 'baz', host='foobar.nasa.gov', netrc_file=netrc)
+    assert username == 'biz'
+    assert password == 'baz'
+
+    netrc.unlink()
+    del os.environ['EARTHDATA_PASSWORD']
+    with pytest.raises(ValueError):
+        _ = ensure_earthdata_credentials(None, None, host='foobar.nasa.gov', netrc_file=netrc)
+
+    netrc.unlink()
+    username, password = ensure_earthdata_credentials('biz', 'baz', host='foobar.nasa.gov', netrc_file=netrc)
+    assert username == 'biz'
+    assert password == 'baz'
+
+    netrc.unlink()
+    username, password = ensure_earthdata_credentials(None, 'baz', host='foobar.nasa.gov', netrc_file=netrc)
+    assert username == 'fizz'
+    assert password == 'baz'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -22,10 +22,14 @@ def test_main_check_earthdata_credentials_prefer_netrc(tmp_path, monkeypatch):
     assert netrc.read_text() == 'machine foobar.nasa.gov login foo password bar'
 
     with pytest.raises(ValueError):
-        ensure_earthdata_credentials(None, None, host='another.nasa.gov')
+        ensure_earthdata_credentials(None, None)
 
     with pytest.raises(ValueError):
-        ensure_earthdata_credentials('biz', 'baz', host='another.nasa.gov')
+        ensure_earthdata_credentials('biz', 'baz')
+
+    netrc.write_text('machine urs.earthdata.nasa.gov login foo password bar')
+    ensure_earthdata_credentials(None, None)
+    assert netrc.read_text() == 'machine urs.earthdata.nasa.gov login foo password bar'
 
 
 def test_main_check_earthdata_credentials_fn_variables(tmp_path, monkeypatch):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -35,10 +35,10 @@ def test_main_check_earthdata_credentials(tmp_path):
         ensure_earthdata_credentials(None, None, host='foobar.nasa.gov', netrc_file=netrc)
 
     with pytest.raises(ValueError):
-        _ = ensure_earthdata_credentials('biz', None, host='foobar.nasa.gov', netrc_file=netrc)
+        ensure_earthdata_credentials('biz', None, host='foobar.nasa.gov', netrc_file=netrc)
 
     with pytest.raises(ValueError):
-        _ = ensure_earthdata_credentials(None, 'baz', host='foobar.nasa.gov', netrc_file=netrc)
+        ensure_earthdata_credentials(None, 'baz', host='foobar.nasa.gov', netrc_file=netrc)
 
     ensure_earthdata_credentials('biz', 'baz', host='foobar.nasa.gov', netrc_file=netrc)
     assert netrc.read_text() == 'machine foobar.nasa.gov login biz password baz'


### PR DESCRIPTION
HyP3 is moving to provide Earthdata credentials to the container via environment variables instead of CLI options to keep them encrypted throughout the processing chain. 