### PR TITLE
Raise warning when IFG extent has at least 80% water

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.3]
-
 ### Added
-* Added support to compute and embed solid earth tide correction layers into GUNW products (see PR #91)
 
 ## [0.2.2]
 
@@ -19,6 +16,8 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Exposes a number of new corrections/ISCE2 processing options including: `ionosphere`, and `ESD threshold` arguments in CLI. Examples in README.
 * Exposes `frame-id` parameter for fixed frame cropping. Discussion, references, and examples in README.
 * Pins ISCE2 version to 2.6.1 and numpy / scipy to previous versions (see environment.yml) - to be amended when newest ISCE2 build is sorted out
+* Added support to compute and embed solid earth tide correction layers into GUNW products (see PR #91)
+* Raises warning if there is at least 80% of water in the IFG area using Natural Earth Land mask.
 
 ## [0.2.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### Added
-
 ## [0.2.2]
 
 ### Added
@@ -15,9 +13,19 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * CLI (and API) can switch between burst and SLC ifg generation thanks to entry point magic (see PR #73 for details)
 * Exposes a number of new corrections/ISCE2 processing options including: `ionosphere`, and `ESD threshold` arguments in CLI. Examples in README.
 * Exposes `frame-id` parameter for fixed frame cropping. Discussion, references, and examples in README.
+* Latitude aligned frames and their expected extents are added as geojson in repository as zip file.
 * Pins ISCE2 version to 2.6.1 and numpy / scipy to previous versions (see environment.yml) - to be amended when newest ISCE2 build is sorted out
 * Added support to compute and embed solid earth tide correction layers into GUNW products (see PR #91)
 * Raises warning if there is at least 80% of water in the IFG area using Natural Earth Land mask.
+
+## Fixed
+* Ensures that when Solid Earth Tide or Ionosphere is added to GUNW, that the internal version attribute is updated from '1b' to '1c'
+* Ensures that correct (i.e. enough) DEM extents are obtained for frame job submission
+* Uses dem-stitcher 2.4.0 to resolve #89 - ensures only polygonal intersection of tiles
+
+## Changed
+* Metadata `intersection_geo` is changed to `gunw_geo`.
+* Differentiates `gunw_geo` (and bounds) for DEM acquisition and `processing_geo` for ISCE2 for frame job submission.
 
 ## [0.2.1]
 

--- a/tests/test_localize_slc.py
+++ b/tests/test_localize_slc.py
@@ -1,5 +1,6 @@
-import pytest
 import warnings
+
+import pytest
 
 from isce2_topsapp.localize_slc import (check_date_order,
                                         check_flight_direction,

--- a/tests/test_localize_slc.py
+++ b/tests/test_localize_slc.py
@@ -1,4 +1,5 @@
 import pytest
+import warnings
 
 from isce2_topsapp.localize_slc import (check_date_order,
                                         check_flight_direction,
@@ -61,6 +62,24 @@ def test_bad_tracks_with_same_flight_direction():
     props = [ob.properties for ob in slc_obs]
 
     assert not check_track_numbers(props)
+
+
+def test_warnings_over_water():
+
+    # Intersection over water
+    ref_ids = ['S1B_IW_SLC__1SDV_20211210T153506_20211210T153533_029965_0393C6_D840']
+    sec_ids = ['S1A_IW_SLC__1SDV_20211122T153535_20211122T153602_040686_04D3DB_520A']
+
+    with pytest.warns(RuntimeWarning):
+        download_slcs(ref_ids, sec_ids, frame_id=-1, dry_run=True)
+
+    # Tibet (no water)
+    ref_ids = ['S1A_IW_SLC__1SDV_20170817T120001_20170817T120028_017963_01E230_A23A']
+    sec_ids = ['S1A_IW_SLC__1SSV_20160717T115946_20160717T120014_012188_012E84_F684',
+               'S1A_IW_SLC__1SSV_20160717T120012_20160717T120039_012188_012E84_4198']
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        download_slcs(ref_ids, sec_ids, frame_id=-1, dry_run=True)
 
 
 def test_bad_date_order():


### PR DESCRIPTION
ISCE2 and this plugin have weird failures when there is not enough bursts over land.

This will simply raise a warning if there is at least 80% water (using a low resolution land mask from Natural Earth packaged with geopandas).

Seeing lots of failures for SLC pairs like this one: https://search.asf.alaska.edu/#/?searchType=List%20Search&searchList=S1B_IW_SLC__1SDV_20210731T153505_20210731T153532_028040_035848_C1F8&zoom=7.017&center=31.893,40.741&resultsLoaded=true&granule=S1B_IW_SLC__1SDV_20210731T153505_20210731T153532_028040_035848_C1F8-SLC

This is warning because there are edge cases where the low resolution mask misses small island areas (e.g. Catalina, Islands, and other coastal Southern California Islands). Hopefully will make debugging failures easier.