### PR TITLE
Add software statement and ppdate workflow actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,45 +11,18 @@ on:
       - dev
 
 jobs:
-  dockerize:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+  call-version-info-workflow:
+    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@main
+    with:
+      conda_env_name: topsapp_env
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Lowercase repo for Github Container Registry
-        run: |
-          echo "REPO=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
-
-      - name: Build, tag, and push image to Github Container Registry
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: true
-          tags: |
-            ghcr.io/${{ env.REPO }}:${{ github.sha }}
-
-      - name: Add test tag
-        if: github.ref == 'refs/heads/dev'
-        uses: akhilerm/tag-push-action@v1.0.0
-        with:
-          src: ghcr.io/${{ env.REPO }}:${{ github.sha }}
-          dst: ghcr.io/${{ env.REPO }}:test
-
-      - name: Add latest tag
-        if: github.ref == 'refs/heads/main'
-        uses: akhilerm/tag-push-action@v1.0.0
-        with:
-          src: ghcr.io/${{ env.REPO }}:${{ github.sha }}
-          dst: ghcr.io/${{ env.REPO }}:latest
+  call-docker-ghcr-workflow:
+    needs: call-version-info-workflow
+    uses: ASFHyP3/actions/.github/workflows/reusable-docker-ghcr.yml@main
+    with:
+      version_tag: ${{ needs.call-version-info-workflow.outputs.version_tag }}
+      release_branch: main
+      develop_branch: dev
+      user: ${{ github.actor }}
+    secrets:
+      USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,18 @@
+name: Changelog updated?
+
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+      - unlabeled
+      - synchronize
+    branches:
+      - main
+      - dev
+
+jobs:
+  call-changelog-check-workflow:
+    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@main
+    secrets:
+      USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labeled-pr.yml
+++ b/.github/workflows/labeled-pr.yml
@@ -1,0 +1,15 @@
+name: Is PR labeled?
+
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+      - unlabeled
+      - synchronize
+    branches:
+      - main
+
+jobs:
+  call-labeled-pr-check-workflow:
+    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,16 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  call-release-workflow:
+    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@main
+    with:
+      release_prefix: dem-stitcher
+      develop_branch: dev
+      sync_pr_label: team-bot
+    secrets:
+      USER_TOKEN: ${{ secrets.ACCESS_GITHUB_TOKEN }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,12 @@
+name: Static analysis
+
+on: push
+
+jobs:
+  call-flake8-workflow:
+    uses: ASFHyP3/actions/.github/workflows/reusable-flake8.yml@main
+    with:
+      local_package_names: isce2_topsapp
+
+  call-secrets-analysis-workflow:
+    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@main

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,15 @@
+name: Tag version
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  call-bump-version-workflow:
+    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@main
+    with:
+      user: access-cloud-insar-team
+      email: access-cloud-insar-team@jpl.nasa.gov
+    secrets:
+      USER_TOKEN: ${{ secrets.ACCESS_GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,13 +1,21 @@
-name: PyTest and Flake8
+name: PyTest
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
 
 jobs:
   pytest:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2
@@ -24,11 +32,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           activate-environment: topsapp_env
           environment-file: environment.yml
-
-      - name: flake8
-        shell: bash -l {0}
-        run: |
-          flake8 . --max-line-length=120 --import-order-style=pycharm --application-import-names isce2_topsapp --exclude=isce2_topsapp/packaging_utils/
 
       - name: Pytest in conda environment
         shell: bash -l {0}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
-include LICENSE
+include LICENSE.txt
 include README.md
 
-recursive-exclude tests *
-recursive-exclude tmp *
+graft isce2_topsapp
+
 global-exclude *.py[cod] __pycache__ *.so

--- a/environment.yml
+++ b/environment.yml
@@ -30,7 +30,8 @@ dependencies:
  - jupyter
  - papermill
  - pytest
+ - pytest-cov
  - setuptools
  - setuptools_scm
  - pip:
-   - git+https://github.com/ACCESS-Cloud-Based-InSAR/dem_stitcher.git
+   - dem_stitcher>=2.1

--- a/isce2_topsapp/__init__.py
+++ b/isce2_topsapp/__init__.py
@@ -26,4 +26,5 @@ __all__ = [
     'topsapp_processing',
     'package_gunw_product',
     'prepare_for_delivery',
+    '__version__',
 ]

--- a/isce2_topsapp/__init__.py
+++ b/isce2_topsapp/__init__.py
@@ -1,3 +1,6 @@
+import warnings
+from importlib.metadata import PackageNotFoundError, version
+
 from .delivery_prep import prepare_for_delivery
 from .localize_aux_cal import download_aux_cal
 from .localize_dem import download_dem_for_isce2
@@ -6,10 +9,21 @@ from .localize_slc import download_slcs
 from .packaging import package_gunw_product
 from .topsapp_proc import topsapp_processing
 
-__all__ = ['download_orbits',
-           'download_slcs',
-           'download_dem_for_isce2',
-           'download_aux_cal',
-           'topsapp_processing',
-           'package_gunw_product',
-           'prepare_for_delivery']
+
+try:
+    __version__ = version(__name__)
+except PackageNotFoundError:
+    __version__ = None
+    warnings.warn('package is not installed!\n'
+                  'Install in editable/develop mode via (from the top of this repo):\n'
+                  '   python -m pip install -e .\n', RuntimeWarning)
+
+__all__ = [
+    'download_orbits',
+    'download_slcs',
+    'download_dem_for_isce2',
+    'download_aux_cal',
+    'topsapp_processing',
+    'package_gunw_product',
+    'prepare_for_delivery',
+]

--- a/isce2_topsapp/packaging.py
+++ b/isce2_topsapp/packaging.py
@@ -8,6 +8,7 @@ from typing import Union
 import numpy as np
 from dateparser import parse
 
+from isce2_topsapp import __version__
 from .templates import read_netcdf_packaging_template
 
 DATASET_VERSION = '2.0.5'
@@ -173,6 +174,9 @@ def _write_json_config(*,
     nc_template = read_netcdf_packaging_template()
 
     nc_template['filename'] = f'{gunw_id}.nc'
+    # This will be appended to the global source attribute
+    nc_template['software_statement'] = f'using the DockerizedTopsApp HyP3 plugin version {__version__}'
+
     out_path = directory/'tops_groups.json'
     with open(out_path, 'w') as f:
         json.dump(nc_template, f, indent=2, sort_keys=True)

--- a/isce2_topsapp/packaging_utils/nc_packaging.py
+++ b/isce2_topsapp/packaging_utils/nc_packaging.py
@@ -4,6 +4,7 @@ from builtins import map
 from builtins import str
 from builtins import range
 from builtins import object
+import argparse
 import sys
 import json
 import logging
@@ -559,13 +560,9 @@ def main():
     cwd = os.getcwd()
     filename = os.path.join(cwd, 'tops_groups.json')
 
-    # open the file
-    f = open(filename)
-    # read the json file with planned netcdf4 structure and put the content in a dictionary
-    structure = json.load(f, object_pairs_hook=OrderedDict)
-    # close the file
-    f.close
-
+    with open(filename) as f:
+        # read the json file with planned netcdf4 structure and put the content in a dictionary
+        structure = json.load(f, object_pairs_hook=OrderedDict)
 
     # set netcdf file
     netcdf_outfile = structure["filename"]
@@ -607,14 +604,18 @@ def main():
         logger.error(traceback.format_exc())
         pass
 
+    source_statement = fid.getncattr('source')
+    software_statement = structure['software_statement']
+    fid.setncattr('source', f'{source_statement} {software_statement}')
+
     # close the file
     fid.close()
 
     logger.info('Done with packaging')
+
 
 if __name__ == '__main__':
     '''
         Main driver.
     '''
     main()
-

--- a/setup.py
+++ b/setup.py
@@ -2,41 +2,74 @@ from pathlib import Path
 
 from setuptools import find_packages, setup
 
-readme = Path(__file__).parent / 'README.md'
 
 setup(
     name='isce2_topsapp',
-    # use_scm_version=True,
+    use_scm_version=True,
     description='Automated ISCE2 TopsApp Processing',
-    long_description=readme.read_text(),
+    long_description=(Path(__file__).parent / 'README.md').read_text(),
     long_description_content_type='text/markdown',
+
     url='https://github.com/dbekaert/DockerizedTopsApp',
-    author=('Charlie Marshak, David Bekaert, Grace Bato, Simran Sangha',
-            'Joseph Kennedy', 'Brett Buzzunga, and others'
-            ),
+
+    author='Charlie Marshak, David Bekaert, Grace Bato, Simran Sangha  Joseph H. Kennedy Brett Buzzunga, and others',
     author_email='charlie.z.marshak@jpl.nasa.gov',
-    license='BSD',
-    include_package_data=True,
+
+    license='Apache',
     classifiers=[
         'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: BSD License',
+        'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 
-    python_requires='~=3.8',
-    package_data={"isce2_topsapp": ["templates/*.xml",
-                                    "templates/*.json"]},
-    packages=find_packages(
-                           exclude=['tmp/', 'tests/']
-                          ),
-    entry_points={'console_scripts': [
+    python_requires='>=3.8',
+
+    install_requires=[
+        'asf_search>=3.0.4',
+        'boto3',
+        'dateparser',
+        'geopandas',
+        'hyp3lib>=1.7',
+        'isce2',
+        'jinja2',
+        'lxml',
+        'matplotlib',
+        'netcdf4',
+        'numpy',
+        'rasterio',
+        'shapely',
+        'tqdm',
+    ],
+
+    extras_require={
+        'develop': [
+            'flake8',
+            'flake8-import-order',
+            'flake8-blind-except',
+            'flake8-builtins',
+            'ipykernel',
+            'jsonschema==3.2.0',
+            'notebook',
+            'papermill',
+            'pytest',
+            'pytest-cov',
+        ]
+    },
+
+    packages=find_packages(),
+    include_package_data=True,
+
+    entry_points={
+        'console_scripts': [
             'isce2_topsapp = isce2_topsapp.__main__:main',
             'makeGeocube = isce2_topsapp.packaging_utils.makeGeocube:main',
             'nc_packaging = isce2_topsapp.packaging_utils.nc_packaging:main'
         ]
     },
+
     zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         'asf_search>=3.0.4',
         'boto3',
         'dateparser',
+        'dem_stitcher>=2.1',
         'geopandas',
         'hyp3lib>=1.7',
         'isce2',


### PR DESCRIPTION
This provides good software version provenance in the netCDF output products so that products are reproducible. The following statement:
```python
f'using the DockerizedTopsApp HyP3 plugin version {__version__}'
```
will be appended to the global `source` netCDF attribute, which currently is:
```
Contains modified Copernicus Sentinel data processed by ESA and ARIA NASA/JPL
```
which in full will read:
> Contains modified Copernicus Sentinel data processed by ESA and ARIA NASA/JPL using the DockerizedTopsApp HyP3 plugin version X.Y.Z

--- 

In order to provide good version numbers, this also updates the `isce2_topsapp` software packaging so that it provides better package metadata and uses `setuptools_scm` to automatically compute a version number based on the git history.

Version numbers follow a pattern like:
    `X.Y.Z[.devN_gHASH]`

where `X.Y.Z` is the semantic version number of the package and the `[.devN_gHASH]` is an option suffix indicating a pre-release development version. `setuptools_scm` works by:
* finding the last git tag that provides a` X.Y.Z` version number
* getting  the short `HASH` of the current commit id
* computing the "distance" or `N` commits since the last tag 

Then, if `N==0`, the version number will be reported as just the tag's `X.Y.Z` number, otherwise it will report a version number of `X.Y.(Z+1).devN_gHASH` to indicate work towards the next release version has been done.

Full description of how version numbers are created here:
https://github.com/pypa/setuptools_scm#default-versioning-scheme

---

This futher updates the CI/CD workflow actions to automatically tag the above version number to the docker image, as well as to align the CI/CD with the actions used for `dem_sticher`. Namely:
* Add a CHANGELOG check
* Add a PR label check for merges to `main`
* Add a tag and release workflow
* Update the docker image build and push workflow
  * Image will now be tagged with the software version (including short hash for dev versions), not the full commit hash
* split static analysis (flake8) out from test workflow so non-conforming style doesn't block functional testing
