### PR TITLE
Update Version Attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.3]
-
-### Added
-* Added support to compute and embed solid earth tide correction layers into GUNW products (see PR #91)
-
 ## [0.2.2]
 
 ### Added
@@ -19,6 +14,10 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Exposes a number of new corrections/ISCE2 processing options including: `ionosphere`, and `ESD threshold` arguments in CLI. Examples in README.
 * Exposes `frame-id` parameter for fixed frame cropping. Discussion, references, and examples in README.
 * Pins ISCE2 version to 2.6.1 and numpy / scipy to previous versions (see environment.yml) - to be amended when newest ISCE2 build is sorted out
+* Added support to compute and embed solid earth tide correction layers into GUNW products (see PR #91)
+
+## Fixed
+* Ensures that when Solid Earth Tide or Ionosphere is added to GUNW, that the internal version attribute is updated from '1b' to '1c'
 
 ## [0.2.1]
 

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -8,14 +8,13 @@ from importlib.metadata import entry_points
 from pathlib import Path
 from typing import Optional
 
-import h5py
-
 from isce2_topsapp import (BurstParams, aws, download_aux_cal, download_bursts,
                            download_dem_for_isce2, download_orbits,
-                           download_slcs, get_asf_slc_objects, get_region_of_interest,
-                           package_gunw_product, prepare_for_delivery,
-                           topsapp_processing)
+                           download_slcs, get_asf_slc_objects,
+                           get_region_of_interest, package_gunw_product,
+                           prepare_for_delivery, topsapp_processing)
 from isce2_topsapp.json_encoder import MetadataEncoder
+from isce2_topsapp.packaging import update_gunw_internal_version_attribute
 from isce2_topsapp.solid_earth_tides import update_gunw_with_solid_earth_tide
 
 
@@ -170,9 +169,9 @@ def gunw_slc():
 
     if args.compute_solid_earth_tide:
         nc_path = update_gunw_with_solid_earth_tide(nc_path)
-        # Update to 1c
-        with h5py.File(nc_path, mode='a') as file:
-            file.attrs.modify('version', '1c')
+
+    if args.compute_solid_earth_tide or additional_2d_layers:
+        update_gunw_internal_version_attribute(nc_path, new_version='1c')
 
     # Move final product to current working directory
     final_directory = prepare_for_delivery(nc_path, loc_data)

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -170,7 +170,7 @@ def gunw_slc():
     if args.compute_solid_earth_tide:
         nc_path = update_gunw_with_solid_earth_tide(nc_path)
 
-    if args.compute_solid_earth_tide or additional_2d_layers:
+    if args.compute_solid_earth_tide or args.estimate_ionosphere_delay:
         update_gunw_internal_version_attribute(nc_path, new_version='1c')
 
     # Move final product to current working directory

--- a/isce2_topsapp/packaging.py
+++ b/isce2_topsapp/packaging.py
@@ -34,6 +34,15 @@ was changed during runtime of `F`.
 """
 
 
+def update_gunw_internal_version_attribute(nc_path: Path, new_version='1c'):
+    with h5py.File(nc_path, mode='a') as file:
+        # Deleting attribute removes the type information so there is no
+        # truncation and a simple string can be written.
+        if 'version' in file.attrs:
+            del file.attrs['version']
+        file.attrs['version'] = new_version
+
+
 def get_gunw_hash_id(reference_ids: list, secondary_ids: list) -> str:
     all_ids = json.dumps([' '.join(sorted(reference_ids)),
                           ' '.join(sorted(secondary_ids))

--- a/tests/prepare-for-delivery.ipynb
+++ b/tests/prepare-for-delivery.ipynb
@@ -3,11 +3,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "forward-hollow",
+   "id": "a9077005",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2022-01-14T02:31:59.840915Z",
-     "start_time": "2022-01-14T02:31:58.339608Z"
+     "end_time": "2023-02-23T02:48:46.776007Z",
+     "start_time": "2023-02-23T02:48:46.772841Z"
     }
    },
    "outputs": [],
@@ -22,12 +22,13 @@
     "from isce2_topsapp.delivery_prep import get_dataset_schema\n",
     "import rasterio\n",
     "import matplotlib.pyplot as plt\n",
-    "import jsonschema"
+    "import jsonschema\n",
+    "from isce2_topsapp.packaging import update_gunw_internal_version_attribute"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "chief-estimate",
+   "id": "1d803cba",
    "metadata": {},
    "source": [
     "# Prepare for Delivery"
@@ -36,11 +37,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "documented-generic",
+   "id": "6e4826bf",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2022-01-14T02:32:09.036872Z",
-     "start_time": "2022-01-14T02:31:59.843097Z"
+     "end_time": "2023-02-23T02:49:14.320081Z",
+     "start_time": "2023-02-23T02:48:47.604876Z"
     }
    },
    "outputs": [],
@@ -56,11 +57,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "sensitive-labor",
+   "id": "841686cd",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2022-01-14T02:32:09.042345Z",
-     "start_time": "2022-01-14T02:32:09.038403Z"
+     "end_time": "2023-02-23T02:49:14.327580Z",
+     "start_time": "2023-02-23T02:49:14.322297Z"
     }
    },
    "outputs": [],
@@ -79,23 +80,83 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "listed-script",
+   "id": "982d838b",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2022-01-14T02:33:23.102437Z",
-     "start_time": "2022-01-14T02:32:09.044591Z"
+     "end_time": "2023-02-23T02:52:00.568443Z",
+     "start_time": "2023-02-23T02:49:14.328921Z"
     }
    },
    "outputs": [],
    "source": [
-    "final_prod_directory = prepare_for_delivery(nc_path, sample_data)\n",
+    "final_prod_directory = prepare_for_delivery(nc_path, sample_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b07ba73",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-02-23T02:52:00.584374Z",
+     "start_time": "2023-02-23T02:52:00.571171Z"
+    }
+   },
+   "outputs": [],
+   "source": [
     "paths = list(final_prod_directory.glob('*'))\n",
+    "paths = list(filter(lambda p: p.name[0] != '.', paths))\n",
     "paths"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "dirty-morocco",
+   "id": "da8c466b",
+   "metadata": {},
+   "source": [
+    "# Test Update Version"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81b12194",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-02-23T02:52:10.225364Z",
+     "start_time": "2023-02-23T02:52:10.221367Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "nc_path_packaged = [path for path in paths if path.suffix == '.nc'][0]\n",
+    "nc_path_packaged"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c863ebae",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-02-23T02:53:23.482724Z",
+     "start_time": "2023-02-23T02:53:23.474497Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import h5py\n",
+    "\n",
+    "update_gunw_internal_version_attribute(nc_path_packaged, new_version='1c')\n",
+    "\n",
+    "with h5py.File(str(nc_path_packaged)) as file:\n",
+    "    v = file.attrs['version']\n",
+    "assert(v == '1c')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6c9a53d0",
    "metadata": {},
    "source": [
     "# Validate JSON"
@@ -104,7 +165,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "martial-appeal",
+   "id": "34891199",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-01-14T02:33:23.109747Z",
@@ -121,7 +182,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "limiting-efficiency",
+   "id": "c552f750",
    "metadata": {},
    "source": [
     "# Water Mask Tests"
@@ -130,7 +191,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "daily-inflation",
+   "id": "e693897b",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-01-14T02:33:23.114503Z",
@@ -145,7 +206,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "negative-companion",
+   "id": "5a622207",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-01-14T02:33:23.135154Z",
@@ -161,7 +222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "median-defensive",
+   "id": "3996340c",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-01-14T02:35:11.474791Z",
@@ -178,7 +239,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "devoted-storm",
+   "id": "e79e76cb",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-01-14T02:35:11.949772Z",
@@ -192,7 +253,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "intermediate-baking",
+   "id": "dff5cc91",
    "metadata": {},
    "source": [
     "Get a profile over the dateline"
@@ -201,7 +262,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "false-traffic",
+   "id": "4f82ca5c",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-01-14T02:35:11.957495Z",
@@ -218,7 +279,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "coordinate-hospital",
+   "id": "406f8941",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-01-14T02:38:07.686730Z",
@@ -237,7 +298,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "demonstrated-footwear",
+   "id": "b22ecb17",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-01-14T02:38:08.098353Z",
@@ -251,7 +312,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "sudden-montgomery",
+   "id": "0ee5142d",
    "metadata": {},
    "source": [
     "## Read Vectorfile\n",
@@ -262,7 +323,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fewer-bunch",
+   "id": "89914a9b",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-01-14T02:41:23.420704Z",
@@ -279,7 +340,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "progressive-bumper",
+   "id": "60784b3d",
    "metadata": {
     "ExecuteTime": {
      "end_time": "2022-01-14T02:41:23.671304Z",
@@ -308,7 +369,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.15"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Resolves #107. Ensures `1b` version attribute is changed to `1c`.

Not really sure about internals of different netcdf drivers and the implications. What caused the issue was that version attribute was read as `numpy.bytes_` with fixed length by `h5py`, whereas for `netCDF4` the same attribute was read as a string and length is variable. The fix using the former driver was to delete the attribute and overwrite it. Anyways, GUNWs are a decade in the making, so might be helpful why we are using so many different drivers.

Have a small notebook to illustrate the curiosity: https://gist.github.com/cmarshak/1822cd22fea0cc634cf026bfccbb4aa7

Added a test of the version update to ensure version update to `1c` going forward.

Also fixed the control flow, which was wrong because the version attribute needs to be updated if SET or ionosphere is added.