### PR TITLE
Dem-stitcher Updates and Burst Skeleton

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.trufflehog.txt
+++ b/.trufflehog.txt
@@ -1,5 +1,5 @@
-.*gitleaks.toml$
 .*.ipynb$
 .*/templates/.*
 tests/sample_loc_metadata.json
 Dockerfile
+tests/test_data/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.1.3]
+
+### Changed
+* Uses updated API dem-stitcher for square resolution cells and translation/resampling
+* Updates dataset (patch change) from 2.0.5 to 2.0.6
+* Sort imports for updated files
+
+
 ## [0.1.2]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.1.3]
 
 ### Changed
-* Uses updated API dem-stitcher for square resolution cells and translation/resampling
+* Uses updated API dem-stitcher for square resolution cells and translation/resampling (>=2.2.0)
 * Updates dataset (patch change) from 2.0.5 to 2.0.6
 * Sort imports for updated files
 
+### Fixed
+* Uses dem-stitcher>=v2.3.0, which by default, fills in `glo-30` tiles that are missing over Armenia and Azerbaijan with the available `glo-90` tiles (upsampled).
 
 ## [0.1.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.1.4]
+* Fixes URLS for `glo-30` and `srtm_v3`
+* Includes Burst skeleton (non-functional)
+
 ## [0.1.3]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,10 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.1.4]
-* Fixes URLS for `glo-30` and `srtm_v3`
-* Includes Burst skeleton (non-functional)
+## [0.2.0]
 
-## [0.1.3]
+### Added
+* A prototype burst processing skeleton (non-functional)
 
 ### Changed
 * Uses updated API dem-stitcher for square resolution cells and translation/resampling (>=2.2.0)
