### PR TITLE
Glo 30 filling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.1.3]
 
 ### Changed
-* Uses updated API dem-stitcher for square resolution cells and translation/resampling
+* Uses updated API dem-stitcher for square resolution cells and translation/resampling (>=2.2.0)
 * Updates dataset (patch change) from 2.0.5 to 2.0.6
 * Sort imports for updated files
 
+### Fixed
+* Uses dem-stitcher>=v2.3.0, which by default, fills in `glo-30` tiles that are missing over Armenia and Azerbaijan with the available `glo-90` tiles (upsampled).
 
 ## [0.1.2]
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ isce2_topsapp --reference-scenes S1B_IW_SLC__1SDV_20210723T014947_20210723T01501
                                  S1B_IW_SLC__1SDV_20210711T015011_20210711T015038_027740_034F80_376C
 ```
 Add `> topsapp_img.out 2> topsapp_img.err` to avoid unnecessary output to your terminal and record the stdout and stderr as files.
-This is reflected in the (`sample_run.sh`)[sample_run.sh].
+This is reflected in the [`sample_run.sh`](sample_run.sh).
 
 To be even more explicity, you can use [`tee`](https://en.wikipedia.org/wiki/Tee_(command)) to record output to both including `> >(tee -a topsapp_img.out) 2> >(tee -a topsapp_img.err >&2)`.
 

--- a/environment.yml
+++ b/environment.yml
@@ -37,5 +37,4 @@ dependencies:
  - setuptools_scm
  - shapely
  - tqdm
- - pip:
-   - dem-stitcher>=2.3.0
+ - dem-stitcher>=2.3.0

--- a/environment.yml
+++ b/environment.yml
@@ -37,4 +37,4 @@ dependencies:
  - setuptools_scm
  - shapely
  - tqdm
- - dem-stitcher>=2.3.0
+ - dem_stitcher>=2.3.0

--- a/environment.yml
+++ b/environment.yml
@@ -38,4 +38,4 @@ dependencies:
  - shapely
  - tqdm
  - pip:
-   - dem-stitcher>=2.2.1
+   - dem-stitcher>=2.3.0

--- a/environment.yml
+++ b/environment.yml
@@ -38,4 +38,4 @@ dependencies:
  - shapely
  - tqdm
  - pip:
-   - dem-stitcher>=2.2.0
+   - dem-stitcher>=2.2.1


### PR DESCRIPTION
Resolves #67. Simply updates `dem-stitcher` to `2.3.0` (see this [PR](https://github.com/ACCESS-Cloud-Based-InSAR/dem-stitcher/pull/35)), which, by default, resolves the filling for `glo_30` dem.