### PR TITLE
fix boolean arguments in GUNW entrypoints

### DIFF
--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -82,6 +82,9 @@ def ensure_earthdata_credentials(username: Optional[str] = None, password: Optio
         )
 
 
+def string_is_true(s: str) -> bool:
+    return s.lower() == 'true'
+
 def gunw_slc():
     parser = ArgumentParser()
     parser.add_argument('--username')
@@ -93,10 +96,10 @@ def gunw_slc():
     parser.add_argument('--secondary-scenes', type=str.split, nargs='+', required=True)
     parser.add_argument('--region-of-interest', type=float, nargs=4, default=None,
                         help='xmin ymin xmax ymax in epgs:4326', required=False)
-    parser.add_argument('--estimate-ionosphere-delay', type=bool, default=False)
+    parser.add_argument('--estimate-ionosphere-delay', type=string_is_true, default=False)
     parser.add_argument('--frame-id', type=int, default=-1)
-    parser.add_argument('--do-esd', type=bool, default=False)
-    parser.add_argument('--esd-coherence-threshold', type=float, default=-1)
+    parser.add_argument('--do-esd', type=string_is_true, default=False)
+    parser.add_argument('--esd-coherence-threshold', type=float, default=-1.)
     args = parser.parse_args()
 
     do_esd_arg = (args.esd_coherence_threshold != -1) == args.do_esd
@@ -133,7 +136,7 @@ def gunw_slc():
                        # Region of interest is passed to topsapp via 'extent' key in loc_data
                        extent=loc_data['extent'],
                        estimate_ionosphere_delay=args.estimate_ionosphere_delay,
-                       do_esd=args.do_esd,
+                       do_esd=do_esd_arg,
                        esd_coherence_threshold=args.esd_coherence_threshold,
                        dem_for_proc=loc_data['full_res_dem_path'],
                        dem_for_geoc=loc_data['low_res_dem_path'],
@@ -177,7 +180,7 @@ def gunw_burst():
     parser.add_argument('--burst-number', type=int, required=True)
     parser.add_argument('--azimuth-looks', type=int, default=2)
     parser.add_argument('--range-looks', type=int, default=10)
-    parser.add_argument('--estimate-ionosphere-delay', type=bool, default=False)
+    parser.add_argument('--estimate-ionosphere-delay', type=string_is_true, default=False)
     args = parser.parse_args()
 
     ensure_earthdata_credentials(args.username, args.password)

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -82,8 +82,11 @@ def ensure_earthdata_credentials(username: Optional[str] = None, password: Optio
         )
 
 
-def string_is_true(s: str) -> bool:
-    return s.lower() == 'true'
+def true_false_string_argument(s: str) -> bool:
+    s = s.lower()
+    if s not in ('true', 'false'):
+        raise ValueError('Only the strings `true` or `false` (any capitalization) may be provided.')
+    return s == 'true'
 
 
 def gunw_slc():
@@ -97,9 +100,9 @@ def gunw_slc():
     parser.add_argument('--secondary-scenes', type=str.split, nargs='+', required=True)
     parser.add_argument('--region-of-interest', type=float, nargs=4, default=None,
                         help='xmin ymin xmax ymax in epgs:4326', required=False)
-    parser.add_argument('--estimate-ionosphere-delay', type=string_is_true, default=False)
+    parser.add_argument('--estimate-ionosphere-delay', type=true_false_string_argument, default=False)
     parser.add_argument('--frame-id', type=int, default=-1)
-    parser.add_argument('--do-esd', type=string_is_true, default=False)
+    parser.add_argument('--do-esd', type=true_false_string_argument, default=False)
     parser.add_argument('--esd-coherence-threshold', type=float, default=-1.)
     args = parser.parse_args()
 
@@ -181,7 +184,7 @@ def gunw_burst():
     parser.add_argument('--burst-number', type=int, required=True)
     parser.add_argument('--azimuth-looks', type=int, default=2)
     parser.add_argument('--range-looks', type=int, default=10)
-    parser.add_argument('--estimate-ionosphere-delay', type=string_is_true, default=False)
+    parser.add_argument('--estimate-ionosphere-delay', type=true_false_string_argument, default=False)
     args = parser.parse_args()
 
     ensure_earthdata_credentials(args.username, args.password)

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -85,6 +85,7 @@ def ensure_earthdata_credentials(username: Optional[str] = None, password: Optio
 def string_is_true(s: str) -> bool:
     return s.lower() == 'true'
 
+
 def gunw_slc():
     parser = ArgumentParser()
     parser.add_argument('--username')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,8 @@
+import argparse
+
 import pytest
 
-from isce2_topsapp.__main__ import ensure_earthdata_credentials
+from isce2_topsapp.__main__ import ensure_earthdata_credentials, true_false_string_argument
 
 
 def test_main_check_earthdata_credentials_prefer_netrc(tmp_path, monkeypatch):
@@ -71,3 +73,19 @@ def test_main_check_earthdata_credentials_env_variables(tmp_path, monkeypatch):
 
     ensure_earthdata_credentials(None, 'baz', host='foobar.nasa.gov')
     assert netrc.read_text() == 'machine foobar.nasa.gov login fizz password baz'
+
+
+def test_true_false_string_argument():
+    assert true_false_string_argument('true') is True
+    assert true_false_string_argument('TRUE') is True
+    assert true_false_string_argument('True') is True
+    assert true_false_string_argument('false') is False
+    assert true_false_string_argument('False') is False
+    assert true_false_string_argument('FALSE') is False
+
+    with pytest.raises(ValueError):
+        true_false_string_argument('foo')
+    with pytest.raises(ValueError):
+        true_false_string_argument('bar')
+    with pytest.raises(ValueError):
+        true_false_string_argument('')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,3 @@
-import argparse
-
 import pytest
 
 from isce2_topsapp.__main__ import ensure_earthdata_credentials, true_false_string_argument


### PR DESCRIPTION
As documented in the README, these arguments expect strings like `'True`'/`'False'`:
* `--estimate-ionosphere-delay`
* `--do-esd`

However, the argument parser uses a `bool` type for these arguments, which evaluates *any* non-empty string as `True`:

```python
>>> bool('true')
True
>>> bool('True')
True
>>> bool('False')
True
>>> bool('false')
True
>>> bool('foobar')
True
>>> bool('')
False
```

This adds a comparison function that can be used as a `type` for the argument parser and only returns true if the string `true` (any capitalization) is provided. 

```python
>>> string_is_true('true')
True
>>> string_is_true('True')
True
>>> string_is_true('False')
False
>>> string_is_true('false')
False
>>> bool('foobar')
False
>>> bool('')
False
```

in-line we the `False` default.

---

Note: Since none of these arguments have been released, I've labeled this as `bumpless`.