### PR TITLE
install released dem-sticher, not dev version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -27,4 +27,4 @@ dependencies:
  - shapely
  - tqdm
  - pip:
-   - git+https://github.com/ACCESS-Cloud-Based-InSAR/dem_stitcher.git
+   - dem-stitcher>=2.1


### PR DESCRIPTION
This will ensure more reproducible builds, at the expense of needed to release dem-sticher to incorporate changes