### PR TITLE
Fix variable name error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Ensures that when Solid Earth Tide or Ionosphere is added to GUNW, that the internal version attribute is updated from '1b' to '1c'
 * Ensures that correct (i.e. enough) DEM extents are obtained for frame job submission
 * Uses dem-stitcher 2.4.0 to resolve #89 - ensures only polygonal intersection of tiles
+* Fix variable name error in localize_slc.py
 
 ## Changed
 * Metadata `intersection_geo` is changed to `gunw_geo`.

--- a/isce2_topsapp/localize_slc.py
+++ b/isce2_topsapp/localize_slc.py
@@ -167,7 +167,7 @@ def download_slcs(reference_ids: list,
                                     secondary_obs,
                                     frame_id=frame_id)
 
-    percent_water_low_res = get_percent_water_from_ne_land(intersection_geo)
+    percent_water_low_res = get_percent_water_from_ne_land(ifg_geo)
     if percent_water_low_res >= 80:
         warn(f'The IFG is {percent_water_low_res:1.2f}% water; '
              'If there are not enough bursts over land - ISCE2 will fail.',


### PR DESCRIPTION
I recently renamed `intersection_geo` to `ifg_geo` since with frames dictating extents, the latter makes more sense. Not sure why this variable change (or lack of it) wasn't caught during tests/linting - but glad we have these integration tests.