### PR TITLE
Update aux cal urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.1.2]
+
+### Fixed
+* Sentinel-1 A/B `aux-cal` files are found at url: https://sar-mpc.eu/ipf-adf/aux_cal/
+* Unpack `aux-cal` with python standard package `zipfile`
+
 ## [0.1.1]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 * Sentinel-1 A/B `aux-cal` files are found at url: https://sar-mpc.eu/ipf-adf/aux_cal/
 * Unpack `aux-cal` with python standard package `zipfile`
+* Fix aux-cal bug (only S1A was being downloaded)
 
 ## [0.1.1]
 

--- a/isce2_topsapp/localize_aux_cal.py
+++ b/isce2_topsapp/localize_aux_cal.py
@@ -1,11 +1,11 @@
-import tarfile
+import zipfile
 from pathlib import Path
 from typing import Union
 
 import requests
 
-S1A_AUX_URL = 'https://sar-mpc.eu/download/55282da1-679d-4ecf-aeef-d06b024451cf/'
-S1B_AUX_URL = 'https://sar-mpc.eu/download/3c8b7c8d-d3de-4381-a19d-7611fb8734b9/'
+S1A_AUX_URL = 'https://sar-mpc.eu/download/55282da1-679d-4ecf-aeef-d06b024451cf'
+S1B_AUX_URL = 'https://sar-mpc.eu/download/3c8b7c8d-d3de-4381-a19d-7611fb8734b9'
 
 
 def download_aux_cal(aux_cal_dir: Union[str, Path] = None):
@@ -25,9 +25,9 @@ def download_aux_cal(aux_cal_dir: Union[str, Path] = None):
     s1a_path = download_one(S1A_AUX_URL)
     s1b_path = download_one(S1B_AUX_URL)
 
-    with tarfile.open(s1a_path) as tar:
-        tar.extractall(path=aux_cal_dir)
-    with tarfile.open(s1b_path) as tar:
-        tar.extractall(path=aux_cal_dir)
+    with zipfile.ZipFile(s1a_path) as zip_file:
+        zip_file.extractall(aux_cal_dir)
+    with zipfile.ZipFile(s1b_path) as zip_file:
+        zip_file.extractall(aux_cal_dir)
 
     return {'aux_cal_dir': str(aux_cal_dir)}

--- a/isce2_topsapp/localize_aux_cal.py
+++ b/isce2_topsapp/localize_aux_cal.py
@@ -14,7 +14,7 @@ def download_aux_cal(aux_cal_dir: Union[str, Path] = None):
     aux_cal_dir.mkdir(exist_ok=True, parents=True)
 
     def download_one(url):
-        resp = requests.get(S1A_AUX_URL)
+        resp = requests.get(url)
         file_name = url.split('/')[-1]
         out_path = aux_cal_dir/file_name
 

--- a/isce2_topsapp/localize_aux_cal.py
+++ b/isce2_topsapp/localize_aux_cal.py
@@ -4,10 +4,8 @@ from typing import Union
 
 import requests
 
-S1A_AUX_URL = ('https://qc.sentinel1.groupcls.com/product/S1A/AUX_CAL/2019/02/'
-               '28/S1A_AUX_CAL_V20190228T092500_G20210104T141310.SAFE.TGZ')
-S1B_AUX_URL = ('https://qc.sentinel1.groupcls.com/product/S1B/AUX_CAL/2019/05/'
-               '14/S1B_AUX_CAL_V20190514T090000_G20210104T140612.SAFE.TGZ')
+S1A_AUX_URL = 'https://sar-mpc.eu/download/55282da1-679d-4ecf-aeef-d06b024451cf/'
+S1B_AUX_URL = 'https://sar-mpc.eu/download/3c8b7c8d-d3de-4381-a19d-7611fb8734b9/'
 
 
 def download_aux_cal(aux_cal_dir: Union[str, Path] = None):


### PR DESCRIPTION
Update the `aux-cal` urls to those found at https://sar-mpc.eu/ipf-adf/aux_cal/ (thank you, @ehavazli).

The new files required python `zipfile` to unpack, not `tarfile`.

Due to GIS issues, I used `gdal<3.4` and `python<3.10` on my mac. I believe this is not an issue on linux.