### PR TITLE
Update actions to use tags instead of `main`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "weekly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,13 +12,11 @@ on:
 
 jobs:
   call-version-info-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@main
-    with:
-      conda_env_name: topsapp_env
+    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.7.0
 
   call-docker-ghcr-workflow:
     needs: call-version-info-workflow
-    uses: ASFHyP3/actions/.github/workflows/reusable-docker-ghcr.yml@main
+    uses: ASFHyP3/actions/.github/workflows/reusable-docker-ghcr.yml@v0.7.0
     with:
       version_tag: ${{ needs.call-version-info-workflow.outputs.version_tag }}
       release_branch: main

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,6 +13,6 @@ on:
 
 jobs:
   call-changelog-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@main
+    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.7.0
     secrets:
       USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labeled-pr.yml
+++ b/.github/workflows/labeled-pr.yml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   call-labeled-pr-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@main
+    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@v0.7.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-release-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@main
+    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.7.0
     with:
       release_prefix: DockerizedTopsApp
       develop_branch: dev

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -4,10 +4,10 @@ on: push
 
 jobs:
   call-flake8-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-flake8.yml@main
+    uses: ASFHyP3/actions/.github/workflows/reusable-flake8.yml@v0.7.0
     with:
       local_package_names: isce2_topsapp
       excludes: isce2_topsapp/packaging_utils/
 
   call-secrets-analysis-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@main
+    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.7.0

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-bump-version-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@main
+    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.7.0
     with:
       user: access-cloud-insar-team
       email: access-cloud-insar-team@jpl.nasa.gov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
           username: ${{ secrets.EARTHDATA_USERNAME }}
           password: ${{ secrets.EARTHDATA_PASSWORD }}
 
-      - uses: mamba-org/provision-with-micromamba@main
+      - uses: mamba-org/provision-with-micromamba@v15
         with:
           environment-name: topsapp_env
           environment-file: environment.yml


### PR DESCRIPTION
Currently, the test build actions are failing because of an invalid workflow file:
![image](https://user-images.githubusercontent.com/7882693/217127625-00342e4d-081a-4a8d-9622-81cbde1c6d3c.png)

ASFHyP3/Actions switch to micromamba in v0.7.0 and no longer needs to know that conda environment name, so this parameter is no longer valid. 

This PR:
* Drops `conda_env_name` from all workflows
* pins the ASFHyP3/Actions versions
* Adds dependabot to open PRs to update action versions