@@ -20,7 +19,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 * Uses dem-stitcher>=v2.3.0, which by default, fills in `glo-30` tiles that are missing over Armenia and Azerbaijan with the available `glo-90` tiles (upsampled).
-
+* Uses dem-stitcher>=v2.3.1 to fix URLs for `glo-30` and `srtm_v3`
 ## [0.1.2]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ isce2_topsapp --reference-scenes S1B_IW_SLC__1SDV_20210723T014947_20210723T01501
                                  S1B_IW_SLC__1SDV_20210711T015011_20210711T015038_027740_034F80_376C
 ```
 Add `> topsapp_img.out 2> topsapp_img.err` to avoid unnecessary output to your terminal and record the stdout and stderr as files.
-This is reflected in the (`sample_run.sh`)[sample_run.sh].
+This is reflected in the [`sample_run.sh`](sample_run.sh).
 
 To be even more explicity, you can use [`tee`](https://en.wikipedia.org/wiki/Tee_(command)) to record output to both including `> >(tee -a topsapp_img.out) 2> >(tee -a topsapp_img.err >&2)`.
 

--- a/environment.yml
+++ b/environment.yml
@@ -4,34 +4,38 @@ channels:
  - anaconda
  - defaults
 dependencies:
- - python>=3.8
+ - python>=3.8,<3.10
  - pip
+ - affine
  - asf_search>=3.0.4
  - boto3
  - dateparser
+ - flake8
+ - flake8-blind-except
+ - flake8-builtins
+ - flake8-import-order
+ - gdal
  - geopandas
  - hyp3lib>=1.7
+ - ipykernel
  - isce2
  - jinja2
+ - joblib
+ - jsonschema==3.2.0
+ - jupyter
  - lxml
  - matplotlib
  - netcdf4
+ - notebook
  - numpy
- - rasterio
- - shapely
- - tqdm
- # for testing and distribution
- - flake8
- - flake8-import-order
- - flake8-blind-except
- - flake8-builtins
- - ipykernel
- - jsonschema==3.2.0
- - jupyter
+ - pandas
  - papermill
  - pytest
  - pytest-cov
+ - rasterio
  - setuptools
  - setuptools_scm
+ - shapely
+ - tqdm
  - pip:
-   - dem_stitcher>=2.1
+   - dem-stitcher>=2.2.0

--- a/environment.yml
+++ b/environment.yml
@@ -38,5 +38,5 @@ dependencies:
  - setuptools_scm
  - shapely
  - tqdm
- - dem_stitcher>=2.3.0
+ - dem_stitcher>=2.3.1
  - aiohttp  # only needed for manifest and swath download

--- a/environment.yml
+++ b/environment.yml
@@ -32,9 +32,11 @@ dependencies:
  - papermill
  - pytest
  - pytest-cov
+ - pytest-mock
  - rasterio
  - setuptools
  - setuptools_scm
  - shapely
  - tqdm
  - dem_stitcher>=2.3.0
+ - aiohttp  # only needed for manifest and swath download

--- a/environment.yml
+++ b/environment.yml
@@ -37,5 +37,4 @@ dependencies:
  - setuptools_scm
  - shapely
  - tqdm
- - pip:
-   - dem-stitcher>=2.2.0
+ - dem_stitcher>=2.3.0

--- a/isce2_topsapp/__init__.py
+++ b/isce2_topsapp/__init__.py
@@ -3,9 +3,10 @@ from importlib.metadata import PackageNotFoundError, version
 
 from isce2_topsapp.delivery_prep import prepare_for_delivery
 from isce2_topsapp.localize_aux_cal import download_aux_cal
+from isce2_topsapp.localize_burst import BurstParams, download_bursts, get_region_of_interest
 from isce2_topsapp.localize_dem import download_dem_for_isce2
 from isce2_topsapp.localize_orbits import download_orbits
-from isce2_topsapp.localize_slc import download_slcs
+from isce2_topsapp.localize_slc import download_slcs, get_asf_slc_objects
 from isce2_topsapp.packaging import package_gunw_product
 from isce2_topsapp.topsapp_proc import topsapp_processing
 
@@ -21,8 +22,12 @@ except PackageNotFoundError:
 __all__ = [
     'download_orbits',
     'download_slcs',
+    'get_asf_slc_objects',
+    'get_region_of_interest',
     'download_dem_for_isce2',
     'download_aux_cal',
+    'download_bursts',
+    'BurstParams',
     'topsapp_processing',
     'package_gunw_product',
     'prepare_for_delivery',

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -1,12 +1,16 @@
 import json
 import netrc
 import os
-from argparse import ArgumentParser
+import sys
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+from importlib.metadata import entry_points
 from pathlib import Path
 from typing import Optional
 
-from isce2_topsapp import (aws, download_aux_cal, download_dem_for_isce2,
-                           download_orbits, download_slcs,
+
+from isce2_topsapp import (BurstParams, aws, download_aux_cal, download_bursts,
+                           download_dem_for_isce2, download_orbits,
+                           download_slcs, get_asf_slc_objects, get_region_of_interest,
                            package_gunw_product, prepare_for_delivery,
                            topsapp_processing)
 from isce2_topsapp.json_encoder import MetadataEncoder
@@ -75,7 +79,7 @@ def ensure_earthdata_credentials(username: Optional[str] = None, password: Optio
         )
 
 
-def main():
+def gunw_slc():
     parser = ArgumentParser()
     parser.add_argument('--username')
     parser.add_argument('--password')
@@ -127,6 +131,85 @@ def main():
     if args.bucket:
         for file in final_directory.glob('S1-GUNW*'):
             aws.upload_file_to_s3(file, args.bucket, args.bucket_prefix)
+
+
+def gunw_burst():
+    parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
+    parser.add_argument('--username')
+    parser.add_argument('--password')
+    parser.add_argument('--bucket')
+    parser.add_argument('--bucket-prefix', default='')
+    parser.add_argument('--dry-run', action='store_true')
+    parser.add_argument('--reference-scene', type=str, required=True)
+    parser.add_argument('--secondary-scene', type=str, required=True)
+    parser.add_argument('--image-number', type=int, required=True)
+    parser.add_argument('--burst-number', type=int, required=True)
+    parser.add_argument('--azimuth-looks', type=int, default=2)
+    parser.add_argument('--range-looks', type=int, default=10)
+    args = parser.parse_args()
+
+    ensure_earthdata_credentials(args.username, args.password)
+
+    ref_obj, sec_obj = get_asf_slc_objects([args.reference_scene, args.secondary_scene])
+
+    ref_params = BurstParams(
+        safe_url=ref_obj.properties['url'],
+        image_number=args.image_number,
+        burst_number=args.burst_number,
+    )
+    sec_params = BurstParams(
+        safe_url=sec_obj.properties['url'],
+        image_number=args.image_number,
+        burst_number=args.burst_number,
+    )
+
+    ref_burst, sec_burst = download_bursts([ref_params, sec_params])
+
+    intersection = ref_burst.footprint.intersection(sec_burst.footprint).bounds
+    is_ascending = ref_burst.orbit_direction == 'ascending'
+    roi = get_region_of_interest(ref_burst.footprint, sec_burst.footprint, is_ascending=is_ascending)
+
+    orbits = download_orbits([ref_burst.safe_name[:-5]], [sec_burst.safe_name[:-5]], dry_run=args.dry_run)
+
+    if not args.dry_run:
+        # TODO this is likely not the optimal geometry to pass to this function
+        dem = download_dem_for_isce2(intersection)
+        _ = download_aux_cal()
+
+    # TODO fails when using the default 19x7 looks
+    topsapp_processing(
+        reference_slc_zips=ref_burst.safe_name,
+        secondary_slc_zips=sec_burst.safe_name,
+        orbit_directory=orbits['orbit_directory'],
+        extent=roi,
+        dem_for_proc=dem['full_res_dem_path'],
+        dem_for_geoc=dem['low_res_dem_path'],
+        azimuth_looks=args.azimuth_looks,
+        range_looks=args.range_looks,
+        swaths=[ref_burst.swath],
+        dry_run=args.dry_run,
+    )
+
+    if args.bucket:
+        for file in Path('merged').glob('*geo*'):
+            aws.upload_file_to_s3(file, args.bucket, args.bucket_prefix)
+
+
+def main():
+    parser = ArgumentParser(prefix_chars='+', formatter_class=ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        '++process', choices=['gunw_slc', 'gunw_burst'], default='gunw_slc',
+        help='Select the HyP3 entrypoint to use'
+    )
+    args, unknowns = parser.parse_known_args()
+
+    sys.argv = [args.process, *unknowns]
+    # FIXME: this gets better in python 3.10
+    # (process_entry_point,) = entry_points(group='console_scripts', name=args.process)
+    process_entry_point = [ep for ep in entry_points()['console_scripts'] if ep.name == args.process][0]
+    sys.exit(
+        process_entry_point.load()()
+    )
 
 
 if __name__ == '__main__':

--- a/isce2_topsapp/localize_burst.py
+++ b/isce2_topsapp/localize_burst.py
@@ -1,0 +1,299 @@
+import copy
+import io
+import netrc
+import re
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, List, Tuple, Union
+
+import aiohttp
+import fsspec
+import pandas as pd
+import requests
+from shapely import geometry
+
+URLS = {
+    'metadata': 'https://g6rmelgj3m.execute-api.us-west-2.amazonaws.com/metadata',
+    'geotiff': 'https://g6rmelgj3m.execute-api.us-west-2.amazonaws.com/geotiff',
+}
+
+
+@dataclass
+class BurstParams:
+    """Class that contains the parameters nessecary to request a burst from the API."""
+
+    safe_url: str
+    image_number: int
+    burst_number: int
+
+
+class BurstMetadata:
+    def __init__(self, metadata: ET.Element, manifest: ET.Element, burst_params: BurstParams):
+        self.safe_url = burst_params.safe_url
+        self.image_number = burst_params.image_number
+        self.burst_number = burst_params.burst_number
+        self.safe_name = Path(self.safe_url).with_suffix('.SAFE').name
+
+        image_numbers = [int(x.attrib['source_filename'].split('-')[-1][2]) for x in metadata]
+        products = [x.tag for x in metadata]
+        image_numbers_and_products = list(zip(image_numbers, products))
+
+        files = {'product': 'annotation', 'calibration': 'calibration', 'noise': 'noise'}
+        for name in files:
+            elem = metadata[image_numbers_and_products.index((self.image_number, name))]
+            content = copy.deepcopy(elem.find('content'))
+            content.tag = 'product'
+            setattr(self, files[name], content)
+            setattr(self, f'{files[name]}_name', elem.attrib['source_filename'])
+
+        self.manifest = manifest
+        self.manifest_name = 'manifest.safe'
+
+        file_paths = [x.attrib['href'] for x in manifest.findall('.//fileLocation')]
+        pattern = f'^./measurement/s1.*{self.image_number}.tiff$'
+        self.measurement_name = [Path(x).name for x in file_paths if re.search(pattern, x)][0]
+
+        self.gcp_df = self.create_gcp_df()
+        self.footprint = self.create_geometry(self.gcp_df)[0]
+        self.swath = int(self.annotation.findtext('.//{*}adsHeader/swath')[2])
+        self.polarisation = self.annotation.findtext('.//{*}adsHeader/polarisation')
+        self.orbit_direction = self.manifest.findtext('.//{*}pass').lower()
+
+    @staticmethod
+    def reformat_gcp(point):
+        attribs = ['line', 'pixel', 'latitude', 'longitude', 'height']
+        values = {}
+        for attrib in attribs:
+            values[attrib] = float(point.find(attrib).text)
+        return values
+
+    def create_gcp_df(self):
+        points = self.annotation.findall('.//{*}geolocationGridPoint')
+        gcp_df = pd.DataFrame([self.reformat_gcp(x) for x in points])
+        gcp_df = gcp_df.sort_values(['line', 'pixel']).reset_index(drop=True)
+        return gcp_df
+
+    def create_geometry(self, gcp_df):
+        burst_index = self.burst_number - 1
+        lines = int(self.annotation.findtext('.//{*}linesPerBurst'))
+        first_line = gcp_df.loc[gcp_df['line'] == burst_index * lines, ['longitude', 'latitude']]
+        second_line = gcp_df.loc[gcp_df['line'] == (burst_index + 1) * lines, ['longitude', 'latitude']]
+        x1 = first_line['longitude'].tolist()
+        y1 = first_line['latitude'].tolist()
+        x2 = second_line['longitude'].tolist()
+        y2 = second_line['latitude'].tolist()
+        x2.reverse()
+        y2.reverse()
+        x = x1 + x2
+        y = y1 + y2
+        footprint = geometry.Polygon(zip(x, y))
+        centroid = tuple([x[0] for x in footprint.centroid.xy])
+        return footprint, footprint.bounds, centroid
+
+
+def create_burst_request(burst_params: BurstParams, content: str) -> dict:
+    payload = {
+        'zip_url': burst_params.safe_url,
+        'image_number': str(burst_params.image_number),
+        'burst_number': str(burst_params.burst_number),
+    }
+    return {
+        'url': URLS[content],
+        'params': payload,
+    }
+
+
+def download_metadata(
+    asf_session: requests.Session, burst_params: BurstParams, out_file: Union[Path, str] = None
+) -> ET.Element:
+    burst_request = create_burst_request(burst_params, content='metadata')
+    burst_request['cookies'] = {'asf-urs': asf_session.cookies['asf-urs']}
+
+    response = asf_session.get(**burst_request)
+    response.raise_for_status()
+
+    metadata = ET.fromstring(response.content)
+
+    if out_file:
+        ET.ElementTree(metadata).write(out_file, encoding='UTF-8', xml_declaration=True)
+
+    return metadata
+
+
+def download_geotiff(asf_session: requests.Session, burst_params: BurstParams, out_file: Union[Path, str]) -> str:
+    burst_request = create_burst_request(burst_params, content='metadata')
+    burst_request['cookies'] = {'asf-urs': asf_session.cookies['asf-urs']}
+
+    for ii in range(1, 4):
+        print(f'Download attempt #{ii}')
+        response = asf_session.get(**burst_request)
+        if downloaded := response.ok:
+            break
+
+    if not downloaded:
+        raise RuntimeError('Download failed three times')
+
+    with open(out_file, 'wb') as f:
+        f.write(response.content)
+
+    return str(out_file)
+
+
+def download_manifest(safe_url: str, out_file: Union[Path, str] = None) -> ET.Element:
+
+    safe_name = Path(safe_url).with_suffix('.SAFE').name
+
+    my_netrc = netrc.netrc()
+    username, _, password = my_netrc.authenticators('urs.earthdata.nasa.gov')
+    auth = aiohttp.BasicAuth(username, password)
+    storage_options = {'client_kwargs': {'trust_env': True, 'auth': auth}}
+
+    http_fs = fsspec.filesystem('https', **storage_options)
+    with http_fs.open(safe_url) as fo:
+        safe_zip = fsspec.filesystem('zip', fo=fo)
+        with safe_zip.open(str(Path(safe_name) / 'manifest.safe')) as f:
+            manifest = f.read()
+
+    if out_file:
+        with open(out_file, 'wb') as f:
+            f.write(manifest)
+
+    manifest = ET.parse(io.BytesIO(manifest)).getroot()
+    return manifest
+
+
+def download_swath(safe_url: str, measurement_path: Path, measurement_name: str) -> str:
+    safe_name = Path(safe_url).with_suffix('.SAFE').name
+    swath_path = safe_name / Path('measurement') / measurement_name
+    out_path = measurement_path / measurement_name
+
+    my_netrc = netrc.netrc()
+    username, _, password = my_netrc.authenticators('urs.earthdata.nasa.gov')
+    auth = aiohttp.BasicAuth(username, password)
+    storage_options = {'client_kwargs': {'trust_env': True, 'auth': auth}}
+
+    http_fs = fsspec.filesystem('https', **storage_options)
+    with http_fs.open(safe_url) as fo:
+        safe_zip = fsspec.filesystem('zip', fo=fo)
+        with safe_zip.open(str(swath_path)) as f:
+            swath = f.read()
+
+    with open(out_path, 'wb') as f:
+        f.write(swath)
+
+    return str(out_path)
+
+
+def spoof_safe(
+    asf_session: requests.Session,
+    burst: BurstMetadata,
+    base_path: Path = Path('.'),
+    download_strategy: str = 'single_burst',
+) -> Path:
+    """Creates this file structure:
+    SLC.SAFE/
+    ├── manifest.safe
+    ├── measurement/
+    │   └── burst.tif
+    └── annotation/
+        ├── annotation.xml
+        └── calbiration/
+            ├── calibration.xml
+            └── noise.xml
+    """
+    safe_path = base_path / burst.safe_name
+    annotation_path = safe_path / 'annotation'
+    calibration_path = safe_path / 'annotation' / 'calibration'
+    measurement_path = safe_path / 'measurement'
+    paths = [annotation_path, calibration_path, measurement_path]
+    for p in paths:
+        if not p.exists():
+            p.mkdir(parents=True)
+
+    et_args = {'encoding': 'UTF-8', 'xml_declaration': True}
+
+    ET.ElementTree(burst.annotation).write(annotation_path / burst.annotation_name, **et_args)
+    ET.ElementTree(burst.calibration).write(calibration_path / burst.calibration_name, **et_args)
+    ET.ElementTree(burst.noise).write(calibration_path / burst.noise_name, **et_args)
+    ET.ElementTree(burst.manifest).write(safe_path / 'manifest.safe', **et_args)
+
+    if download_strategy == 'single_burst':
+        burst_params = BurstParams(
+            safe_url=burst.safe_url, image_number=burst.image_number, burst_number=burst.burst_number
+        )
+        download_geotiff(asf_session, burst_params, measurement_path / burst.measurement_name)
+    elif download_strategy == 'surrounding_burst':
+        n_bursts = len(burst.annotation.find('.//burstList'))
+        names = {
+            'burst_pre.tiff': burst.burst_number - 1,
+            burst.measurement_name: burst.burst_number,
+            'burst_post.tiff': burst.burst_number + 1,
+        }
+        names = {k: v for k, v in names.items() if 0 < v <= n_bursts}
+        for n in names:
+            burst_params = BurstParams(safe_url=burst.safe_url, image_number=burst.image_number, burst_number=names[n])
+            download_geotiff(asf_session, burst_params, measurement_path / n)
+    elif download_strategy == 'swath':
+        download_swath(
+            burst.safe_url,
+            measurement_path,
+            burst.measurement_name,
+        )
+    else:
+        raise NotImplementedError(f'Download strategy {download_strategy} is not implemented, check spelling.')
+
+    return safe_path
+
+
+# TODO currently only validated for descending orbits
+def get_region_of_interest(
+    poly1: geometry.Polygon, poly2: geometry.Polygon, is_ascending: bool = True
+) -> Tuple[float, float, float, float]:
+    bbox1 = geometry.box(*poly1.bounds)
+    bbox2 = geometry.box(*poly2.bounds)
+    intersection = bbox1.intersection(bbox2)
+    bounds = intersection.bounds
+
+    x, y = (0, 1) if is_ascending else (2, 1)
+    roi = geometry.Point(bounds[x], bounds[y]).buffer(0.005)
+    bounds = roi.bounds  # returns (minx, miny, maxx, maxy)
+    return bounds
+
+
+def get_asf_session() -> requests.Session:
+    # requests will automatically use the netrc file:
+    # https://requests.readthedocs.io/en/latest/user/authentication/#netrc-authentication
+    session = requests.Session()
+    payload = {
+        'response_type': 'code',
+        'client_id': 'BO_n7nTIlMljdvU6kRRB3g',
+        'redirect_uri': 'https://auth.asf.alaska.edu/login',
+    }
+    response = session.get('https://urs.earthdata.nasa.gov/oauth/authorize', params=payload)
+    response.raise_for_status()
+    return session
+
+
+def download_bursts(param_list: Iterator[BurstParams]) -> List[BurstMetadata]:
+    """Steps
+    For each burst:
+        1. Download metadata
+        2. Create BurstMetadata object
+        3. Create directory structure
+        4. Write metadata
+        5. Download and write geotiff
+    """
+    asf_session = get_asf_session()
+    bursts = []
+    for i, params in enumerate(param_list):
+        print(f'Creating SAFE {i+1}...')
+        manifest = download_manifest(params.safe_url)
+        metadata = download_metadata(asf_session, params)
+        burst = BurstMetadata(metadata, manifest, params)
+        bursts.append(burst)
+        spoof_safe(asf_session, burst, download_strategy='swath')
+
+    print('SAFEs created!')
+
+    return bursts

--- a/isce2_topsapp/localize_dem.py
+++ b/isce2_topsapp/localize_dem.py
@@ -13,7 +13,7 @@ from shapely.geometry import box
 
 def tag_dem_xml_as_ellipsoidal(dem_path: Path) -> str:
     xml_path = str(dem_path) + '.xml'
-    assert(Path(xml_path).exists())
+    assert Path(xml_path).exists()
     tree = etree.parse(xml_path)
     root = tree.getroot()
 

--- a/isce2_topsapp/localize_slc.py
+++ b/isce2_topsapp/localize_slc.py
@@ -40,11 +40,11 @@ def check_geometry(reference_obs: list,
 
     # Two geometries must intersect for their to be an interferogram
     intersection_geo = secondary_geo.intersection(reference_geo)
-    assert(not intersection_geo.is_empty)
+    assert not intersection_geo.is_empty
 
     # if they are not Polygons they are multipolygons and not valid
-    assert(isinstance(secondary_geo, Polygon))
-    assert(isinstance(reference_geo, Polygon))
+    assert isinstance(secondary_geo, Polygon)
+    assert isinstance(reference_geo, Polygon)
     return intersection_geo
 
 
@@ -60,8 +60,8 @@ def download_slcs(reference_ids: list,
     secondary_props = [ob.properties for ob in secondary_obs]
 
     # Check the number of objects is the same as inputs
-    assert(len(reference_obs) == len(reference_ids))
-    assert(len(secondary_obs) == len(secondary_ids))
+    assert len(reference_obs) == len(reference_ids)
+    assert len(secondary_obs) == len(secondary_ids)
 
     intersection_geo = check_geometry(reference_obs, secondary_obs)
 

--- a/isce2_topsapp/packaging.py
+++ b/isce2_topsapp/packaging.py
@@ -191,7 +191,7 @@ def perform_netcdf_packaging(*,
     isce_data_dir = Path(isce_data_dir)
     merged_dir = isce_data_dir/'merged'
     metadata_path = merged_dir/'metadata.h5'
-    assert(metadata_path.exists())
+    assert metadata_path.exists()
 
     # Write config file
     _write_json_config(gunw_id=gunw_id,
@@ -207,7 +207,7 @@ def perform_netcdf_packaging(*,
     out_nc_file = merged_dir/f'{gunw_id}.nc'
 
     # Check if the netcdf file was created
-    assert(out_nc_file.exists())
+    assert out_nc_file.exists()
     return out_nc_file
 
 

--- a/isce2_topsapp/packaging.py
+++ b/isce2_topsapp/packaging.py
@@ -11,7 +11,7 @@ from dateparser import parse
 import isce2_topsapp
 from isce2_topsapp.templates import read_netcdf_packaging_template
 
-DATASET_VERSION = '2.0.5'
+DATASET_VERSION = '2.0.6'
 
 
 """Warning: the packaging scripts were written as command line scripts and

--- a/isce2_topsapp/templates/topsapp_template.xml
+++ b/isce2_topsapp/templates/topsapp_template.xml
@@ -17,7 +17,7 @@
     <property name="range looks">{{ range_looks }}</property>
     <property name="azimuth looks">{{ azimuth_looks }}</property>
     <property name="filter strength">{{ filter_strength }}</property>
-    <!-- <property name="region of interest">{{ region_of_interest }}</property> -->
+    <property name="region of interest">{{ region_of_interest }}</property>
     <property name="demFilename">{{ demFilename }}</property>
     <property name="geocodeDemFilename">{{ geocodeDemFilename }}</property>
     <property name="do unwrap">True</property>

--- a/isce2_topsapp/topsapp_proc.py
+++ b/isce2_topsapp/topsapp_proc.py
@@ -33,6 +33,8 @@ def topsapp_processing(*,
                        extent: list,
                        dem_for_proc: str,
                        dem_for_geoc: str,
+                       azimuth_looks: int = 7,
+                       range_looks: int = 19,
                        swaths: list = None,
                        dry_run: bool = False):
     swaths = swaths or [1, 2, 3]
@@ -60,8 +62,8 @@ def topsapp_processing(*,
                                   do_unwrap=True,
                                   use_virtual_files=True,
                                   esd_coherence_threshold=-1,
-                                  azimuth_looks=7,
-                                  range_looks=19,
+                                  azimuth_looks=azimuth_looks,
+                                  range_looks=range_looks,
                                   swaths=swaths
                                   )
     with open('topsApp.xml', "w") as file:

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,8 @@ setup(
     entry_points={
         'console_scripts': [
             'isce2_topsapp = isce2_topsapp.__main__:main',
+            'gunw_slc = isce2_topsapp.__main__:gunw_slc',
+            'gunw_burst = isce2_topsapp.__main__:gunw_burst',
             'makeGeocube = isce2_topsapp.packaging_utils.makeGeocube:main',
             'nc_packaging = isce2_topsapp.packaging_utils.nc_packaging:main'
         ]

--- a/tests/test_data/ref_manifest.xml
+++ b/tests/test_data/ref_manifest.xml
@@ -1,0 +1,487 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xfdu:XFDU xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml" xmlns:xfdu="urn:ccsds:schema:xfdu:1" xmlns:safe="http://www.esa.int/safe/sentinel-1.0" xmlns:s1="http://www.esa.int/safe/sentinel-1.0/sentinel-1" xmlns:s1sar="http://www.esa.int/safe/sentinel-1.0/sentinel-1/sar" xmlns:s1sarl1="http://www.esa.int/safe/sentinel-1.0/sentinel-1/sar/level-1" xmlns:s1sarl2="http://www.esa.int/safe/sentinel-1.0/sentinel-1/sar/level-2" xmlns:gx="http://www.google.com/kml/ext/2.2" version="esa/safe/sentinel-1.0/sentinel-1/sar/level-1/slc/standard/iwdp">
+  <informationPackageMap>
+    <xfdu:contentUnit unitType="SAFE Archive Information Package" textInfo="Sentinel-1 IW Level-1 SLC Product" dmdID="acquisitionPeriod platform generalProductInformation measurementOrbitReference measurementFrameSet" pdiID="processing">
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1ProductSchema">
+        <dataObjectPointer dataObjectID="products1aiw1slcvh20200604t02225220200604t02231703286103ce65001"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1NoiseSchema">
+        <dataObjectPointer dataObjectID="noises1aiw1slcvh20200604t02225220200604t02231703286103ce65001"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1CalibrationSchema">
+        <dataObjectPointer dataObjectID="calibrations1aiw1slcvh20200604t02225220200604t02231703286103ce65001"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1ProductSchema">
+        <dataObjectPointer dataObjectID="products1aiw2slcvh20200604t02225320200604t02231803286103ce65002"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1NoiseSchema">
+        <dataObjectPointer dataObjectID="noises1aiw2slcvh20200604t02225320200604t02231803286103ce65002"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1CalibrationSchema">
+        <dataObjectPointer dataObjectID="calibrations1aiw2slcvh20200604t02225320200604t02231803286103ce65002"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1ProductSchema">
+        <dataObjectPointer dataObjectID="products1aiw3slcvh20200604t02225120200604t02231703286103ce65003"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1NoiseSchema">
+        <dataObjectPointer dataObjectID="noises1aiw3slcvh20200604t02225120200604t02231703286103ce65003"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1CalibrationSchema">
+        <dataObjectPointer dataObjectID="calibrations1aiw3slcvh20200604t02225120200604t02231703286103ce65003"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1ProductSchema">
+        <dataObjectPointer dataObjectID="products1aiw1slcvv20200604t02225220200604t02231703286103ce65004"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1NoiseSchema">
+        <dataObjectPointer dataObjectID="noises1aiw1slcvv20200604t02225220200604t02231703286103ce65004"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1CalibrationSchema">
+        <dataObjectPointer dataObjectID="calibrations1aiw1slcvv20200604t02225220200604t02231703286103ce65004"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1ProductSchema">
+        <dataObjectPointer dataObjectID="products1aiw2slcvv20200604t02225320200604t02231803286103ce65005"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1NoiseSchema">
+        <dataObjectPointer dataObjectID="noises1aiw2slcvv20200604t02225320200604t02231803286103ce65005"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1CalibrationSchema">
+        <dataObjectPointer dataObjectID="calibrations1aiw2slcvv20200604t02225320200604t02231803286103ce65005"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1ProductSchema">
+        <dataObjectPointer dataObjectID="products1aiw3slcvv20200604t02225120200604t02231703286103ce65006"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1NoiseSchema">
+        <dataObjectPointer dataObjectID="noises1aiw3slcvv20200604t02225120200604t02231703286103ce65006"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1CalibrationSchema">
+        <dataObjectPointer dataObjectID="calibrations1aiw3slcvv20200604t02225120200604t02231703286103ce65006"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1MapOverlaySchema">
+        <dataObjectPointer dataObjectID="mapoverlay"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1ProductPreviewSchema">
+        <dataObjectPointer dataObjectID="productpreview"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Measurement Data Unit" repID="s1Level1MeasurementSchema" dmdID="products1aiw1slcvh20200604t02225220200604t02231703286103ce65001Annotation noises1aiw1slcvh20200604t02225220200604t02231703286103ce65001Annotation calibrations1aiw1slcvh20200604t02225220200604t02231703286103ce65001Annotation ">
+        <dataObjectPointer dataObjectID="s1aiw1slcvh20200604t02225220200604t02231703286103ce65001"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Measurement Data Unit" repID="s1Level1MeasurementSchema" dmdID="products1aiw2slcvh20200604t02225320200604t02231803286103ce65002Annotation noises1aiw2slcvh20200604t02225320200604t02231803286103ce65002Annotation calibrations1aiw2slcvh20200604t02225320200604t02231803286103ce65002Annotation ">
+        <dataObjectPointer dataObjectID="s1aiw2slcvh20200604t02225320200604t02231803286103ce65002"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Measurement Data Unit" repID="s1Level1MeasurementSchema" dmdID="products1aiw3slcvh20200604t02225120200604t02231703286103ce65003Annotation noises1aiw3slcvh20200604t02225120200604t02231703286103ce65003Annotation calibrations1aiw3slcvh20200604t02225120200604t02231703286103ce65003Annotation ">
+        <dataObjectPointer dataObjectID="s1aiw3slcvh20200604t02225120200604t02231703286103ce65003"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Measurement Data Unit" repID="s1Level1MeasurementSchema" dmdID="products1aiw1slcvv20200604t02225220200604t02231703286103ce65004Annotation noises1aiw1slcvv20200604t02225220200604t02231703286103ce65004Annotation calibrations1aiw1slcvv20200604t02225220200604t02231703286103ce65004Annotation ">
+        <dataObjectPointer dataObjectID="s1aiw1slcvv20200604t02225220200604t02231703286103ce65004"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Measurement Data Unit" repID="s1Level1MeasurementSchema" dmdID="products1aiw2slcvv20200604t02225320200604t02231803286103ce65005Annotation noises1aiw2slcvv20200604t02225320200604t02231803286103ce65005Annotation calibrations1aiw2slcvv20200604t02225320200604t02231803286103ce65005Annotation ">
+        <dataObjectPointer dataObjectID="s1aiw2slcvv20200604t02225320200604t02231803286103ce65005"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Measurement Data Unit" repID="s1Level1MeasurementSchema" dmdID="products1aiw3slcvv20200604t02225120200604t02231703286103ce65006Annotation noises1aiw3slcvv20200604t02225120200604t02231703286103ce65006Annotation calibrations1aiw3slcvv20200604t02225120200604t02231703286103ce65006Annotation ">
+        <dataObjectPointer dataObjectID="s1aiw3slcvv20200604t02225120200604t02231703286103ce65006"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Measurement Data Unit" repID="s1Level1QuickLookSchema">
+        <dataObjectPointer dataObjectID="quicklook"/>
+      </xfdu:contentUnit>
+    </xfdu:contentUnit>
+  </informationPackageMap>
+  <metadataSection>
+    <metadataObject ID="products1aiw1slcvh20200604t02225220200604t02231703286103ce65001Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="products1aiw1slcvh20200604t02225220200604t02231703286103ce65001"/>
+    </metadataObject>
+    <metadataObject ID="noises1aiw1slcvh20200604t02225220200604t02231703286103ce65001Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="noises1aiw1slcvh20200604t02225220200604t02231703286103ce65001"/>
+    </metadataObject>
+    <metadataObject ID="calibrations1aiw1slcvh20200604t02225220200604t02231703286103ce65001Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="calibrations1aiw1slcvh20200604t02225220200604t02231703286103ce65001"/>
+    </metadataObject>
+    <metadataObject ID="products1aiw2slcvh20200604t02225320200604t02231803286103ce65002Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="products1aiw2slcvh20200604t02225320200604t02231803286103ce65002"/>
+    </metadataObject>
+    <metadataObject ID="noises1aiw2slcvh20200604t02225320200604t02231803286103ce65002Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="noises1aiw2slcvh20200604t02225320200604t02231803286103ce65002"/>
+    </metadataObject>
+    <metadataObject ID="calibrations1aiw2slcvh20200604t02225320200604t02231803286103ce65002Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="calibrations1aiw2slcvh20200604t02225320200604t02231803286103ce65002"/>
+    </metadataObject>
+    <metadataObject ID="products1aiw3slcvh20200604t02225120200604t02231703286103ce65003Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="products1aiw3slcvh20200604t02225120200604t02231703286103ce65003"/>
+    </metadataObject>
+    <metadataObject ID="noises1aiw3slcvh20200604t02225120200604t02231703286103ce65003Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="noises1aiw3slcvh20200604t02225120200604t02231703286103ce65003"/>
+    </metadataObject>
+    <metadataObject ID="calibrations1aiw3slcvh20200604t02225120200604t02231703286103ce65003Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="calibrations1aiw3slcvh20200604t02225120200604t02231703286103ce65003"/>
+    </metadataObject>
+    <metadataObject ID="products1aiw1slcvv20200604t02225220200604t02231703286103ce65004Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="products1aiw1slcvv20200604t02225220200604t02231703286103ce65004"/>
+    </metadataObject>
+    <metadataObject ID="noises1aiw1slcvv20200604t02225220200604t02231703286103ce65004Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="noises1aiw1slcvv20200604t02225220200604t02231703286103ce65004"/>
+    </metadataObject>
+    <metadataObject ID="calibrations1aiw1slcvv20200604t02225220200604t02231703286103ce65004Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="calibrations1aiw1slcvv20200604t02225220200604t02231703286103ce65004"/>
+    </metadataObject>
+    <metadataObject ID="products1aiw2slcvv20200604t02225320200604t02231803286103ce65005Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="products1aiw2slcvv20200604t02225320200604t02231803286103ce65005"/>
+    </metadataObject>
+    <metadataObject ID="noises1aiw2slcvv20200604t02225320200604t02231803286103ce65005Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="noises1aiw2slcvv20200604t02225320200604t02231803286103ce65005"/>
+    </metadataObject>
+    <metadataObject ID="calibrations1aiw2slcvv20200604t02225320200604t02231803286103ce65005Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="calibrations1aiw2slcvv20200604t02225320200604t02231803286103ce65005"/>
+    </metadataObject>
+    <metadataObject ID="products1aiw3slcvv20200604t02225120200604t02231703286103ce65006Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="products1aiw3slcvv20200604t02225120200604t02231703286103ce65006"/>
+    </metadataObject>
+    <metadataObject ID="noises1aiw3slcvv20200604t02225120200604t02231703286103ce65006Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="noises1aiw3slcvv20200604t02225120200604t02231703286103ce65006"/>
+    </metadataObject>
+    <metadataObject ID="calibrations1aiw3slcvv20200604t02225120200604t02231703286103ce65006Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="calibrations1aiw3slcvv20200604t02225120200604t02231703286103ce65006"/>
+    </metadataObject>
+    <metadataObject ID="mapoverlayAnnotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="mapoverlay"/>
+    </metadataObject>
+    <metadataObject ID="productpreviewAnnotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="productpreview"/>
+    </metadataObject>
+    <metadataObject ID="processing" classification="PROVENANCE" category="PDI">
+      <metadataWrap mimeType="text/xml" vocabularyName="SAFE" textInfo="Processing">
+        <xmlData>
+          <safe:processing name="SLC Post Processing" start="2020-06-04T06:18:16.740007" stop="2020-06-04T06:26:49.000000">
+            <safe:facility country="Germany" name="Copernicus S1 Core Ground Segment - DPA" organisation="ESA" site="DLR-Oberpfaffenhofen">
+              <safe:software name="Sentinel-1 IPF" version="003.20"/>
+            </safe:facility>
+            <safe:resource name="S1A_IW_SL1__1_DV_20200604T022251_20200604T022323_032861_03CE65_6C9E.SAFE" role="Level-1 Intermediate SLC Product">
+              <processing name="SLC Processing" start="2020-06-04T06:20:13.000000" stop="2020-06-04T06:25:35.000000" xmlns="http://www.esa.int/safe/sentinel-1.0">
+                <facility country="Germany" name="Copernicus S1 Core Ground Segment - DPA" organisation="ESA" site="DLR-Oberpfaffenhofen">
+                  <software name="Sentinel-1 IPF" version="003.20"/>
+                </facility>
+                <resource name="/data/localWD/645951171/S1A_AUX_PP1_V20171017T080000_G20200512T125711.SAFE" role="AUX_PP1"/>
+                <resource name="/data/localWD/645951171/S1A_AUX_CAL_V20171017T080000_G20190731T120030.SAFE" role="AUX_CAL"/>
+                <resource name="/data/localWD/645951171/S1A_AUX_INS_V20171017T080000_G20180313T104658.SAFE" role="AUX_INS"/>
+                <resource name="/data/localWD/645951171/S1A_OPER_AUX_RESORB_OPOD_20200604T055751_V20200604T014113_20200604T045843.EOF" role="AUX_RES"/>
+                <resource name="/data/localWD/645951171/S1A_IW_RAW__0SDV_20200604T022249_20200604T022321_032861_03CE65_62EB.SAFE" role="Level-0 Product">
+                  <processing xmlns="http://www.esa.int/safe/sentinel-1.0" name="Generation of Sentinel-1 L0 SAR Product, dual polarisation" start="2020-06-04T06:09:18.865317" stop="2020-06-04T06:09:18.974882">
+                    <facility country="Germany" name="DPA_" organisation="ESA" site="DLR-Oberpfaffenhofen">
+                      <software name="" version=""/>
+                    </facility>
+                    <resource name="S-1 Core PDGS S-1 Level-0 Product Format Specifications S1PD.SP.00110.ASTR" role="Applicable Document"/>
+                    <resource name="Sentinel-1 SAR Space Packet Protocol Data Unit S1-IF-ASD-PL-0007" role="Applicable Document" version="13.0"/>
+                    <resource name="Unknown" role="Raw Data">
+                      <processing xmlns="http://www.esa.int/safe/sentinel-1.0" name="Generation of Sentinel-1 SAR Slice L0 product single polarisation" start="2020-06-04T06:07:39.940264" stop="2020-06-04T06:07:40.679034">
+                        <resource name="S-1 Core PDGS S-1 Level-0 Product Format Specifications S1PD.SP.00110.ASTR" role="Applicable Document">
+                           </resource>
+                        <resource name="Sentinel-1 SAR Space Packet Protocol Data Unit S1-IF-ASD-PL-0007" version="13.0" role="Applicable Document">
+                           </resource>
+                        <resource name="Downlinked Stream" role="Raw Data">
+                          <processing xmlns="http://www.esa.int/safe/sentinel-1.0" name="Raw Data Downlink Channel1 1" start="2020-06-04T05:26:19.265774" stop="2020-06-04T05:26:42.460152">
+                              </processing>
+                        </resource>
+                      </processing>
+                    </resource>
+                    <resource name="Unknown" role="Raw Data">
+                      <processing xmlns="http://www.esa.int/safe/sentinel-1.0" name="Generation of Sentinel-1 SAR Slice L0 product single polarisation" start="2020-06-04T06:09:02.983590" stop="2020-06-04T06:09:03.813929">
+                        <resource name="S-1 Core PDGS S-1 Level-0 Product Format Specifications S1PD.SP.00110.ASTR" role="Applicable Document">
+                           </resource>
+                        <resource name="Sentinel-1 SAR Space Packet Protocol Data Unit S1-IF-ASD-PL-0007" version="13.0" role="Applicable Document">
+                           </resource>
+                        <resource name="Downlinked Stream" role="Raw Data">
+                          <processing xmlns="http://www.esa.int/safe/sentinel-1.0" name="Raw Data Downlink Channel2 2" start="2020-06-04T05:39:59.579150" stop="2020-06-04T05:40:27.283032">
+                              </processing>
+                        </resource>
+                      </processing>
+                    </resource>
+                  </processing>
+                </resource>
+                <resource name="Sentinel-1 Product Definition (S1-RS-MDA-52-7440) release 2/7" role="product definition"/>
+                <resource name="Sentinel-1 Product Specification (S1-RS-MDA-52-7441) release 3/6" role="product specification"/>
+              </processing>
+            </safe:resource>
+          </safe:processing>
+        </xmlData>
+      </metadataWrap>
+    </metadataObject>
+    <metadataObject ID="platform" classification="DESCRIPTION" category="DMD">
+      <metadataWrap mimeType="text/xml" vocabularyName="SAFE" textInfo="Platform Description">
+        <xmlData>
+          <safe:platform>
+            <safe:nssdcIdentifier>2014-016A</safe:nssdcIdentifier>
+            <safe:familyName>SENTINEL-1</safe:familyName>
+            <safe:number>A</safe:number>
+            <safe:instrument>
+              <safe:familyName abbreviation="SAR">Synthetic Aperture Radar</safe:familyName>
+              <safe:extension>
+                <s1sarl1:instrumentMode>
+                  <s1sarl1:mode>IW</s1sarl1:mode>
+                  <s1sarl1:swath>IW1</s1sarl1:swath>
+                  <s1sarl1:swath>IW2</s1sarl1:swath>
+                  <s1sarl1:swath>IW3</s1sarl1:swath>
+                </s1sarl1:instrumentMode>
+              </safe:extension>
+            </safe:instrument>
+          </safe:platform>
+        </xmlData>
+      </metadataWrap>
+    </metadataObject>
+    <metadataObject ID="measurementOrbitReference" classification="DESCRIPTION" category="DMD">
+      <metadataWrap mimeType="text/xml" vocabularyName="SAFE" textInfo="Orbit Reference">
+        <xmlData>
+          <safe:orbitReference>
+            <safe:orbitNumber type="start">32861</safe:orbitNumber>
+            <safe:orbitNumber type="stop">32861</safe:orbitNumber>
+            <safe:relativeOrbitNumber type="start">64</safe:relativeOrbitNumber>
+            <safe:relativeOrbitNumber type="stop">64</safe:relativeOrbitNumber>
+            <safe:cycleNumber>202</safe:cycleNumber>
+            <safe:phaseIdentifier>1</safe:phaseIdentifier>
+            <safe:extension>
+              <s1:orbitProperties>
+                <s1:pass>DESCENDING</s1:pass>
+                <s1:ascendingNodeTime>2020-06-04T01:41:19.421224</s1:ascendingNodeTime>
+              </s1:orbitProperties>
+            </safe:extension>
+          </safe:orbitReference>
+        </xmlData>
+      </metadataWrap>
+    </metadataObject>
+    <metadataObject ID="generalProductInformation" classification="DESCRIPTION" category="DMD">
+      <metadataWrap mimeType="text/xml" vocabularyName="SAFE" textInfo="General Product Information">
+        <xmlData>
+          <s1sarl1:standAloneProductInformation>
+            <s1sarl1:instrumentConfigurationID>6</s1sarl1:instrumentConfigurationID>
+            <s1sarl1:missionDataTakeID>249445</s1sarl1:missionDataTakeID>
+            <s1sarl1:transmitterReceiverPolarisation>VV</s1sarl1:transmitterReceiverPolarisation>
+            <s1sarl1:transmitterReceiverPolarisation>VH</s1sarl1:transmitterReceiverPolarisation>
+            <s1sarl1:productClass>S</s1sarl1:productClass>
+            <s1sarl1:productClassDescription>SAR Standard L1 Product</s1sarl1:productClassDescription>
+            <s1sarl1:productComposition>Slice</s1sarl1:productComposition>
+            <s1sarl1:productType>SLC</s1sarl1:productType>
+            <s1sarl1:productTimelinessCategory>Fast-24h</s1sarl1:productTimelinessCategory>
+            <s1sarl1:sliceProductFlag>true</s1sarl1:sliceProductFlag>
+            <s1sarl1:segmentStartTime>2020-06-04T02:18:14.446800</s1sarl1:segmentStartTime>
+            <s1sarl1:sliceNumber>12</s1sarl1:sliceNumber>
+            <s1sarl1:totalSlices>15</s1sarl1:totalSlices>
+          </s1sarl1:standAloneProductInformation>
+        </xmlData>
+      </metadataWrap>
+    </metadataObject>
+    <metadataObject ID="acquisitionPeriod" classification="DESCRIPTION" category="DMD">
+      <metadataWrap mimeType="text/xml" vocabularyName="SAFE" textInfo="Acquisition Period">
+        <xmlData>
+          <safe:acquisitionPeriod>
+            <safe:startTime>2020-06-04T02:22:51.824758</safe:startTime>
+            <safe:stopTime>2020-06-04T02:23:18.799823</safe:stopTime>
+            <safe:extension>
+              <s1:timeANX>
+                <s1:startTimeANX>2.492404e+06</s1:startTimeANX>
+                <s1:stopTimeANX>2.519378e+06</s1:stopTimeANX>
+              </s1:timeANX>
+            </safe:extension>
+          </safe:acquisitionPeriod>
+        </xmlData>
+      </metadataWrap>
+    </metadataObject>
+    <metadataObject ID="measurementFrameSet" classification="DESCRIPTION" category="DMD">
+      <metadataWrap mimeType="text/xml" vocabularyName="SAFE" textInfo="Frame Set">
+        <xmlData>
+          <safe:frameSet>
+            <safe:frame>
+              <safe:footPrint srsName="http://www.opengis.net/gml/srs/epsg.xml#4326">
+                <gml:coordinates>27.188002,54.890476 27.599976,52.364201 29.224121,52.680912 28.814882,55.247711</gml:coordinates>
+              </safe:footPrint>
+            </safe:frame>
+          </safe:frameSet>
+        </xmlData>
+      </metadataWrap>
+    </metadataObject>
+    <metadataObject ID="s1Level1ProductSchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="XML Schema" locatorType="URL" href="./support/s1-level-1-product.xsd"/>
+    </metadataObject>
+    <metadataObject ID="s1Level1NoiseSchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="XML Schema" locatorType="URL" href="./support/s1-level-1-noise.xsd"/>
+    </metadataObject>
+    <metadataObject ID="s1Level1CalibrationSchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="XML Schema" locatorType="URL" href="./support/s1-level-1-calibration.xsd"/>
+    </metadataObject>
+    <metadataObject ID="s1ObjectTypesSchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="XML Schema" locatorType="URL" href="./support/s1-object-types.xsd"/>
+    </metadataObject>
+    <metadataObject ID="s1Level1MeasurementSchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="SDF" locatorType="URL" href="./support/s1-level-1-measurement.xsd"/>
+    </metadataObject>
+    <metadataObject ID="s1Level1ProductPreviewSchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="XML Schema" locatorType="URL" href="./support/s1-product-preview.xsd"/>
+    </metadataObject>
+    <metadataObject ID="s1Level1QuickLookSchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="XML Schema" locatorType="URL" href="./support/s1-level-1-quicklook.xsd"/>
+    </metadataObject>
+    <metadataObject ID="s1Level1MapOverlaySchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="XML Schema" locatorType="URL" href="./support/s1-map-overlay.xsd"/>
+    </metadataObject>
+  </metadataSection>
+  <dataObjectSection>
+    <dataObject ID="products1aiw1slcvh20200604t02225220200604t02231703286103ce65001" repID="s1Level1ProductSchema">
+      <byteStream mimeType="text/xml" size="879365">
+        <fileLocation locatorType="URL" href="./annotation/s1a-iw1-slc-vh-20200604t022252-20200604t022317-032861-03ce65-001.xml"/>
+        <checksum checksumName="MD5">8af95000c0c4570ac06c0552bba382e3</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="noises1aiw1slcvh20200604t02225220200604t02231703286103ce65001" repID="s1Level1NoiseSchema">
+      <byteStream mimeType="text/xml" size="127589">
+        <fileLocation locatorType="URL" href="./annotation/calibration/noise-s1a-iw1-slc-vh-20200604t022252-20200604t022317-032861-03ce65-001.xml"/>
+        <checksum checksumName="MD5">4f8379a1da33f27899a70debb319346b</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="calibrations1aiw1slcvh20200604t02225220200604t02231703286103ce65001" repID="s1Level1CalibrationSchema">
+      <byteStream mimeType="text/xml" size="909982">
+        <fileLocation locatorType="URL" href="./annotation/calibration/calibration-s1a-iw1-slc-vh-20200604t022252-20200604t022317-032861-03ce65-001.xml"/>
+        <checksum checksumName="MD5">d53a0de01d5822433b896aaa7718edc2</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="products1aiw2slcvh20200604t02225320200604t02231803286103ce65002" repID="s1Level1ProductSchema">
+      <byteStream mimeType="text/xml" size="871740">
+        <fileLocation locatorType="URL" href="./annotation/s1a-iw2-slc-vh-20200604t022253-20200604t022318-032861-03ce65-002.xml"/>
+        <checksum checksumName="MD5">0b7406c0c50586b4b973215ae46d5bfc</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="noises1aiw2slcvh20200604t02225320200604t02231803286103ce65002" repID="s1Level1NoiseSchema">
+      <byteStream mimeType="text/xml" size="144672">
+        <fileLocation locatorType="URL" href="./annotation/calibration/noise-s1a-iw2-slc-vh-20200604t022253-20200604t022318-032861-03ce65-002.xml"/>
+        <checksum checksumName="MD5">9cc72c8a7929cc5f5fd13af745bfdd69</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="calibrations1aiw2slcvh20200604t02225320200604t02231803286103ce65002" repID="s1Level1CalibrationSchema">
+      <byteStream mimeType="text/xml" size="1074818">
+        <fileLocation locatorType="URL" href="./annotation/calibration/calibration-s1a-iw2-slc-vh-20200604t022253-20200604t022318-032861-03ce65-002.xml"/>
+        <checksum checksumName="MD5">0a156b6ba4bf9800939d4be3f1ffc0df</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="products1aiw3slcvh20200604t02225120200604t02231703286103ce65003" repID="s1Level1ProductSchema">
+      <byteStream mimeType="text/xml" size="785129">
+        <fileLocation locatorType="URL" href="./annotation/s1a-iw3-slc-vh-20200604t022251-20200604t022317-032861-03ce65-003.xml"/>
+        <checksum checksumName="MD5">b59ac865bc4554e3a11804a68559efcf</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="noises1aiw3slcvh20200604t02225120200604t02231703286103ce65003" repID="s1Level1NoiseSchema">
+      <byteStream mimeType="text/xml" size="142370">
+        <fileLocation locatorType="URL" href="./annotation/calibration/noise-s1a-iw3-slc-vh-20200604t022251-20200604t022317-032861-03ce65-003.xml"/>
+        <checksum checksumName="MD5">20b276c6ccc176aba1602ed6b60d59d2</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="calibrations1aiw3slcvh20200604t02225120200604t02231703286103ce65003" repID="s1Level1CalibrationSchema">
+      <byteStream mimeType="text/xml" size="1037813">
+        <fileLocation locatorType="URL" href="./annotation/calibration/calibration-s1a-iw3-slc-vh-20200604t022251-20200604t022317-032861-03ce65-003.xml"/>
+        <checksum checksumName="MD5">2e0099ea2ce39d567ad29f1d20e209ba</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="products1aiw1slcvv20200604t02225220200604t02231703286103ce65004" repID="s1Level1ProductSchema">
+      <byteStream mimeType="text/xml" size="879424">
+        <fileLocation locatorType="URL" href="./annotation/s1a-iw1-slc-vv-20200604t022252-20200604t022317-032861-03ce65-004.xml"/>
+        <checksum checksumName="MD5">2cb2c0ec4495bbcb12c758346c9b036e</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="noises1aiw1slcvv20200604t02225220200604t02231703286103ce65004" repID="s1Level1NoiseSchema">
+      <byteStream mimeType="text/xml" size="127589">
+        <fileLocation locatorType="URL" href="./annotation/calibration/noise-s1a-iw1-slc-vv-20200604t022252-20200604t022317-032861-03ce65-004.xml"/>
+        <checksum checksumName="MD5">e0090d6f88753c8829205c5cb5d3cedd</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="calibrations1aiw1slcvv20200604t02225220200604t02231703286103ce65004" repID="s1Level1CalibrationSchema">
+      <byteStream mimeType="text/xml" size="909982">
+        <fileLocation locatorType="URL" href="./annotation/calibration/calibration-s1a-iw1-slc-vv-20200604t022252-20200604t022317-032861-03ce65-004.xml"/>
+        <checksum checksumName="MD5">be73b098057dd62b41f00b93cbc2d317</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="products1aiw2slcvv20200604t02225320200604t02231803286103ce65005" repID="s1Level1ProductSchema">
+      <byteStream mimeType="text/xml" size="871703">
+        <fileLocation locatorType="URL" href="./annotation/s1a-iw2-slc-vv-20200604t022253-20200604t022318-032861-03ce65-005.xml"/>
+        <checksum checksumName="MD5">ad7d52664f60abbb8a41a3f662077563</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="noises1aiw2slcvv20200604t02225320200604t02231803286103ce65005" repID="s1Level1NoiseSchema">
+      <byteStream mimeType="text/xml" size="144672">
+        <fileLocation locatorType="URL" href="./annotation/calibration/noise-s1a-iw2-slc-vv-20200604t022253-20200604t022318-032861-03ce65-005.xml"/>
+        <checksum checksumName="MD5">ab99e01f11986d3b4427fb71a55c5f79</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="calibrations1aiw2slcvv20200604t02225320200604t02231803286103ce65005" repID="s1Level1CalibrationSchema">
+      <byteStream mimeType="text/xml" size="1074818">
+        <fileLocation locatorType="URL" href="./annotation/calibration/calibration-s1a-iw2-slc-vv-20200604t022253-20200604t022318-032861-03ce65-005.xml"/>
+        <checksum checksumName="MD5">be3979b4fcd60c3b3b2e41d0953266b1</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="products1aiw3slcvv20200604t02225120200604t02231703286103ce65006" repID="s1Level1ProductSchema">
+      <byteStream mimeType="text/xml" size="785131">
+        <fileLocation locatorType="URL" href="./annotation/s1a-iw3-slc-vv-20200604t022251-20200604t022317-032861-03ce65-006.xml"/>
+        <checksum checksumName="MD5">01b69ce4a985e524c34d6fe954628428</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="noises1aiw3slcvv20200604t02225120200604t02231703286103ce65006" repID="s1Level1NoiseSchema">
+      <byteStream mimeType="text/xml" size="142370">
+        <fileLocation locatorType="URL" href="./annotation/calibration/noise-s1a-iw3-slc-vv-20200604t022251-20200604t022317-032861-03ce65-006.xml"/>
+        <checksum checksumName="MD5">995df306690178e5f1b3a855c0dfedcc</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="calibrations1aiw3slcvv20200604t02225120200604t02231703286103ce65006" repID="s1Level1CalibrationSchema">
+      <byteStream mimeType="text/xml" size="1037813">
+        <fileLocation locatorType="URL" href="./annotation/calibration/calibration-s1a-iw3-slc-vv-20200604t022251-20200604t022317-032861-03ce65-006.xml"/>
+        <checksum checksumName="MD5">8904633a0fdcda07b7f213ab333c4af7</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="mapoverlay" repID="s1Level1MapOverlaySchema">
+      <byteStream mimeType="text/xml" size="1018">
+        <fileLocation locatorType="URL" href="./preview/map-overlay.kml"/>
+        <checksum checksumName="MD5">e7768864b1f0f27ab7b67749f0c90562</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="productpreview" repID="s1Level1ProductPreviewSchema">
+      <byteStream mimeType="text/xml" size="6264">
+        <fileLocation locatorType="URL" href="./preview/product-preview.html"/>
+        <checksum checksumName="MD5">70d0c58c1bea94a655cfec99ef1753a9</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="s1aiw1slcvh20200604t02225220200604t02231703286103ce65001" repID="s1Level1MeasurementSchema">
+      <byteStream mimeType="application/octet-stream" size="1161781760">
+        <fileLocation locatorType="URL" href="./measurement/s1a-iw1-slc-vh-20200604t022252-20200604t022317-032861-03ce65-001.tiff"/>
+        <checksum checksumName="MD5">3a25b2c122506b444ccecec113745b6b</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="s1aiw2slcvh20200604t02225320200604t02231803286103ce65002" repID="s1Level1MeasurementSchema">
+      <byteStream mimeType="application/octet-stream" size="1383581576">
+        <fileLocation locatorType="URL" href="./measurement/s1a-iw2-slc-vh-20200604t022253-20200604t022318-032861-03ce65-002.tiff"/>
+        <checksum checksumName="MD5">35ebe75201a92f2c6d242e614bbd144f</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="s1aiw3slcvh20200604t02225120200604t02231703286103ce65003" repID="s1Level1MeasurementSchema">
+      <byteStream mimeType="application/octet-stream" size="1340549516">
+        <fileLocation locatorType="URL" href="./measurement/s1a-iw3-slc-vh-20200604t022251-20200604t022317-032861-03ce65-003.tiff"/>
+        <checksum checksumName="MD5">eddbf62d21c1d3b93d40d91549d39547</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="s1aiw1slcvv20200604t02225220200604t02231703286103ce65004" repID="s1Level1MeasurementSchema">
+      <byteStream mimeType="application/octet-stream" size="1161781760">
+        <fileLocation locatorType="URL" href="./measurement/s1a-iw1-slc-vv-20200604t022252-20200604t022317-032861-03ce65-004.tiff"/>
+        <checksum checksumName="MD5">72e9c15a64b00d3d0c261faed3ab384a</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="s1aiw2slcvv20200604t02225320200604t02231803286103ce65005" repID="s1Level1MeasurementSchema">
+      <byteStream mimeType="application/octet-stream" size="1383581576">
+        <fileLocation locatorType="URL" href="./measurement/s1a-iw2-slc-vv-20200604t022253-20200604t022318-032861-03ce65-005.tiff"/>
+        <checksum checksumName="MD5">06674ef44201d3b36e41f9de530d6fc8</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="s1aiw3slcvv20200604t02225120200604t02231703286103ce65006" repID="s1Level1MeasurementSchema">
+      <byteStream mimeType="application/octet-stream" size="1340549516">
+        <fileLocation locatorType="URL" href="./measurement/s1a-iw3-slc-vv-20200604t022251-20200604t022317-032861-03ce65-006.tiff"/>
+        <checksum checksumName="MD5">d3a3e431e77eec77621e034ad47c6050</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="quicklook" repID="s1Level1QuickLookSchema">
+      <byteStream mimeType="application/octet-stream" size="6287413">
+        <fileLocation locatorType="URL" href="./preview/quick-look.png"/>
+        <checksum checksumName="MD5">f8a3d335bdb28b7adfb1a3e8f63c77cd</checksum>
+      </byteStream>
+    </dataObject>
+  </dataObjectSection>
+</xfdu:XFDU>

--- a/tests/test_data/sec_manifest.xml
+++ b/tests/test_data/sec_manifest.xml
@@ -1,0 +1,487 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xfdu:XFDU xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml" xmlns:xfdu="urn:ccsds:schema:xfdu:1" xmlns:safe="http://www.esa.int/safe/sentinel-1.0" xmlns:s1="http://www.esa.int/safe/sentinel-1.0/sentinel-1" xmlns:s1sar="http://www.esa.int/safe/sentinel-1.0/sentinel-1/sar" xmlns:s1sarl1="http://www.esa.int/safe/sentinel-1.0/sentinel-1/sar/level-1" xmlns:s1sarl2="http://www.esa.int/safe/sentinel-1.0/sentinel-1/sar/level-2" xmlns:gx="http://www.google.com/kml/ext/2.2" version="esa/safe/sentinel-1.0/sentinel-1/sar/level-1/slc/standard/iwdp">
+  <informationPackageMap>
+    <xfdu:contentUnit unitType="SAFE Archive Information Package" textInfo="Sentinel-1 IW Level-1 SLC Product" dmdID="acquisitionPeriod platform generalProductInformation measurementOrbitReference measurementFrameSet" pdiID="processing">
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1ProductSchema">
+        <dataObjectPointer dataObjectID="products1aiw1slcvh20200616t02225320200616t02231803303603d3a3001"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1NoiseSchema">
+        <dataObjectPointer dataObjectID="noises1aiw1slcvh20200616t02225320200616t02231803303603d3a3001"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1CalibrationSchema">
+        <dataObjectPointer dataObjectID="calibrations1aiw1slcvh20200616t02225320200616t02231803303603d3a3001"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1ProductSchema">
+        <dataObjectPointer dataObjectID="products1aiw2slcvh20200616t02225420200616t02231903303603d3a3002"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1NoiseSchema">
+        <dataObjectPointer dataObjectID="noises1aiw2slcvh20200616t02225420200616t02231903303603d3a3002"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1CalibrationSchema">
+        <dataObjectPointer dataObjectID="calibrations1aiw2slcvh20200616t02225420200616t02231903303603d3a3002"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1ProductSchema">
+        <dataObjectPointer dataObjectID="products1aiw3slcvh20200616t02225220200616t02231703303603d3a3003"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1NoiseSchema">
+        <dataObjectPointer dataObjectID="noises1aiw3slcvh20200616t02225220200616t02231703303603d3a3003"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1CalibrationSchema">
+        <dataObjectPointer dataObjectID="calibrations1aiw3slcvh20200616t02225220200616t02231703303603d3a3003"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1ProductSchema">
+        <dataObjectPointer dataObjectID="products1aiw1slcvv20200616t02225320200616t02231803303603d3a3004"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1NoiseSchema">
+        <dataObjectPointer dataObjectID="noises1aiw1slcvv20200616t02225320200616t02231803303603d3a3004"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1CalibrationSchema">
+        <dataObjectPointer dataObjectID="calibrations1aiw1slcvv20200616t02225320200616t02231803303603d3a3004"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1ProductSchema">
+        <dataObjectPointer dataObjectID="products1aiw2slcvv20200616t02225420200616t02231903303603d3a3005"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1NoiseSchema">
+        <dataObjectPointer dataObjectID="noises1aiw2slcvv20200616t02225420200616t02231903303603d3a3005"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1CalibrationSchema">
+        <dataObjectPointer dataObjectID="calibrations1aiw2slcvv20200616t02225420200616t02231903303603d3a3005"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1ProductSchema">
+        <dataObjectPointer dataObjectID="products1aiw3slcvv20200616t02225220200616t02231703303603d3a3006"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1NoiseSchema">
+        <dataObjectPointer dataObjectID="noises1aiw3slcvv20200616t02225220200616t02231703303603d3a3006"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1CalibrationSchema">
+        <dataObjectPointer dataObjectID="calibrations1aiw3slcvv20200616t02225220200616t02231703303603d3a3006"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1MapOverlaySchema">
+        <dataObjectPointer dataObjectID="mapoverlay"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Metadata Unit" repID="s1Level1ProductPreviewSchema">
+        <dataObjectPointer dataObjectID="productpreview"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Measurement Data Unit" repID="s1Level1MeasurementSchema" dmdID="products1aiw1slcvh20200616t02225320200616t02231803303603d3a3001Annotation noises1aiw1slcvh20200616t02225320200616t02231803303603d3a3001Annotation calibrations1aiw1slcvh20200616t02225320200616t02231803303603d3a3001Annotation ">
+        <dataObjectPointer dataObjectID="s1aiw1slcvh20200616t02225320200616t02231803303603d3a3001"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Measurement Data Unit" repID="s1Level1MeasurementSchema" dmdID="products1aiw2slcvh20200616t02225420200616t02231903303603d3a3002Annotation noises1aiw2slcvh20200616t02225420200616t02231903303603d3a3002Annotation calibrations1aiw2slcvh20200616t02225420200616t02231903303603d3a3002Annotation ">
+        <dataObjectPointer dataObjectID="s1aiw2slcvh20200616t02225420200616t02231903303603d3a3002"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Measurement Data Unit" repID="s1Level1MeasurementSchema" dmdID="products1aiw3slcvh20200616t02225220200616t02231703303603d3a3003Annotation noises1aiw3slcvh20200616t02225220200616t02231703303603d3a3003Annotation calibrations1aiw3slcvh20200616t02225220200616t02231703303603d3a3003Annotation ">
+        <dataObjectPointer dataObjectID="s1aiw3slcvh20200616t02225220200616t02231703303603d3a3003"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Measurement Data Unit" repID="s1Level1MeasurementSchema" dmdID="products1aiw1slcvv20200616t02225320200616t02231803303603d3a3004Annotation noises1aiw1slcvv20200616t02225320200616t02231803303603d3a3004Annotation calibrations1aiw1slcvv20200616t02225320200616t02231803303603d3a3004Annotation ">
+        <dataObjectPointer dataObjectID="s1aiw1slcvv20200616t02225320200616t02231803303603d3a3004"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Measurement Data Unit" repID="s1Level1MeasurementSchema" dmdID="products1aiw2slcvv20200616t02225420200616t02231903303603d3a3005Annotation noises1aiw2slcvv20200616t02225420200616t02231903303603d3a3005Annotation calibrations1aiw2slcvv20200616t02225420200616t02231903303603d3a3005Annotation ">
+        <dataObjectPointer dataObjectID="s1aiw2slcvv20200616t02225420200616t02231903303603d3a3005"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Measurement Data Unit" repID="s1Level1MeasurementSchema" dmdID="products1aiw3slcvv20200616t02225220200616t02231703303603d3a3006Annotation noises1aiw3slcvv20200616t02225220200616t02231703303603d3a3006Annotation calibrations1aiw3slcvv20200616t02225220200616t02231703303603d3a3006Annotation ">
+        <dataObjectPointer dataObjectID="s1aiw3slcvv20200616t02225220200616t02231703303603d3a3006"/>
+      </xfdu:contentUnit>
+      <xfdu:contentUnit unitType="Measurement Data Unit" repID="s1Level1QuickLookSchema">
+        <dataObjectPointer dataObjectID="quicklook"/>
+      </xfdu:contentUnit>
+    </xfdu:contentUnit>
+  </informationPackageMap>
+  <metadataSection>
+    <metadataObject ID="products1aiw1slcvh20200616t02225320200616t02231803303603d3a3001Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="products1aiw1slcvh20200616t02225320200616t02231803303603d3a3001"/>
+    </metadataObject>
+    <metadataObject ID="noises1aiw1slcvh20200616t02225320200616t02231803303603d3a3001Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="noises1aiw1slcvh20200616t02225320200616t02231803303603d3a3001"/>
+    </metadataObject>
+    <metadataObject ID="calibrations1aiw1slcvh20200616t02225320200616t02231803303603d3a3001Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="calibrations1aiw1slcvh20200616t02225320200616t02231803303603d3a3001"/>
+    </metadataObject>
+    <metadataObject ID="products1aiw2slcvh20200616t02225420200616t02231903303603d3a3002Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="products1aiw2slcvh20200616t02225420200616t02231903303603d3a3002"/>
+    </metadataObject>
+    <metadataObject ID="noises1aiw2slcvh20200616t02225420200616t02231903303603d3a3002Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="noises1aiw2slcvh20200616t02225420200616t02231903303603d3a3002"/>
+    </metadataObject>
+    <metadataObject ID="calibrations1aiw2slcvh20200616t02225420200616t02231903303603d3a3002Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="calibrations1aiw2slcvh20200616t02225420200616t02231903303603d3a3002"/>
+    </metadataObject>
+    <metadataObject ID="products1aiw3slcvh20200616t02225220200616t02231703303603d3a3003Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="products1aiw3slcvh20200616t02225220200616t02231703303603d3a3003"/>
+    </metadataObject>
+    <metadataObject ID="noises1aiw3slcvh20200616t02225220200616t02231703303603d3a3003Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="noises1aiw3slcvh20200616t02225220200616t02231703303603d3a3003"/>
+    </metadataObject>
+    <metadataObject ID="calibrations1aiw3slcvh20200616t02225220200616t02231703303603d3a3003Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="calibrations1aiw3slcvh20200616t02225220200616t02231703303603d3a3003"/>
+    </metadataObject>
+    <metadataObject ID="products1aiw1slcvv20200616t02225320200616t02231803303603d3a3004Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="products1aiw1slcvv20200616t02225320200616t02231803303603d3a3004"/>
+    </metadataObject>
+    <metadataObject ID="noises1aiw1slcvv20200616t02225320200616t02231803303603d3a3004Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="noises1aiw1slcvv20200616t02225320200616t02231803303603d3a3004"/>
+    </metadataObject>
+    <metadataObject ID="calibrations1aiw1slcvv20200616t02225320200616t02231803303603d3a3004Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="calibrations1aiw1slcvv20200616t02225320200616t02231803303603d3a3004"/>
+    </metadataObject>
+    <metadataObject ID="products1aiw2slcvv20200616t02225420200616t02231903303603d3a3005Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="products1aiw2slcvv20200616t02225420200616t02231903303603d3a3005"/>
+    </metadataObject>
+    <metadataObject ID="noises1aiw2slcvv20200616t02225420200616t02231903303603d3a3005Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="noises1aiw2slcvv20200616t02225420200616t02231903303603d3a3005"/>
+    </metadataObject>
+    <metadataObject ID="calibrations1aiw2slcvv20200616t02225420200616t02231903303603d3a3005Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="calibrations1aiw2slcvv20200616t02225420200616t02231903303603d3a3005"/>
+    </metadataObject>
+    <metadataObject ID="products1aiw3slcvv20200616t02225220200616t02231703303603d3a3006Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="products1aiw3slcvv20200616t02225220200616t02231703303603d3a3006"/>
+    </metadataObject>
+    <metadataObject ID="noises1aiw3slcvv20200616t02225220200616t02231703303603d3a3006Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="noises1aiw3slcvv20200616t02225220200616t02231703303603d3a3006"/>
+    </metadataObject>
+    <metadataObject ID="calibrations1aiw3slcvv20200616t02225220200616t02231703303603d3a3006Annotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="calibrations1aiw3slcvv20200616t02225220200616t02231703303603d3a3006"/>
+    </metadataObject>
+    <metadataObject ID="mapoverlayAnnotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="mapoverlay"/>
+    </metadataObject>
+    <metadataObject ID="productpreviewAnnotation" classification="DESCRIPTION" category="DMD">
+      <dataObjectPointer dataObjectID="productpreview"/>
+    </metadataObject>
+    <metadataObject ID="processing" classification="PROVENANCE" category="PDI">
+      <metadataWrap mimeType="text/xml" vocabularyName="SAFE" textInfo="Processing">
+        <xmlData>
+          <safe:processing name="SLC Post Processing" start="2020-06-16T06:02:43.311726" stop="2020-06-16T06:11:26.000000">
+            <safe:facility country="Germany" name="Copernicus S1 Core Ground Segment - DPA" organisation="ESA" site="DLR-Oberpfaffenhofen">
+              <safe:software name="Sentinel-1 IPF" version="003.20"/>
+            </safe:facility>
+            <safe:resource name="S1A_IW_SL1__1_DV_20200616T022251_20200616T022324_033036_03D3A3_F2C2.SAFE" role="Level-1 Intermediate SLC Product">
+              <processing name="SLC Processing" start="2020-06-16T06:04:49.000000" stop="2020-06-16T06:10:13.000000" xmlns="http://www.esa.int/safe/sentinel-1.0">
+                <facility country="Germany" name="Copernicus S1 Core Ground Segment - DPA" organisation="ESA" site="DLR-Oberpfaffenhofen">
+                  <software name="Sentinel-1 IPF" version="003.20"/>
+                </facility>
+                <resource name="/data/localWD/647109670/S1A_AUX_PP1_V20171017T080000_G20200512T125711.SAFE" role="AUX_PP1"/>
+                <resource name="/data/localWD/647109670/S1A_AUX_CAL_V20171017T080000_G20190731T120030.SAFE" role="AUX_CAL"/>
+                <resource name="/data/localWD/647109670/S1A_AUX_INS_V20171017T080000_G20180313T104658.SAFE" role="AUX_INS"/>
+                <resource name="/data/localWD/647109670/S1A_OPER_AUX_RESORB_OPOD_20200616T050706_V20200616T000230_20200616T032000.EOF" role="AUX_RES"/>
+                <resource name="/data/localWD/647109670/S1A_IW_RAW__0SDV_20200616T022250_20200616T022322_033036_03D3A3_1670.SAFE" role="Level-0 Product">
+                  <processing xmlns="http://www.esa.int/safe/sentinel-1.0" name="Generation of Sentinel-1 L0 SAR Product, dual polarisation" start="2020-06-16T05:08:49.071820" stop="2020-06-16T05:08:49.178999">
+                    <facility country="Germany" name="DPA_" organisation="ESA" site="DLR-Oberpfaffenhofen">
+                      <software name="" version=""/>
+                    </facility>
+                    <resource name="S-1 Core PDGS S-1 Level-0 Product Format Specifications S1PD.SP.00110.ASTR" role="Applicable Document"/>
+                    <resource name="Sentinel-1 SAR Space Packet Protocol Data Unit S1-IF-ASD-PL-0007" role="Applicable Document" version="13.0"/>
+                    <resource name="Unknown" role="Raw Data">
+                      <processing xmlns="http://www.esa.int/safe/sentinel-1.0" name="Generation of Sentinel-1 SAR Slice L0 product single polarisation" start="2020-06-16T05:07:08.230526" stop="2020-06-16T05:07:09.043807">
+                        <resource name="S-1 Core PDGS S-1 Level-0 Product Format Specifications S1PD.SP.00110.ASTR" role="Applicable Document">
+                           </resource>
+                        <resource name="Sentinel-1 SAR Space Packet Protocol Data Unit S1-IF-ASD-PL-0007" version="13.0" role="Applicable Document">
+                           </resource>
+                        <resource name="Downlinked Stream" role="Raw Data">
+                          <processing xmlns="http://www.esa.int/safe/sentinel-1.0" name="Raw Data Downlink Channel1 1" start="2020-06-16T04:15:04.353953" stop="2020-06-16T04:15:10.905946">
+                              </processing>
+                        </resource>
+                      </processing>
+                    </resource>
+                    <resource name="Unknown" role="Raw Data">
+                      <processing xmlns="http://www.esa.int/safe/sentinel-1.0" name="Generation of Sentinel-1 SAR Slice L0 product single polarisation" start="2020-06-16T05:08:32.780995" stop="2020-06-16T05:08:33.804938">
+                        <resource name="S-1 Core PDGS S-1 Level-0 Product Format Specifications S1PD.SP.00110.ASTR" role="Applicable Document">
+                           </resource>
+                        <resource name="Sentinel-1 SAR Space Packet Protocol Data Unit S1-IF-ASD-PL-0007" version="13.0" role="Applicable Document">
+                           </resource>
+                        <resource name="Downlinked Stream" role="Raw Data">
+                          <processing xmlns="http://www.esa.int/safe/sentinel-1.0" name="Raw Data Downlink Channel2 2" start="2020-06-16T04:14:56.855664" stop="2020-06-16T04:15:17.259470">
+                              </processing>
+                        </resource>
+                      </processing>
+                    </resource>
+                  </processing>
+                </resource>
+                <resource name="Sentinel-1 Product Definition (S1-RS-MDA-52-7440) release 2/7" role="product definition"/>
+                <resource name="Sentinel-1 Product Specification (S1-RS-MDA-52-7441) release 3/6" role="product specification"/>
+              </processing>
+            </safe:resource>
+          </safe:processing>
+        </xmlData>
+      </metadataWrap>
+    </metadataObject>
+    <metadataObject ID="platform" classification="DESCRIPTION" category="DMD">
+      <metadataWrap mimeType="text/xml" vocabularyName="SAFE" textInfo="Platform Description">
+        <xmlData>
+          <safe:platform>
+            <safe:nssdcIdentifier>2014-016A</safe:nssdcIdentifier>
+            <safe:familyName>SENTINEL-1</safe:familyName>
+            <safe:number>A</safe:number>
+            <safe:instrument>
+              <safe:familyName abbreviation="SAR">Synthetic Aperture Radar</safe:familyName>
+              <safe:extension>
+                <s1sarl1:instrumentMode>
+                  <s1sarl1:mode>IW</s1sarl1:mode>
+                  <s1sarl1:swath>IW1</s1sarl1:swath>
+                  <s1sarl1:swath>IW2</s1sarl1:swath>
+                  <s1sarl1:swath>IW3</s1sarl1:swath>
+                </s1sarl1:instrumentMode>
+              </safe:extension>
+            </safe:instrument>
+          </safe:platform>
+        </xmlData>
+      </metadataWrap>
+    </metadataObject>
+    <metadataObject ID="measurementOrbitReference" classification="DESCRIPTION" category="DMD">
+      <metadataWrap mimeType="text/xml" vocabularyName="SAFE" textInfo="Orbit Reference">
+        <xmlData>
+          <safe:orbitReference>
+            <safe:orbitNumber type="start">33036</safe:orbitNumber>
+            <safe:orbitNumber type="stop">33036</safe:orbitNumber>
+            <safe:relativeOrbitNumber type="start">64</safe:relativeOrbitNumber>
+            <safe:relativeOrbitNumber type="stop">64</safe:relativeOrbitNumber>
+            <safe:cycleNumber>203</safe:cycleNumber>
+            <safe:phaseIdentifier>1</safe:phaseIdentifier>
+            <safe:extension>
+              <s1:orbitProperties>
+                <s1:pass>DESCENDING</s1:pass>
+                <s1:ascendingNodeTime>2020-06-16T01:41:20.310851</s1:ascendingNodeTime>
+              </s1:orbitProperties>
+            </safe:extension>
+          </safe:orbitReference>
+        </xmlData>
+      </metadataWrap>
+    </metadataObject>
+    <metadataObject ID="generalProductInformation" classification="DESCRIPTION" category="DMD">
+      <metadataWrap mimeType="text/xml" vocabularyName="SAFE" textInfo="General Product Information">
+        <xmlData>
+          <s1sarl1:standAloneProductInformation>
+            <s1sarl1:instrumentConfigurationID>6</s1sarl1:instrumentConfigurationID>
+            <s1sarl1:missionDataTakeID>250787</s1sarl1:missionDataTakeID>
+            <s1sarl1:transmitterReceiverPolarisation>VV</s1sarl1:transmitterReceiverPolarisation>
+            <s1sarl1:transmitterReceiverPolarisation>VH</s1sarl1:transmitterReceiverPolarisation>
+            <s1sarl1:productClass>S</s1sarl1:productClass>
+            <s1sarl1:productClassDescription>SAR Standard L1 Product</s1sarl1:productClassDescription>
+            <s1sarl1:productComposition>Slice</s1sarl1:productComposition>
+            <s1sarl1:productType>SLC</s1sarl1:productType>
+            <s1sarl1:productTimelinessCategory>Fast-24h</s1sarl1:productTimelinessCategory>
+            <s1sarl1:sliceProductFlag>true</s1sarl1:sliceProductFlag>
+            <s1sarl1:segmentStartTime>2020-06-16T02:18:15.341240</s1sarl1:segmentStartTime>
+            <s1sarl1:sliceNumber>12</s1sarl1:sliceNumber>
+            <s1sarl1:totalSlices>15</s1sarl1:totalSlices>
+          </s1sarl1:standAloneProductInformation>
+        </xmlData>
+      </metadataWrap>
+    </metadataObject>
+    <metadataObject ID="acquisitionPeriod" classification="DESCRIPTION" category="DMD">
+      <metadataWrap mimeType="text/xml" vocabularyName="SAFE" textInfo="Acquisition Period">
+        <xmlData>
+          <safe:acquisitionPeriod>
+            <safe:startTime>2020-06-16T02:22:52.719197</safe:startTime>
+            <safe:stopTime>2020-06-16T02:23:19.694262</safe:stopTime>
+            <safe:extension>
+              <s1:timeANX>
+                <s1:startTimeANX>2.492408e+06</s1:startTimeANX>
+                <s1:stopTimeANX>2.519384e+06</s1:stopTimeANX>
+              </s1:timeANX>
+            </safe:extension>
+          </safe:acquisitionPeriod>
+        </xmlData>
+      </metadataWrap>
+    </metadataObject>
+    <metadataObject ID="measurementFrameSet" classification="DESCRIPTION" category="DMD">
+      <metadataWrap mimeType="text/xml" vocabularyName="SAFE" textInfo="Frame Set">
+        <xmlData>
+          <safe:frameSet>
+            <safe:frame>
+              <safe:footPrint srsName="http://www.opengis.net/gml/srs/epsg.xml#4326">
+                <gml:coordinates>27.187984,54.889427 27.599964,52.363209 29.224113,52.679935 28.814869,55.246681</gml:coordinates>
+              </safe:footPrint>
+            </safe:frame>
+          </safe:frameSet>
+        </xmlData>
+      </metadataWrap>
+    </metadataObject>
+    <metadataObject ID="s1Level1ProductSchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="XML Schema" locatorType="URL" href="./support/s1-level-1-product.xsd"/>
+    </metadataObject>
+    <metadataObject ID="s1Level1NoiseSchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="XML Schema" locatorType="URL" href="./support/s1-level-1-noise.xsd"/>
+    </metadataObject>
+    <metadataObject ID="s1Level1CalibrationSchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="XML Schema" locatorType="URL" href="./support/s1-level-1-calibration.xsd"/>
+    </metadataObject>
+    <metadataObject ID="s1ObjectTypesSchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="XML Schema" locatorType="URL" href="./support/s1-object-types.xsd"/>
+    </metadataObject>
+    <metadataObject ID="s1Level1MeasurementSchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="SDF" locatorType="URL" href="./support/s1-level-1-measurement.xsd"/>
+    </metadataObject>
+    <metadataObject ID="s1Level1ProductPreviewSchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="XML Schema" locatorType="URL" href="./support/s1-product-preview.xsd"/>
+    </metadataObject>
+    <metadataObject ID="s1Level1QuickLookSchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="XML Schema" locatorType="URL" href="./support/s1-level-1-quicklook.xsd"/>
+    </metadataObject>
+    <metadataObject ID="s1Level1MapOverlaySchema" classification="SYNTAX" category="REP">
+      <metadataReference mimeType="text/xml" vocabularyName="XML Schema" locatorType="URL" href="./support/s1-map-overlay.xsd"/>
+    </metadataObject>
+  </metadataSection>
+  <dataObjectSection>
+    <dataObject ID="products1aiw1slcvh20200616t02225320200616t02231803303603d3a3001" repID="s1Level1ProductSchema">
+      <byteStream mimeType="text/xml" size="879809">
+        <fileLocation locatorType="URL" href="./annotation/s1a-iw1-slc-vh-20200616t022253-20200616t022318-033036-03d3a3-001.xml"/>
+        <checksum checksumName="MD5">b3f527a7717fa2555029dbd8c62e7a8e</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="noises1aiw1slcvh20200616t02225320200616t02231803303603d3a3001" repID="s1Level1NoiseSchema">
+      <byteStream mimeType="text/xml" size="127589">
+        <fileLocation locatorType="URL" href="./annotation/calibration/noise-s1a-iw1-slc-vh-20200616t022253-20200616t022318-033036-03d3a3-001.xml"/>
+        <checksum checksumName="MD5">fed96394e1a602be27f95b7a8ffaea2f</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="calibrations1aiw1slcvh20200616t02225320200616t02231803303603d3a3001" repID="s1Level1CalibrationSchema">
+      <byteStream mimeType="text/xml" size="909982">
+        <fileLocation locatorType="URL" href="./annotation/calibration/calibration-s1a-iw1-slc-vh-20200616t022253-20200616t022318-033036-03d3a3-001.xml"/>
+        <checksum checksumName="MD5">4c5c4182bfa9f69ae569fc3ada730b57</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="products1aiw2slcvh20200616t02225420200616t02231903303603d3a3002" repID="s1Level1ProductSchema">
+      <byteStream mimeType="text/xml" size="872199">
+        <fileLocation locatorType="URL" href="./annotation/s1a-iw2-slc-vh-20200616t022254-20200616t022319-033036-03d3a3-002.xml"/>
+        <checksum checksumName="MD5">a86e8763bd00a4be607779e3ddf1a59d</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="noises1aiw2slcvh20200616t02225420200616t02231903303603d3a3002" repID="s1Level1NoiseSchema">
+      <byteStream mimeType="text/xml" size="144672">
+        <fileLocation locatorType="URL" href="./annotation/calibration/noise-s1a-iw2-slc-vh-20200616t022254-20200616t022319-033036-03d3a3-002.xml"/>
+        <checksum checksumName="MD5">a87cebcbe5a5690c32e2547d8f371291</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="calibrations1aiw2slcvh20200616t02225420200616t02231903303603d3a3002" repID="s1Level1CalibrationSchema">
+      <byteStream mimeType="text/xml" size="1074818">
+        <fileLocation locatorType="URL" href="./annotation/calibration/calibration-s1a-iw2-slc-vh-20200616t022254-20200616t022319-033036-03d3a3-002.xml"/>
+        <checksum checksumName="MD5">5f409734af11d49428f7f5c6e5d98a5a</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="products1aiw3slcvh20200616t02225220200616t02231703303603d3a3003" repID="s1Level1ProductSchema">
+      <byteStream mimeType="text/xml" size="786532">
+        <fileLocation locatorType="URL" href="./annotation/s1a-iw3-slc-vh-20200616t022252-20200616t022317-033036-03d3a3-003.xml"/>
+        <checksum checksumName="MD5">39d0e6c2e1fd4dc7644a868bf7c80a99</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="noises1aiw3slcvh20200616t02225220200616t02231703303603d3a3003" repID="s1Level1NoiseSchema">
+      <byteStream mimeType="text/xml" size="142370">
+        <fileLocation locatorType="URL" href="./annotation/calibration/noise-s1a-iw3-slc-vh-20200616t022252-20200616t022317-033036-03d3a3-003.xml"/>
+        <checksum checksumName="MD5">40252af8902342a53eaf09d9a39ddb32</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="calibrations1aiw3slcvh20200616t02225220200616t02231703303603d3a3003" repID="s1Level1CalibrationSchema">
+      <byteStream mimeType="text/xml" size="1037813">
+        <fileLocation locatorType="URL" href="./annotation/calibration/calibration-s1a-iw3-slc-vh-20200616t022252-20200616t022317-033036-03d3a3-003.xml"/>
+        <checksum checksumName="MD5">9fc29e7f1584a5c91ca08e9ccfbae4f4</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="products1aiw1slcvv20200616t02225320200616t02231803303603d3a3004" repID="s1Level1ProductSchema">
+      <byteStream mimeType="text/xml" size="879866">
+        <fileLocation locatorType="URL" href="./annotation/s1a-iw1-slc-vv-20200616t022253-20200616t022318-033036-03d3a3-004.xml"/>
+        <checksum checksumName="MD5">24b9e23dcf6862f3234ecef623d94ef7</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="noises1aiw1slcvv20200616t02225320200616t02231803303603d3a3004" repID="s1Level1NoiseSchema">
+      <byteStream mimeType="text/xml" size="127589">
+        <fileLocation locatorType="URL" href="./annotation/calibration/noise-s1a-iw1-slc-vv-20200616t022253-20200616t022318-033036-03d3a3-004.xml"/>
+        <checksum checksumName="MD5">da9f43f558ba17afd047c05f04645942</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="calibrations1aiw1slcvv20200616t02225320200616t02231803303603d3a3004" repID="s1Level1CalibrationSchema">
+      <byteStream mimeType="text/xml" size="909982">
+        <fileLocation locatorType="URL" href="./annotation/calibration/calibration-s1a-iw1-slc-vv-20200616t022253-20200616t022318-033036-03d3a3-004.xml"/>
+        <checksum checksumName="MD5">dc35398e28eceb0b4980c80909ef6ccc</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="products1aiw2slcvv20200616t02225420200616t02231903303603d3a3005" repID="s1Level1ProductSchema">
+      <byteStream mimeType="text/xml" size="872166">
+        <fileLocation locatorType="URL" href="./annotation/s1a-iw2-slc-vv-20200616t022254-20200616t022319-033036-03d3a3-005.xml"/>
+        <checksum checksumName="MD5">3320d8379f2b8e85792bc329d1c38311</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="noises1aiw2slcvv20200616t02225420200616t02231903303603d3a3005" repID="s1Level1NoiseSchema">
+      <byteStream mimeType="text/xml" size="144672">
+        <fileLocation locatorType="URL" href="./annotation/calibration/noise-s1a-iw2-slc-vv-20200616t022254-20200616t022319-033036-03d3a3-005.xml"/>
+        <checksum checksumName="MD5">0bfee29678ce5b54420a367a051aec87</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="calibrations1aiw2slcvv20200616t02225420200616t02231903303603d3a3005" repID="s1Level1CalibrationSchema">
+      <byteStream mimeType="text/xml" size="1074818">
+        <fileLocation locatorType="URL" href="./annotation/calibration/calibration-s1a-iw2-slc-vv-20200616t022254-20200616t022319-033036-03d3a3-005.xml"/>
+        <checksum checksumName="MD5">18d82d43e9bf67344e1b3b02cbd3d5a8</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="products1aiw3slcvv20200616t02225220200616t02231703303603d3a3006" repID="s1Level1ProductSchema">
+      <byteStream mimeType="text/xml" size="786534">
+        <fileLocation locatorType="URL" href="./annotation/s1a-iw3-slc-vv-20200616t022252-20200616t022317-033036-03d3a3-006.xml"/>
+        <checksum checksumName="MD5">4fddcb717687bc468e48247966ef5b33</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="noises1aiw3slcvv20200616t02225220200616t02231703303603d3a3006" repID="s1Level1NoiseSchema">
+      <byteStream mimeType="text/xml" size="142370">
+        <fileLocation locatorType="URL" href="./annotation/calibration/noise-s1a-iw3-slc-vv-20200616t022252-20200616t022317-033036-03d3a3-006.xml"/>
+        <checksum checksumName="MD5">5b857a207f641fff8f6c9ac89e05d3aa</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="calibrations1aiw3slcvv20200616t02225220200616t02231703303603d3a3006" repID="s1Level1CalibrationSchema">
+      <byteStream mimeType="text/xml" size="1037813">
+        <fileLocation locatorType="URL" href="./annotation/calibration/calibration-s1a-iw3-slc-vv-20200616t022252-20200616t022317-033036-03d3a3-006.xml"/>
+        <checksum checksumName="MD5">b87eee2688d0919ef4781372f4520365</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="mapoverlay" repID="s1Level1MapOverlaySchema">
+      <byteStream mimeType="text/xml" size="1018">
+        <fileLocation locatorType="URL" href="./preview/map-overlay.kml"/>
+        <checksum checksumName="MD5">2730322e88b4d63303175e6a6f84d812</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="productpreview" repID="s1Level1ProductPreviewSchema">
+      <byteStream mimeType="text/xml" size="6264">
+        <fileLocation locatorType="URL" href="./preview/product-preview.html"/>
+        <checksum checksumName="MD5">626bd907a65e5c9804a72305e523f275</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="s1aiw1slcvh20200616t02225320200616t02231803303603d3a3001" repID="s1Level1MeasurementSchema">
+      <byteStream mimeType="application/octet-stream" size="1161781760">
+        <fileLocation locatorType="URL" href="./measurement/s1a-iw1-slc-vh-20200616t022253-20200616t022318-033036-03d3a3-001.tiff"/>
+        <checksum checksumName="MD5">83b5d59e66df7bdbbeed9590eb349789</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="s1aiw2slcvh20200616t02225420200616t02231903303603d3a3002" repID="s1Level1MeasurementSchema">
+      <byteStream mimeType="application/octet-stream" size="1383581576">
+        <fileLocation locatorType="URL" href="./measurement/s1a-iw2-slc-vh-20200616t022254-20200616t022319-033036-03d3a3-002.tiff"/>
+        <checksum checksumName="MD5">b03b7e251a6ebd78caa996828a2fa96d</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="s1aiw3slcvh20200616t02225220200616t02231703303603d3a3003" repID="s1Level1MeasurementSchema">
+      <byteStream mimeType="application/octet-stream" size="1340604056">
+        <fileLocation locatorType="URL" href="./measurement/s1a-iw3-slc-vh-20200616t022252-20200616t022317-033036-03d3a3-003.tiff"/>
+        <checksum checksumName="MD5">bdea119f0ff56a9081aabe0388436971</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="s1aiw1slcvv20200616t02225320200616t02231803303603d3a3004" repID="s1Level1MeasurementSchema">
+      <byteStream mimeType="application/octet-stream" size="1161781760">
+        <fileLocation locatorType="URL" href="./measurement/s1a-iw1-slc-vv-20200616t022253-20200616t022318-033036-03d3a3-004.tiff"/>
+        <checksum checksumName="MD5">2d1bc46f30112919438c1713c24788e3</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="s1aiw2slcvv20200616t02225420200616t02231903303603d3a3005" repID="s1Level1MeasurementSchema">
+      <byteStream mimeType="application/octet-stream" size="1383581576">
+        <fileLocation locatorType="URL" href="./measurement/s1a-iw2-slc-vv-20200616t022254-20200616t022319-033036-03d3a3-005.tiff"/>
+        <checksum checksumName="MD5">341a2a0061057c7a60de8a79ac71c6da</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="s1aiw3slcvv20200616t02225220200616t02231703303603d3a3006" repID="s1Level1MeasurementSchema">
+      <byteStream mimeType="application/octet-stream" size="1340604056">
+        <fileLocation locatorType="URL" href="./measurement/s1a-iw3-slc-vv-20200616t022252-20200616t022317-033036-03d3a3-006.tiff"/>
+        <checksum checksumName="MD5">9cafec4a99e48a03a93caa1c651bdd85</checksum>
+      </byteStream>
+    </dataObject>
+    <dataObject ID="quicklook" repID="s1Level1QuickLookSchema">
+      <byteStream mimeType="application/octet-stream" size="6319676">
+        <fileLocation locatorType="URL" href="./preview/quick-look.png"/>
+        <checksum checksumName="MD5">93223b6995f5deb8176b0b54a4524bf6</checksum>
+      </byteStream>
+    </dataObject>
+  </dataObjectSection>
+</xfdu:XFDU>

--- a/tests/test_localize_burst.py
+++ b/tests/test_localize_burst.py
@@ -1,0 +1,116 @@
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import numpy as np
+import pytest
+import requests
+from shapely import geometry
+
+from isce2_topsapp import localize_burst
+
+URL_BASE = 'https://datapool.asf.alaska.edu/SLC'
+
+
+@pytest.fixture()
+def ref_metadata():
+    metadata_path = Path(__file__).parent.absolute() / 'test_data' / 'ref_metadata.xml'
+    xml = ET.parse(metadata_path).getroot()
+    return xml
+
+
+@pytest.fixture()
+def ref_manifest():
+    metadata_path = Path(__file__).parent.absolute() / 'test_data' / 'ref_manifest.xml'
+    xml = ET.parse(metadata_path).getroot()
+    return xml
+
+
+@pytest.fixture()
+def ref_burst(ref_metadata, ref_manifest):
+    safe_url = f'{URL_BASE}/SA/S1A_IW_SLC__1SDV_20200604T022251_20200604T022318_032861_03CE65_7C85.zip'
+    params = localize_burst.BurstParams(safe_url, 5, 8)
+    burst = localize_burst.BurstMetadata(ref_metadata, ref_manifest, params)
+    return burst
+
+
+@pytest.fixture()
+def sec_metadata():
+    metadata_path = Path(__file__).parent.absolute() / 'test_data' / 'sec_metadata.xml'
+    xml = ET.parse(metadata_path).getroot()
+    return xml
+
+
+@pytest.fixture()
+def sec_manifest():
+    metadata_path = Path(__file__).parent.absolute() / 'test_data' / 'sec_manifest.xml'
+    xml = ET.parse(metadata_path).getroot()
+    return xml
+
+
+@pytest.fixture()
+def sec_burst(sec_metadata, sec_manifest):
+    safe_url = f'{URL_BASE}/SA/S1A_IW_SLC__1SDV_20200616T022252_20200616T022319_033036_03D3A3_5D11.zip'
+    params = localize_burst.BurstParams(safe_url, 5, 8)
+    burst = localize_burst.BurstMetadata(sec_metadata, sec_manifest, params)
+    return burst
+
+
+def test_create_gcp_df(ref_burst):
+    n_bursts = int(ref_burst.annotation.findall('.//burstList')[0].attrib['count'])
+    lines_per_burst = int(ref_burst.annotation.findtext('.//{*}linesPerBurst'))
+
+    gcp_df = ref_burst.create_gcp_df()
+    assert np.all(gcp_df.columns == ['line', 'pixel', 'latitude', 'longitude', 'height'])
+    assert gcp_df.line.min() == 0
+    assert gcp_df.line.max() == (n_bursts * lines_per_burst) - 1
+
+
+def test_create_geometry(ref_burst):
+    burst_number = 8
+    real_box = (53.17067752190982, 27.51599975559423, 54.13361604403157, 27.83356711546872)
+
+    gcp_df = ref_burst.create_gcp_df()
+    box = ref_burst.create_geometry(gcp_df)[1]
+    assert ref_burst.burst_number == burst_number
+    assert np.all([np.isclose(a, b) for a, b in zip(box, real_box)])
+
+
+@pytest.mark.parametrize(
+    'pattern',
+    (
+        '*SAFE',
+        '*SAFE/annotation/*xml',
+        '*SAFE/annotation/calibration/calibration*xml',
+        '*SAFE/annotation/calibration/noise*xml',
+    ),
+)
+def test_spoof_safe(ref_burst, tmpdir, mocker, pattern):
+    tmpdir = Path(tmpdir)
+    mocker.patch('isce2_topsapp.localize_burst.download_geotiff', return_value='')
+    localize_burst.spoof_safe(requests.Session(), ref_burst, tmpdir)
+    assert len(list(tmpdir.glob(pattern))) == 1
+
+
+def test_get_region_of_interest(ref_burst, sec_burst, ref_metadata, ref_manifest):
+    safe_url = f'{URL_BASE}/SA/S1A_IW_SLC__1SDV_20200616T022252_20200616T022319_033036_03D3A3_5D11.zip'
+    burst_7 = localize_burst.BurstMetadata(
+        ref_metadata,
+        ref_manifest,
+        localize_burst.BurstParams(safe_url, 5, 7),
+    )
+    burst_8 = localize_burst.BurstMetadata(
+        ref_metadata,
+        ref_manifest,
+        localize_burst.BurstParams(safe_url, 5, 8),
+    )
+    burst_9 = localize_burst.BurstMetadata(
+        ref_metadata,
+        ref_manifest,
+        localize_burst.BurstParams(safe_url, 5, 9),
+    )
+    asc = ref_burst.orbit_direction == 'ascending'
+    roi = geometry.box(*localize_burst.get_region_of_interest(ref_burst.footprint, sec_burst.footprint, asc))
+
+    assert roi.intersects(geometry.box(*burst_8.footprint.bounds))
+    assert not roi.intersects(geometry.box(*burst_7.footprint.bounds))
+    assert not roi.intersects(geometry.box(*burst_9.footprint.bounds))

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,2 @@
+[flake8]
+application_import_names = isce2_topsapp


### PR DESCRIPTION
Unfortunately, this represents all the dem changes since May 2022, the burst prototype from Forrest and Joe, and all the things in between (aux cal url changes). I hope things don't break too much.

We need to really have hyp3 testing integrated. That would be a valuable and possibly fun hackathon.

Currently, we don't have suitable integration tests outside of manual inspection of the GUNWs with ARIA-Tools, which are important to ensure these products can be used for time-series analysis. I ran the dev-branch via in hyp3 using the job type`INSAR_ISCE_TEST` over Hawaii track 124, downloaded products, and was able successfully run `ariaTSsetup.py -f 'products/*.nc'`. This is of course grossly over simplified description, but I am sufficiently confident processing can continue.

I put a `minor` label - but maybe it is major with the burst prototype. Anyways, the dataset version shouldn't change.

Actually, I am not sure how to make sure the changelog is in sync with the actions. That is probably worth a check @jhkennedy 