### PR TITLE
Use just the frame-id for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ isce2_topsapp --reference-scenes S1A_IW_SLC__1SDV_20230113T135954_20230113T14002
               --secondary-scenes S1A_IW_SLC__1SDV_20221208T135956_20221208T140023_046241_05897B_86FA \
                                  S1A_IW_SLC__1SDV_20221208T140021_20221208T140048_046241_05897B_8EBC \
                                  S1A_IW_SLC__1SDV_20221208T140046_20221208T140113_046241_05897B_28A9 \
-              --region-of-interest -120.902529 35.257855 -117.740922 37.231403 \
               --frame-id 19965 \
               > topsapp_img_f19965.out 2> topsapp_img_f19965.err
 ```
@@ -84,7 +83,6 @@ isce2_topsapp --reference-scenes S1A_IW_SLC__1SDV_20230113T140019_20230113T14004
                                  S1A_IW_SLC__1SDV_20230113T140044_20230113T140111_046766_059B44_FBB8 \
               --secondary-scenes S1A_IW_SLC__1SDV_20221208T140021_20221208T140048_046241_05897B_8EBC \
                                  S1A_IW_SLC__1SDV_20221208T140046_20221208T140113_046241_05897B_28A9 \
-              --region-of-interest -121.167298 33.929114 -118.055825 35.904876 \
               --frame-id 19966 \
               > topsapp_img_f19966.out 2> topsapp_img_f19966.err
 ```

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -24,7 +24,8 @@ def localize_data(reference_scenes: list,
 
     Can be used to run workflow without redownloading data (except DEM).
 
-    region_of_interest is in xmin, ymin, xmax, ymax format (epsg: 4326)
+    Fixed frames are found here: s3://s1-gunw-frames/s1_frames.geojson
+    And discussed in the readme.
     """
     out_slc = download_slcs(reference_scenes,
                             secondary_scenes,

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -18,7 +18,7 @@ from isce2_topsapp.json_encoder import MetadataEncoder
 
 def localize_data(reference_scenes: list,
                   secondary_scenes: list,
-                  region_of_interest: list,
+                  frame_id: int = -1,
                   dry_run: bool = False) -> dict:
     """The dry-run prevents gets necessary metadata from SLCs and orbits.
 
@@ -28,7 +28,7 @@ def localize_data(reference_scenes: list,
     """
     out_slc = download_slcs(reference_scenes,
                             secondary_scenes,
-                            region_of_interest=region_of_interest,
+                            frame_id=frame_id,
                             dry_run=dry_run)
 
     out_orbits = download_orbits(reference_scenes,
@@ -91,8 +91,6 @@ def gunw_slc():
     parser.add_argument('--dry-run', action='store_true')
     parser.add_argument('--reference-scenes', type=str.split, nargs='+', required=True)
     parser.add_argument('--secondary-scenes', type=str.split, nargs='+', required=True)
-    parser.add_argument('--region-of-interest', type=float, nargs=4, default=None,
-                        help='xmin ymin xmax ymax in epgs:4326', required=False)
     parser.add_argument('--estimate-ionosphere-delay', type=bool, default=False)
     parser.add_argument('--frame-id', type=int, default=-1)
     parser.add_argument('--do-esd', type=bool, default=False)
@@ -113,12 +111,8 @@ def gunw_slc():
     loc_data = localize_data(args.reference_scenes,
                              args.secondary_scenes,
                              dry_run=args.dry_run,
-                             region_of_interest=args.region_of_interest)
-    # TODO: either remove this or ensure it is passed to CMR metadata
+                             frame_id=args.frame_id)
     loc_data['frame_id'] = args.frame_id
-    if args.frame_id >= 0:
-        if not args.region_of_interest:
-            raise RuntimeError('If you specify frame_id, then must specify region_of_interest')
 
     # Allows for easier re-inspection of processing, packaging, and delivery
     # after job completes

--- a/isce2_topsapp/localize_slc.py
+++ b/isce2_topsapp/localize_slc.py
@@ -44,6 +44,10 @@ def check_geometry(reference_obs: list,
     connected_ref = (reference_geo.geom_type == 'Polygon')
     connected_sec = (secondary_geo.geom_type == 'Polygon')
 
+    if (not connected_sec) or (not connected_ref):
+        raise RuntimeError('Reference and/or secondary dates were not connected'
+                           ' in their coverage (multipolygons)')
+
     # Two geometries must intersect for their to be an interferogram
     intersection_geo = secondary_geo.intersection(reference_geo)
     if intersection_geo.is_empty:
@@ -60,10 +64,6 @@ def check_geometry(reference_obs: list,
                                'area (i.e. ref and sec overlap)')
         region_of_interest_geo = box(*df_frame.total_bounds)
         intersection_geo = region_of_interest_geo
-
-    if (not connected_sec) or (not connected_ref):
-        raise RuntimeError('Reference and/or secondary dates were not connected'
-                           ' in their coverage (multipolygons)')
     return intersection_geo
 
 


### PR DESCRIPTION
Per @asjohnston-asf suggestion, utilize just the frame-id to submit jobs.

I am reading directly from an s3 bucket. We could also add the dependency from [s1-frame-enumerator](https://github.com/ACCESS-Cloud-Based-InSAR/s1-frame-enumerator) and read it from that.