### PR TITLE
Update Solid Earth Tide Correction to reference and secondary groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Exposes `frame-id` parameter for fixed frame cropping. Discussion, references, and examples in README.
 * Latitude aligned frames and their expected extents are added as geojson in repository as zip file.
 * Pins ISCE2 version to 2.6.1 and numpy / scipy to previous versions (see environment.yml) - to be amended when newest ISCE2 build is sorted out
-* Added support to compute and embed solid earth tide correction layers into GUNW products (see PR #91)
+* Added support to compute and embed solid earth tide correction layers into GUNW products (see PR #91) - reference and secondary have own groups
 * Raises warning if there is at least 80% of water in the IFG area using Natural Earth Land mask.
 
 ## Fixed

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -168,7 +168,8 @@ def gunw_slc():
                                    )
 
     if args.compute_solid_earth_tide:
-        nc_path = update_gunw_with_solid_earth_tide(nc_path)
+        nc_path = update_gunw_with_solid_earth_tide(nc_path, 'reference')
+        nc_path = update_gunw_with_solid_earth_tide(nc_path, 'secondary')
 
     if args.compute_solid_earth_tide or args.estimate_ionosphere_delay:
         update_gunw_internal_version_attribute(nc_path, new_version='1c')

--- a/isce2_topsapp/solid_earth_tides.py
+++ b/isce2_topsapp/solid_earth_tides.py
@@ -156,10 +156,11 @@ def export_se_tides_to_dataset(gunw_path: str,
 def update_gunw_with_solid_earth_tide(gunw_path: Path, acq_type: str) -> Path:
     if acq_type not in ['reference', 'secondary']:
         raise ValueError('acq_type must be in "reference" or "secondary"')
-    se_tide_group = '/science/grids/corrections/external/tides'
-    se_tide_group_acq = f'{se_tide_group}/{acq_type}'
+    tide_group = '/science/grids/corrections/external/tides'
     # If GUNW has dummy placeholder - delete it
-    se_tide_group_dummy = f'{se_tide_group}/solidEarthTides'
+    se_tide_group_dummy = f'{tide_group}/solidEarthTides'
+
+    se_tide_group_acq = f'{tide_group}/solidEarth/{acq_type}'
     with h5py.File(gunw_path, 'a') as file:
         if se_tide_group_dummy in file:
             del file[se_tide_group_dummy]

--- a/tests/solid_earth_tides.ipynb
+++ b/tests/solid_earth_tides.ipynb
@@ -3,22 +3,31 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "8b166ef0",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-02-28T20:36:25.474559Z",
+     "start_time": "2023-02-28T20:36:23.082810Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "from pathlib import Path\n",
     "import requests\n",
     "from isce2_topsapp.solid_earth_tides import compute_solid_earth_tide_from_gunw, update_gunw_with_solid_earth_tide"
-   ],
-   "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-02-07T02:10:03.484032Z",
-     "start_time": "2023-02-07T02:10:00.556938Z"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "784aa63a",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-02-28T20:36:38.736306Z",
+     "start_time": "2023-02-28T20:36:25.477267Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "url = 'https://grfn.asf.alaska.edu/door/download/S1-GUNW-A-R-064-tops-20210723_20210711-015001-35393N_33512N-PP-6267-v2_0_4.nc'\n",
     "gunw_path = Path(url.split('/')[-1])\n",
@@ -26,34 +35,29 @@
     "resp = requests.get(url)\n",
     "with open(gunw_path, 'wb') as file:\n",
     "    file.write(resp.content)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-02-07T02:10:13.866460Z",
-     "start_time": "2023-02-07T02:10:03.486567Z"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "source": [
-    "set_ds = compute_solid_earth_tide_from_gunw(gunw_path)\n",
-    "set_ds"
-   ],
+   "id": "613a1787",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-02-28T20:36:39.040480Z",
+     "start_time": "2023-02-28T20:36:38.738321Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
-      "/Users/ssangha/Downloads/snap_setup/stable_oct5_2021/envs/topsapp_env/lib/python3.9/site-packages/pysolid/grid.py:93: UserWarning: Input line 1 contained no data and will not be counted towards `max_rows=1062`.  This differs from the behaviour in NumPy <=1.22 which counted lines rather than rows.  If desired, the previous behaviour can be achieved by using `itertools.islice`.\n",
+      "/Users/cmarshak/mambaforge/envs/topsapp_env/lib/python3.9/site-packages/pysolid/grid.py:93: UserWarning: Input line 1 contained no data and will not be counted towards `max_rows=1062`.  This differs from the behaviour in NumPy <=1.22 which counted lines rather than rows.  If desired, the previous behaviour can be achieved by using `itertools.islice`.\n",
       "Please see the 1.23 release notes for an example on how to do this.  If you wish to ignore this warning, use `warnings.filterwarnings`.  This warning is expected to be removed in the future and is given only once per `loadtxt` call.\n",
       "  fc = np.loadtxt(txt_file,\n"
      ]
     },
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div><svg style=\"position: absolute; width: 0; height: 0; overflow: hidden\">\n",
@@ -427,53 +431,53 @@
        "  * height          (height) float64 -1.5e+03 0.0 3e+03 9e+03\n",
        "    spatial_ref     int64 0\n",
        "Data variables:\n",
-       "    solidEarthTide  (height, latitude, longitude) float32 17.8 17.7 ... 14.47</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-c7a77239-956e-48c9-bc1e-2be83430f2a6' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-c7a77239-956e-48c9-bc1e-2be83430f2a6' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>height</span>: 4</li><li><span class='xr-has-index'>latitude</span>: 26</li><li><span class='xr-has-index'>longitude</span>: 37</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-14eedecb-f30f-40b3-a8e6-9efb76fcff37' class='xr-section-summary-in' type='checkbox'  checked><label for='section-14eedecb-f30f-40b3-a8e6-9efb76fcff37' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>longitude</span></div><div class='xr-var-dims'>(longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-119.2 -119.1 ... -115.7 -115.6</div><input id='attrs-488e13d3-0569-4240-9dba-5eb1184be36d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-488e13d3-0569-4240-9dba-5eb1184be36d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1a55b605-abd5-4e64-a5bb-89458601a2f5' class='xr-var-data-in' type='checkbox'><label for='data-1a55b605-abd5-4e64-a5bb-89458601a2f5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Lon</dd><dt><span>units :</span></dt><dd>degrees_east</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([-119.2, -119.1, -119. , -118.9, -118.8, -118.7, -118.6, -118.5, -118.4,\n",
+       "    solidEarthTide  (height, latitude, longitude) float32 -28.14 ... -23.08</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-c70cac63-815b-4e83-8417-5c4870b3958d' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-c70cac63-815b-4e83-8417-5c4870b3958d' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>height</span>: 4</li><li><span class='xr-has-index'>latitude</span>: 26</li><li><span class='xr-has-index'>longitude</span>: 37</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-6ba5c5d7-99aa-421a-866e-a967fb250706' class='xr-section-summary-in' type='checkbox'  checked><label for='section-6ba5c5d7-99aa-421a-866e-a967fb250706' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>longitude</span></div><div class='xr-var-dims'>(longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-119.2 -119.1 ... -115.7 -115.6</div><input id='attrs-2b5f7524-a8b7-4b03-b51e-e7fa43ea8431' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2b5f7524-a8b7-4b03-b51e-e7fa43ea8431' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-21886218-da8a-4796-8c59-370f9173b04e' class='xr-var-data-in' type='checkbox'><label for='data-21886218-da8a-4796-8c59-370f9173b04e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Lon</dd><dt><span>units :</span></dt><dd>degrees_east</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([-119.2, -119.1, -119. , -118.9, -118.8, -118.7, -118.6, -118.5, -118.4,\n",
        "       -118.3, -118.2, -118.1, -118. , -117.9, -117.8, -117.7, -117.6, -117.5,\n",
        "       -117.4, -117.3, -117.2, -117.1, -117. , -116.9, -116.8, -116.7, -116.6,\n",
        "       -116.5, -116.4, -116.3, -116.2, -116.1, -116. , -115.9, -115.8, -115.7,\n",
-       "       -115.6])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>latitude</span></div><div class='xr-var-dims'>(latitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>35.7 35.6 35.5 ... 33.4 33.3 33.2</div><input id='attrs-c5f27da7-c873-44b0-a24a-8e53f5159a27' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c5f27da7-c873-44b0-a24a-8e53f5159a27' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6159b12c-ea4d-4c8e-a961-2245ee12fb7e' class='xr-var-data-in' type='checkbox'><label for='data-6159b12c-ea4d-4c8e-a961-2245ee12fb7e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Lat</dd><dt><span>units :</span></dt><dd>degrees_north</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([35.7, 35.6, 35.5, 35.4, 35.3, 35.2, 35.1, 35. , 34.9, 34.8, 34.7, 34.6,\n",
+       "       -115.6])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>latitude</span></div><div class='xr-var-dims'>(latitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>35.7 35.6 35.5 ... 33.4 33.3 33.2</div><input id='attrs-88d67f5b-2445-4bc8-89f8-74ac5e5b9bfb' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-88d67f5b-2445-4bc8-89f8-74ac5e5b9bfb' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a76410b7-cf6a-4f9a-b55f-7137f0eb1bc8' class='xr-var-data-in' type='checkbox'><label for='data-a76410b7-cf6a-4f9a-b55f-7137f0eb1bc8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Lat</dd><dt><span>units :</span></dt><dd>degrees_north</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([35.7, 35.6, 35.5, 35.4, 35.3, 35.2, 35.1, 35. , 34.9, 34.8, 34.7, 34.6,\n",
        "       34.5, 34.4, 34.3, 34.2, 34.1, 34. , 33.9, 33.8, 33.7, 33.6, 33.5, 33.4,\n",
-       "       33.3, 33.2])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>height</span></div><div class='xr-var-dims'>(height)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-1.5e+03 0.0 3e+03 9e+03</div><input id='attrs-57ec2f70-9918-45d7-acf7-00007fbf53fc' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-57ec2f70-9918-45d7-acf7-00007fbf53fc' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-288f0d50-ce9b-4993-8c0d-414186e0a61d' class='xr-var-data-in' type='checkbox'><label for='data-288f0d50-ce9b-4993-8c0d-414186e0a61d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Lev</dd><dt><span>units :</span></dt><dd>meter</dd><dt><span>long_name :</span></dt><dd>height</dd><dt><span>standard_name :</span></dt><dd>height</dd><dt><span>positive :</span></dt><dd>up</dd></dl></div><div class='xr-var-data'><pre>array([-1500.,     0.,  3000.,  9000.])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>spatial_ref</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0</div><input id='attrs-2c38309a-517a-43ad-8d83-43ec1ff3adb3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2c38309a-517a-43ad-8d83-43ec1ff3adb3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-06ace257-7042-4bf3-b9b1-67bb5f5f235b' class='xr-var-data-in' type='checkbox'><label for='data-06ace257-7042-4bf3-b9b1-67bb5f5f235b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>crs_wkt :</span></dt><dd>GEOGCS[&quot;WGS 84&quot;,DATUM[&quot;WGS_1984&quot;,SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],PRIMEM[&quot;Greenwich&quot;,0,AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],UNIT[&quot;degree&quot;,0.0174532925199433,AUTHORITY[&quot;EPSG&quot;,&quot;9122&quot;]],AXIS[&quot;Latitude&quot;,NORTH],AXIS[&quot;Longitude&quot;,EAST],AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</dd><dt><span>semi_major_axis :</span></dt><dd>6378137.0</dd><dt><span>semi_minor_axis :</span></dt><dd>6356752.314245179</dd><dt><span>inverse_flattening :</span></dt><dd>298.257223563</dd><dt><span>reference_ellipsoid_name :</span></dt><dd>WGS 84</dd><dt><span>longitude_of_prime_meridian :</span></dt><dd>0.0</dd><dt><span>prime_meridian_name :</span></dt><dd>Greenwich</dd><dt><span>geographic_crs_name :</span></dt><dd>WGS 84</dd><dt><span>grid_mapping_name :</span></dt><dd>latitude_longitude</dd><dt><span>spatial_ref :</span></dt><dd>GEOGCS[&quot;WGS 84&quot;,DATUM[&quot;WGS_1984&quot;,SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],PRIMEM[&quot;Greenwich&quot;,0,AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],UNIT[&quot;degree&quot;,0.0174532925199433,AUTHORITY[&quot;EPSG&quot;,&quot;9122&quot;]],AXIS[&quot;Latitude&quot;,NORTH],AXIS[&quot;Longitude&quot;,EAST],AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-ae22f3f2-8051-492b-8419-086d20dd75c8' class='xr-section-summary-in' type='checkbox'  checked><label for='section-ae22f3f2-8051-492b-8419-086d20dd75c8' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>solidEarthTide</span></div><div class='xr-var-dims'>(height, latitude, longitude)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>17.8 17.7 17.61 ... 14.57 14.47</div><input id='attrs-681e8cf4-fa2d-49e7-b81e-818117072063' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-681e8cf4-fa2d-49e7-b81e-818117072063' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4cfd3659-5e83-41ee-8c74-eb4adac8d29d' class='xr-var-data-in' type='checkbox'><label for='data-4cfd3659-5e83-41ee-8c74-eb4adac8d29d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>description :</span></dt><dd>Solid Earth tide</dd><dt><span>units :</span></dt><dd>radians</dd><dt><span>long_name :</span></dt><dd>solidEarthTide</dd><dt><span>standard_name :</span></dt><dd>solidEarthTide</dd><dt><span>_FillValue :</span></dt><dd>0.0</dd></dl></div><div class='xr-var-data'><pre>array([[[17.79665  , 17.704428 , 17.611319 , ..., 14.507284 ,\n",
-       "         14.413987 , 14.321208 ],\n",
-       "        [17.8089   , 17.716831 , 17.623856 , ..., 14.517818 ,\n",
-       "         14.424359 , 14.331416 ],\n",
-       "        [17.820887 , 17.728977 , 17.63614  , ..., 14.528217 ,\n",
-       "         14.434599 , 14.341495 ],\n",
+       "       33.3, 33.2])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>height</span></div><div class='xr-var-dims'>(height)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-1.5e+03 0.0 3e+03 9e+03</div><input id='attrs-76795f05-c402-44ab-90e7-2bacb1f0431d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-76795f05-c402-44ab-90e7-2bacb1f0431d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-dc41ab96-6da4-4395-8c5c-8add378205cc' class='xr-var-data-in' type='checkbox'><label for='data-dc41ab96-6da4-4395-8c5c-8add378205cc' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Lev</dd><dt><span>units :</span></dt><dd>meter</dd><dt><span>long_name :</span></dt><dd>height</dd><dt><span>standard_name :</span></dt><dd>height</dd><dt><span>positive :</span></dt><dd>up</dd></dl></div><div class='xr-var-data'><pre>array([-1500.,     0.,  3000.,  9000.])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>spatial_ref</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0</div><input id='attrs-77f3bf29-5121-469c-9a34-0f3b36aa73e8' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-77f3bf29-5121-469c-9a34-0f3b36aa73e8' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8117f3b2-fc82-4e82-a831-00f1c143afe7' class='xr-var-data-in' type='checkbox'><label for='data-8117f3b2-fc82-4e82-a831-00f1c143afe7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>crs_wkt :</span></dt><dd>GEOGCS[&quot;WGS 84&quot;,DATUM[&quot;WGS_1984&quot;,SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],PRIMEM[&quot;Greenwich&quot;,0,AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],UNIT[&quot;degree&quot;,0.0174532925199433,AUTHORITY[&quot;EPSG&quot;,&quot;9122&quot;]],AXIS[&quot;Latitude&quot;,NORTH],AXIS[&quot;Longitude&quot;,EAST],AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</dd><dt><span>semi_major_axis :</span></dt><dd>6378137.0</dd><dt><span>semi_minor_axis :</span></dt><dd>6356752.314245179</dd><dt><span>inverse_flattening :</span></dt><dd>298.257223563</dd><dt><span>reference_ellipsoid_name :</span></dt><dd>WGS 84</dd><dt><span>longitude_of_prime_meridian :</span></dt><dd>0.0</dd><dt><span>prime_meridian_name :</span></dt><dd>Greenwich</dd><dt><span>geographic_crs_name :</span></dt><dd>WGS 84</dd><dt><span>grid_mapping_name :</span></dt><dd>latitude_longitude</dd><dt><span>spatial_ref :</span></dt><dd>GEOGCS[&quot;WGS 84&quot;,DATUM[&quot;WGS_1984&quot;,SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],PRIMEM[&quot;Greenwich&quot;,0,AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],UNIT[&quot;degree&quot;,0.0174532925199433,AUTHORITY[&quot;EPSG&quot;,&quot;9122&quot;]],AXIS[&quot;Latitude&quot;,NORTH],AXIS[&quot;Longitude&quot;,EAST],AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-b96302c5-dc14-4d5c-8302-b54ec9ef9edb' class='xr-section-summary-in' type='checkbox'  checked><label for='section-b96302c5-dc14-4d5c-8302-b54ec9ef9edb' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>solidEarthTide</span></div><div class='xr-var-dims'>(height, latitude, longitude)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-28.14 -27.96 ... -23.27 -23.08</div><input id='attrs-95e4641c-99f3-4f22-a273-501f4a8f3a1d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-95e4641c-99f3-4f22-a273-501f4a8f3a1d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-78950c7f-67f2-4fb2-9123-a9251ac5c549' class='xr-var-data-in' type='checkbox'><label for='data-78950c7f-67f2-4fb2-9123-a9251ac5c549' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>description :</span></dt><dd>Solid Earth tide</dd><dt><span>units :</span></dt><dd>radians</dd><dt><span>long_name :</span></dt><dd>solidEarthTide</dd><dt><span>standard_name :</span></dt><dd>solidEarthTide</dd><dt><span>_FillValue :</span></dt><dd>0.0</dd></dl></div><div class='xr-var-data'><pre>array([[[-28.14476 , -27.961794, -27.777964, ..., -21.9595  ,\n",
+       "         -21.790537, -21.622738],\n",
+       "        [-28.230165, -28.047003, -27.862946, ..., -22.027756,\n",
+       "         -21.858156, -21.689722],\n",
+       "        [-28.315493, -28.132145, -27.947868, ..., -22.09607 ,\n",
+       "         -21.925833, -21.756765],\n",
        "        ...,\n",
-       "        [18.007963 , 17.920965 , 17.832592 , ..., 14.714321 ,\n",
-       "         14.617831 , 14.521804 ],\n",
-       "        [18.013624 , 17.926939 , 17.838854 , ..., 14.7215805,\n",
-       "         14.624977 , 14.528833 ],\n",
-       "        [18.018976 , 17.932608 , 17.844818 , ..., 14.728686 ,\n",
-       "         14.631973 , 14.535717 ]],\n",
+       "        [-30.082977, -29.898222, -29.711739, ..., -23.54298 ,\n",
+       "         -23.359518, -23.177214],\n",
+       "        [-30.165653, -29.980957, -29.794495, ..., -23.6124  ,\n",
+       "         -23.428318, -23.24539 ],\n",
+       "        [-30.248161, -30.06354 , -29.87711 , ..., -23.68186 ,\n",
+       "         -23.49716 , -23.313608]],\n",
        "\n",
-       "       [[17.792112 , 17.69968  , 17.606363 , ..., 14.497879 ,\n",
-       "         14.404515 , 14.311674 ],\n",
-       "        [17.804426 , 17.712149 , 17.618965 , ..., 14.508448 ,\n",
-       "         14.414924 , 14.321919 ],\n",
-       "        [17.816479 , 17.724358 , 17.631315 , ..., 14.518884 ,\n",
-       "         14.425199 , 14.332034 ],\n",
+       "       [[-28.123861, -27.940355, -27.755995, ..., -21.92653 ,\n",
+       "         -21.7574  , -21.589445],\n",
+       "        [-28.2094  , -28.025694, -27.841105, ..., -21.994816,\n",
+       "         -21.825048, -21.656458],\n",
+       "        [-28.294863, -28.110968, -27.926159, ..., -22.063162,\n",
+       "         -21.892757, -21.72353 ],\n",
        "...\n",
-       "        [17.998798 , 17.911161 , 17.82215  , ..., 14.688744 ,\n",
-       "         14.592007 , 14.4957485],\n",
-       "        [18.004658 , 17.91733  , 17.828608 , ..., 14.696131 ,\n",
-       "         14.599281 , 14.502904 ],\n",
-       "        [18.010204 , 17.923197 , 17.83477  , ..., 14.703367 ,\n",
-       "         14.606406 , 14.509913 ]],\n",
+       "        [-30.029863, -29.843287, -29.65501 , ..., -23.446476,\n",
+       "         -23.262367, -23.079449],\n",
+       "        [-30.112995, -29.926474, -29.738207, ..., -23.516035,\n",
+       "         -23.331299, -23.147749],\n",
+       "        [-30.195957, -30.009504, -29.821264, ..., -23.585636,\n",
+       "         -23.400278, -23.216097]],\n",
        "\n",
-       "       [[17.764214 , 17.67051  , 17.575937 , ..., 14.440653 ,\n",
-       "         14.346909 , 14.253711 ],\n",
-       "        [17.776924 , 17.683372 , 17.588928 , ..., 14.451444 ,\n",
-       "         14.3575325, 14.264168 ],\n",
-       "        [17.789373 , 17.695976 , 17.60167  , ..., 14.462101 ,\n",
-       "         14.368026 , 14.274496 ],\n",
+       "       [[-27.996492, -27.809717, -27.62215 , ..., -21.726734,\n",
+       "         -21.556633, -21.387758],\n",
+       "        [-28.082838, -27.895847, -27.70803 , ..., -21.79521 ,\n",
+       "         -21.624456, -21.454937],\n",
+       "        [-28.169115, -27.981915, -27.793861, ..., -21.863747,\n",
+       "         -21.692345, -21.522175],\n",
        "        ...,\n",
-       "        [17.986229 , 17.89772  , 17.807842 , ..., 14.654119 ,\n",
-       "         14.557059 , 14.460495 ],\n",
-       "        [17.992353 , 17.90416  , 17.81457  , ..., 14.661681 ,\n",
-       "         14.564503 , 14.467817 ],\n",
-       "        [17.998167 , 17.910294 , 17.821    , ..., 14.669093 ,\n",
-       "         14.571799 , 14.474995 ]]], dtype=float32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-6073b54e-27a3-456f-97ed-dbd4445c59f3' class='xr-section-summary-in' type='checkbox'  ><label for='section-6073b54e-27a3-456f-97ed-dbd4445c59f3' class='xr-section-summary' >Indexes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>longitude</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-aa308431-ffa9-4d46-8bed-2eb713e4fc91' class='xr-index-data-in' type='checkbox'/><label for='index-aa308431-ffa9-4d46-8bed-2eb713e4fc91' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Float64Index([             -119.2, -119.10000000000001,              -119.0,\n",
+       "        [-29.957848, -29.768818, -29.578117, ..., -23.316416,\n",
+       "         -23.13146 , -22.947731],\n",
+       "        [-30.041592, -29.852608, -29.66191 , ..., -23.386162,\n",
+       "         -23.200565, -23.0162  ],\n",
+       "        [-30.125172, -29.936249, -29.745562, ..., -23.455952,\n",
+       "         -23.269718, -23.084713]]], dtype=float32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-2d4c6a69-76b5-408a-b4b4-bb5f51853db9' class='xr-section-summary-in' type='checkbox'  ><label for='section-2d4c6a69-76b5-408a-b4b4-bb5f51853db9' class='xr-section-summary' >Indexes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>longitude</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-6da2e22e-5129-47f7-9f9f-2a6ff0821b13' class='xr-index-data-in' type='checkbox'/><label for='index-6da2e22e-5129-47f7-9f9f-2a6ff0821b13' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Float64Index([             -119.2, -119.10000000000001,              -119.0,\n",
        "                           -118.9,              -118.8,              -118.7,\n",
        "              -118.60000000000001,              -118.5,              -118.4,\n",
        "                           -118.3,              -118.2, -118.10000000000001,\n",
@@ -486,7 +490,7 @@
        "                           -116.2, -116.10000000000001,              -116.0,\n",
        "                           -115.9,              -115.8,              -115.7,\n",
        "              -115.60000000000001],\n",
-       "             dtype=&#x27;float64&#x27;, name=&#x27;longitude&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>latitude</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-a3b30e12-2be8-4208-b6ce-48bda0a97d8f' class='xr-index-data-in' type='checkbox'/><label for='index-a3b30e12-2be8-4208-b6ce-48bda0a97d8f' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Float64Index([              35.7,               35.6,               35.5,\n",
+       "             dtype=&#x27;float64&#x27;, name=&#x27;longitude&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>latitude</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-71a87f2f-859c-482b-93b4-dd50d890832f' class='xr-index-data-in' type='checkbox'/><label for='index-71a87f2f-859c-482b-93b4-dd50d890832f' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Float64Index([              35.7,               35.6,               35.5,\n",
        "              35.400000000000006, 35.300000000000004,               35.2,\n",
        "                            35.1,               35.0, 34.900000000000006,\n",
        "              34.800000000000004,               34.7,               34.6,\n",
@@ -495,7 +499,7 @@
        "              33.900000000000006, 33.800000000000004,               33.7,\n",
        "                            33.6,               33.5, 33.400000000000006,\n",
        "              33.300000000000004,               33.2],\n",
-       "             dtype=&#x27;float64&#x27;, name=&#x27;latitude&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>height</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-b4877da2-46ad-4c88-9b0f-e21d654cd6ba' class='xr-index-data-in' type='checkbox'/><label for='index-b4877da2-46ad-4c88-9b0f-e21d654cd6ba' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Float64Index([-1500.0, 0.0, 3000.0, 9000.0], dtype=&#x27;float64&#x27;, name=&#x27;height&#x27;))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-e066eee9-adb8-4253-bd5e-12ee93c370b1' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-e066eee9-adb8-4253-bd5e-12ee93c370b1' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
+       "             dtype=&#x27;float64&#x27;, name=&#x27;latitude&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>height</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-d75795c9-e5e9-4a1d-bfa0-e1708d393199' class='xr-index-data-in' type='checkbox'/><label for='index-d75795c9-e5e9-4a1d-bfa0-e1708d393199' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Float64Index([-1500.0, 0.0, 3000.0, 9000.0], dtype=&#x27;float64&#x27;, name=&#x27;height&#x27;))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-f6348ef4-c2ca-441b-9ef2-74e2a0adec23' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-f6348ef4-c2ca-441b-9ef2-74e2a0adec23' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -506,84 +510,569 @@
        "  * height          (height) float64 -1.5e+03 0.0 3e+03 9e+03\n",
        "    spatial_ref     int64 0\n",
        "Data variables:\n",
-       "    solidEarthTide  (height, latitude, longitude) float32 17.8 17.7 ... 14.47"
+       "    solidEarthTide  (height, latitude, longitude) float32 -28.14 ... -23.08"
       ]
      },
+     "execution_count": 3,
      "metadata": {},
-     "execution_count": 3
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-02-07T02:10:14.199042Z",
-     "start_time": "2023-02-07T02:10:13.871876Z"
-    }
-   }
+   "source": [
+    "set_ds_ref = compute_solid_earth_tide_from_gunw(gunw_path, 'reference')\n",
+    "set_ds_ref"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "source": [
-    "update_gunw_with_solid_earth_tide(gunw_path)"
-   ],
+   "id": "b074fcb5",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-02-28T20:36:39.237039Z",
+     "start_time": "2023-02-28T20:36:39.043198Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
-      "/Users/ssangha/Downloads/snap_setup/stable_oct5_2021/envs/topsapp_env/lib/python3.9/site-packages/pysolid/grid.py:93: UserWarning: Input line 1 contained no data and will not be counted towards `max_rows=1062`.  This differs from the behaviour in NumPy <=1.22 which counted lines rather than rows.  If desired, the previous behaviour can be achieved by using `itertools.islice`.\n",
+      "/Users/cmarshak/mambaforge/envs/topsapp_env/lib/python3.9/site-packages/pysolid/grid.py:93: UserWarning: Input line 1 contained no data and will not be counted towards `max_rows=1062`.  This differs from the behaviour in NumPy <=1.22 which counted lines rather than rows.  If desired, the previous behaviour can be achieved by using `itertools.islice`.\n",
       "Please see the 1.23 release notes for an example on how to do this.  If you wish to ignore this warning, use `warnings.filterwarnings`.  This warning is expected to be removed in the future and is given only once per `loadtxt` call.\n",
       "  fc = np.loadtxt(txt_file,\n"
      ]
     },
     {
-     "output_type": "execute_result",
+     "data": {
+      "text/html": [
+       "<div><svg style=\"position: absolute; width: 0; height: 0; overflow: hidden\">\n",
+       "<defs>\n",
+       "<symbol id=\"icon-database\" viewBox=\"0 0 32 32\">\n",
+       "<path d=\"M16 0c-8.837 0-16 2.239-16 5v4c0 2.761 7.163 5 16 5s16-2.239 16-5v-4c0-2.761-7.163-5-16-5z\"></path>\n",
+       "<path d=\"M16 17c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z\"></path>\n",
+       "<path d=\"M16 26c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z\"></path>\n",
+       "</symbol>\n",
+       "<symbol id=\"icon-file-text2\" viewBox=\"0 0 32 32\">\n",
+       "<path d=\"M28.681 7.159c-0.694-0.947-1.662-2.053-2.724-3.116s-2.169-2.030-3.116-2.724c-1.612-1.182-2.393-1.319-2.841-1.319h-15.5c-1.378 0-2.5 1.121-2.5 2.5v27c0 1.378 1.122 2.5 2.5 2.5h23c1.378 0 2.5-1.122 2.5-2.5v-19.5c0-0.448-0.137-1.23-1.319-2.841zM24.543 5.457c0.959 0.959 1.712 1.825 2.268 2.543h-4.811v-4.811c0.718 0.556 1.584 1.309 2.543 2.268zM28 29.5c0 0.271-0.229 0.5-0.5 0.5h-23c-0.271 0-0.5-0.229-0.5-0.5v-27c0-0.271 0.229-0.5 0.5-0.5 0 0 15.499-0 15.5 0v7c0 0.552 0.448 1 1 1h7v19.5z\"></path>\n",
+       "<path d=\"M23 26h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z\"></path>\n",
+       "<path d=\"M23 22h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z\"></path>\n",
+       "<path d=\"M23 18h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z\"></path>\n",
+       "</symbol>\n",
+       "</defs>\n",
+       "</svg>\n",
+       "<style>/* CSS stylesheet for displaying xarray objects in jupyterlab.\n",
+       " *\n",
+       " */\n",
+       "\n",
+       ":root {\n",
+       "  --xr-font-color0: var(--jp-content-font-color0, rgba(0, 0, 0, 1));\n",
+       "  --xr-font-color2: var(--jp-content-font-color2, rgba(0, 0, 0, 0.54));\n",
+       "  --xr-font-color3: var(--jp-content-font-color3, rgba(0, 0, 0, 0.38));\n",
+       "  --xr-border-color: var(--jp-border-color2, #e0e0e0);\n",
+       "  --xr-disabled-color: var(--jp-layout-color3, #bdbdbd);\n",
+       "  --xr-background-color: var(--jp-layout-color0, white);\n",
+       "  --xr-background-color-row-even: var(--jp-layout-color1, white);\n",
+       "  --xr-background-color-row-odd: var(--jp-layout-color2, #eeeeee);\n",
+       "}\n",
+       "\n",
+       "html[theme=dark],\n",
+       "body[data-theme=dark],\n",
+       "body.vscode-dark {\n",
+       "  --xr-font-color0: rgba(255, 255, 255, 1);\n",
+       "  --xr-font-color2: rgba(255, 255, 255, 0.54);\n",
+       "  --xr-font-color3: rgba(255, 255, 255, 0.38);\n",
+       "  --xr-border-color: #1F1F1F;\n",
+       "  --xr-disabled-color: #515151;\n",
+       "  --xr-background-color: #111111;\n",
+       "  --xr-background-color-row-even: #111111;\n",
+       "  --xr-background-color-row-odd: #313131;\n",
+       "}\n",
+       "\n",
+       ".xr-wrap {\n",
+       "  display: block !important;\n",
+       "  min-width: 300px;\n",
+       "  max-width: 700px;\n",
+       "}\n",
+       "\n",
+       ".xr-text-repr-fallback {\n",
+       "  /* fallback to plain text repr when CSS is not injected (untrusted notebook) */\n",
+       "  display: none;\n",
+       "}\n",
+       "\n",
+       ".xr-header {\n",
+       "  padding-top: 6px;\n",
+       "  padding-bottom: 6px;\n",
+       "  margin-bottom: 4px;\n",
+       "  border-bottom: solid 1px var(--xr-border-color);\n",
+       "}\n",
+       "\n",
+       ".xr-header > div,\n",
+       ".xr-header > ul {\n",
+       "  display: inline;\n",
+       "  margin-top: 0;\n",
+       "  margin-bottom: 0;\n",
+       "}\n",
+       "\n",
+       ".xr-obj-type,\n",
+       ".xr-array-name {\n",
+       "  margin-left: 2px;\n",
+       "  margin-right: 10px;\n",
+       "}\n",
+       "\n",
+       ".xr-obj-type {\n",
+       "  color: var(--xr-font-color2);\n",
+       "}\n",
+       "\n",
+       ".xr-sections {\n",
+       "  padding-left: 0 !important;\n",
+       "  display: grid;\n",
+       "  grid-template-columns: 150px auto auto 1fr 20px 20px;\n",
+       "}\n",
+       "\n",
+       ".xr-section-item {\n",
+       "  display: contents;\n",
+       "}\n",
+       "\n",
+       ".xr-section-item input {\n",
+       "  display: none;\n",
+       "}\n",
+       "\n",
+       ".xr-section-item input + label {\n",
+       "  color: var(--xr-disabled-color);\n",
+       "}\n",
+       "\n",
+       ".xr-section-item input:enabled + label {\n",
+       "  cursor: pointer;\n",
+       "  color: var(--xr-font-color2);\n",
+       "}\n",
+       "\n",
+       ".xr-section-item input:enabled + label:hover {\n",
+       "  color: var(--xr-font-color0);\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary {\n",
+       "  grid-column: 1;\n",
+       "  color: var(--xr-font-color2);\n",
+       "  font-weight: 500;\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary > span {\n",
+       "  display: inline-block;\n",
+       "  padding-left: 0.5em;\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary-in:disabled + label {\n",
+       "  color: var(--xr-font-color2);\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary-in + label:before {\n",
+       "  display: inline-block;\n",
+       "  content: '►';\n",
+       "  font-size: 11px;\n",
+       "  width: 15px;\n",
+       "  text-align: center;\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary-in:disabled + label:before {\n",
+       "  color: var(--xr-disabled-color);\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary-in:checked + label:before {\n",
+       "  content: '▼';\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary-in:checked + label > span {\n",
+       "  display: none;\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary,\n",
+       ".xr-section-inline-details {\n",
+       "  padding-top: 4px;\n",
+       "  padding-bottom: 4px;\n",
+       "}\n",
+       "\n",
+       ".xr-section-inline-details {\n",
+       "  grid-column: 2 / -1;\n",
+       "}\n",
+       "\n",
+       ".xr-section-details {\n",
+       "  display: none;\n",
+       "  grid-column: 1 / -1;\n",
+       "  margin-bottom: 5px;\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary-in:checked ~ .xr-section-details {\n",
+       "  display: contents;\n",
+       "}\n",
+       "\n",
+       ".xr-array-wrap {\n",
+       "  grid-column: 1 / -1;\n",
+       "  display: grid;\n",
+       "  grid-template-columns: 20px auto;\n",
+       "}\n",
+       "\n",
+       ".xr-array-wrap > label {\n",
+       "  grid-column: 1;\n",
+       "  vertical-align: top;\n",
+       "}\n",
+       "\n",
+       ".xr-preview {\n",
+       "  color: var(--xr-font-color3);\n",
+       "}\n",
+       "\n",
+       ".xr-array-preview,\n",
+       ".xr-array-data {\n",
+       "  padding: 0 5px !important;\n",
+       "  grid-column: 2;\n",
+       "}\n",
+       "\n",
+       ".xr-array-data,\n",
+       ".xr-array-in:checked ~ .xr-array-preview {\n",
+       "  display: none;\n",
+       "}\n",
+       "\n",
+       ".xr-array-in:checked ~ .xr-array-data,\n",
+       ".xr-array-preview {\n",
+       "  display: inline-block;\n",
+       "}\n",
+       "\n",
+       ".xr-dim-list {\n",
+       "  display: inline-block !important;\n",
+       "  list-style: none;\n",
+       "  padding: 0 !important;\n",
+       "  margin: 0;\n",
+       "}\n",
+       "\n",
+       ".xr-dim-list li {\n",
+       "  display: inline-block;\n",
+       "  padding: 0;\n",
+       "  margin: 0;\n",
+       "}\n",
+       "\n",
+       ".xr-dim-list:before {\n",
+       "  content: '(';\n",
+       "}\n",
+       "\n",
+       ".xr-dim-list:after {\n",
+       "  content: ')';\n",
+       "}\n",
+       "\n",
+       ".xr-dim-list li:not(:last-child):after {\n",
+       "  content: ',';\n",
+       "  padding-right: 5px;\n",
+       "}\n",
+       "\n",
+       ".xr-has-index {\n",
+       "  font-weight: bold;\n",
+       "}\n",
+       "\n",
+       ".xr-var-list,\n",
+       ".xr-var-item {\n",
+       "  display: contents;\n",
+       "}\n",
+       "\n",
+       ".xr-var-item > div,\n",
+       ".xr-var-item label,\n",
+       ".xr-var-item > .xr-var-name span {\n",
+       "  background-color: var(--xr-background-color-row-even);\n",
+       "  margin-bottom: 0;\n",
+       "}\n",
+       "\n",
+       ".xr-var-item > .xr-var-name:hover span {\n",
+       "  padding-right: 5px;\n",
+       "}\n",
+       "\n",
+       ".xr-var-list > li:nth-child(odd) > div,\n",
+       ".xr-var-list > li:nth-child(odd) > label,\n",
+       ".xr-var-list > li:nth-child(odd) > .xr-var-name span {\n",
+       "  background-color: var(--xr-background-color-row-odd);\n",
+       "}\n",
+       "\n",
+       ".xr-var-name {\n",
+       "  grid-column: 1;\n",
+       "}\n",
+       "\n",
+       ".xr-var-dims {\n",
+       "  grid-column: 2;\n",
+       "}\n",
+       "\n",
+       ".xr-var-dtype {\n",
+       "  grid-column: 3;\n",
+       "  text-align: right;\n",
+       "  color: var(--xr-font-color2);\n",
+       "}\n",
+       "\n",
+       ".xr-var-preview {\n",
+       "  grid-column: 4;\n",
+       "}\n",
+       "\n",
+       ".xr-index-preview {\n",
+       "  grid-column: 2 / 5;\n",
+       "  color: var(--xr-font-color2);\n",
+       "}\n",
+       "\n",
+       ".xr-var-name,\n",
+       ".xr-var-dims,\n",
+       ".xr-var-dtype,\n",
+       ".xr-preview,\n",
+       ".xr-attrs dt {\n",
+       "  white-space: nowrap;\n",
+       "  overflow: hidden;\n",
+       "  text-overflow: ellipsis;\n",
+       "  padding-right: 10px;\n",
+       "}\n",
+       "\n",
+       ".xr-var-name:hover,\n",
+       ".xr-var-dims:hover,\n",
+       ".xr-var-dtype:hover,\n",
+       ".xr-attrs dt:hover {\n",
+       "  overflow: visible;\n",
+       "  width: auto;\n",
+       "  z-index: 1;\n",
+       "}\n",
+       "\n",
+       ".xr-var-attrs,\n",
+       ".xr-var-data,\n",
+       ".xr-index-data {\n",
+       "  display: none;\n",
+       "  background-color: var(--xr-background-color) !important;\n",
+       "  padding-bottom: 5px !important;\n",
+       "}\n",
+       "\n",
+       ".xr-var-attrs-in:checked ~ .xr-var-attrs,\n",
+       ".xr-var-data-in:checked ~ .xr-var-data,\n",
+       ".xr-index-data-in:checked ~ .xr-index-data {\n",
+       "  display: block;\n",
+       "}\n",
+       "\n",
+       ".xr-var-data > table {\n",
+       "  float: right;\n",
+       "}\n",
+       "\n",
+       ".xr-var-name span,\n",
+       ".xr-var-data,\n",
+       ".xr-index-name div,\n",
+       ".xr-index-data,\n",
+       ".xr-attrs {\n",
+       "  padding-left: 25px !important;\n",
+       "}\n",
+       "\n",
+       ".xr-attrs,\n",
+       ".xr-var-attrs,\n",
+       ".xr-var-data,\n",
+       ".xr-index-data {\n",
+       "  grid-column: 1 / -1;\n",
+       "}\n",
+       "\n",
+       "dl.xr-attrs {\n",
+       "  padding: 0;\n",
+       "  margin: 0;\n",
+       "  display: grid;\n",
+       "  grid-template-columns: 125px auto;\n",
+       "}\n",
+       "\n",
+       ".xr-attrs dt,\n",
+       ".xr-attrs dd {\n",
+       "  padding: 0;\n",
+       "  margin: 0;\n",
+       "  float: left;\n",
+       "  padding-right: 10px;\n",
+       "  width: auto;\n",
+       "}\n",
+       "\n",
+       ".xr-attrs dt {\n",
+       "  font-weight: normal;\n",
+       "  grid-column: 1;\n",
+       "}\n",
+       "\n",
+       ".xr-attrs dt:hover span {\n",
+       "  display: inline-block;\n",
+       "  background: var(--xr-background-color);\n",
+       "  padding-right: 10px;\n",
+       "}\n",
+       "\n",
+       ".xr-attrs dd {\n",
+       "  grid-column: 2;\n",
+       "  white-space: pre-wrap;\n",
+       "  word-break: break-all;\n",
+       "}\n",
+       "\n",
+       ".xr-icon-database,\n",
+       ".xr-icon-file-text2,\n",
+       ".xr-no-icon {\n",
+       "  display: inline-block;\n",
+       "  vertical-align: middle;\n",
+       "  width: 1em;\n",
+       "  height: 1.5em !important;\n",
+       "  stroke-width: 0;\n",
+       "  stroke: currentColor;\n",
+       "  fill: currentColor;\n",
+       "}\n",
+       "</style><pre class='xr-text-repr-fallback'>&lt;xarray.Dataset&gt;\n",
+       "Dimensions:         (height: 4, latitude: 26, longitude: 37)\n",
+       "Coordinates:\n",
+       "  * longitude       (longitude) float64 -119.2 -119.1 -119.0 ... -115.7 -115.6\n",
+       "  * latitude        (latitude) float64 35.7 35.6 35.5 35.4 ... 33.4 33.3 33.2\n",
+       "  * height          (height) float64 -1.5e+03 0.0 3e+03 9e+03\n",
+       "    spatial_ref     int64 0\n",
+       "Data variables:\n",
+       "    solidEarthTide  (height, latitude, longitude) float32 -10.35 ... -8.61</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-2f1a2bd2-7904-4fa5-8435-1ab92453e10d' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-2f1a2bd2-7904-4fa5-8435-1ab92453e10d' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>height</span>: 4</li><li><span class='xr-has-index'>latitude</span>: 26</li><li><span class='xr-has-index'>longitude</span>: 37</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-510a925f-8461-4c71-aeb4-23e23ae340dc' class='xr-section-summary-in' type='checkbox'  checked><label for='section-510a925f-8461-4c71-aeb4-23e23ae340dc' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>longitude</span></div><div class='xr-var-dims'>(longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-119.2 -119.1 ... -115.7 -115.6</div><input id='attrs-8de3b4a0-c955-44d0-af2a-e43f2c0543cd' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8de3b4a0-c955-44d0-af2a-e43f2c0543cd' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8422c04b-18cd-4c13-b051-7bacdd728f99' class='xr-var-data-in' type='checkbox'><label for='data-8422c04b-18cd-4c13-b051-7bacdd728f99' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Lon</dd><dt><span>units :</span></dt><dd>degrees_east</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([-119.2, -119.1, -119. , -118.9, -118.8, -118.7, -118.6, -118.5, -118.4,\n",
+       "       -118.3, -118.2, -118.1, -118. , -117.9, -117.8, -117.7, -117.6, -117.5,\n",
+       "       -117.4, -117.3, -117.2, -117.1, -117. , -116.9, -116.8, -116.7, -116.6,\n",
+       "       -116.5, -116.4, -116.3, -116.2, -116.1, -116. , -115.9, -115.8, -115.7,\n",
+       "       -115.6])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>latitude</span></div><div class='xr-var-dims'>(latitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>35.7 35.6 35.5 ... 33.4 33.3 33.2</div><input id='attrs-8a49bf97-ccfd-4792-bc7f-05a38c993e27' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8a49bf97-ccfd-4792-bc7f-05a38c993e27' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-87a849ee-75da-4d59-8db4-8effacf7eb0a' class='xr-var-data-in' type='checkbox'><label for='data-87a849ee-75da-4d59-8db4-8effacf7eb0a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Lat</dd><dt><span>units :</span></dt><dd>degrees_north</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([35.7, 35.6, 35.5, 35.4, 35.3, 35.2, 35.1, 35. , 34.9, 34.8, 34.7, 34.6,\n",
+       "       34.5, 34.4, 34.3, 34.2, 34.1, 34. , 33.9, 33.8, 33.7, 33.6, 33.5, 33.4,\n",
+       "       33.3, 33.2])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>height</span></div><div class='xr-var-dims'>(height)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-1.5e+03 0.0 3e+03 9e+03</div><input id='attrs-d536f230-9a0f-4256-9df1-85241744dd95' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d536f230-9a0f-4256-9df1-85241744dd95' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-cdbb61b4-2a30-41c7-99f6-64b0a69ba2ec' class='xr-var-data-in' type='checkbox'><label for='data-cdbb61b4-2a30-41c7-99f6-64b0a69ba2ec' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Lev</dd><dt><span>units :</span></dt><dd>meter</dd><dt><span>long_name :</span></dt><dd>height</dd><dt><span>standard_name :</span></dt><dd>height</dd><dt><span>positive :</span></dt><dd>up</dd></dl></div><div class='xr-var-data'><pre>array([-1500.,     0.,  3000.,  9000.])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>spatial_ref</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0</div><input id='attrs-6f456eec-f4c2-4dc1-92de-258409dbb234' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6f456eec-f4c2-4dc1-92de-258409dbb234' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3f8d3e34-e3e7-4274-80f6-9d570bf2dc08' class='xr-var-data-in' type='checkbox'><label for='data-3f8d3e34-e3e7-4274-80f6-9d570bf2dc08' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>crs_wkt :</span></dt><dd>GEOGCS[&quot;WGS 84&quot;,DATUM[&quot;WGS_1984&quot;,SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],PRIMEM[&quot;Greenwich&quot;,0,AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],UNIT[&quot;degree&quot;,0.0174532925199433,AUTHORITY[&quot;EPSG&quot;,&quot;9122&quot;]],AXIS[&quot;Latitude&quot;,NORTH],AXIS[&quot;Longitude&quot;,EAST],AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</dd><dt><span>semi_major_axis :</span></dt><dd>6378137.0</dd><dt><span>semi_minor_axis :</span></dt><dd>6356752.314245179</dd><dt><span>inverse_flattening :</span></dt><dd>298.257223563</dd><dt><span>reference_ellipsoid_name :</span></dt><dd>WGS 84</dd><dt><span>longitude_of_prime_meridian :</span></dt><dd>0.0</dd><dt><span>prime_meridian_name :</span></dt><dd>Greenwich</dd><dt><span>geographic_crs_name :</span></dt><dd>WGS 84</dd><dt><span>grid_mapping_name :</span></dt><dd>latitude_longitude</dd><dt><span>spatial_ref :</span></dt><dd>GEOGCS[&quot;WGS 84&quot;,DATUM[&quot;WGS_1984&quot;,SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],PRIMEM[&quot;Greenwich&quot;,0,AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],UNIT[&quot;degree&quot;,0.0174532925199433,AUTHORITY[&quot;EPSG&quot;,&quot;9122&quot;]],AXIS[&quot;Latitude&quot;,NORTH],AXIS[&quot;Longitude&quot;,EAST],AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-331146bd-2384-444c-a84f-4ef02258bf70' class='xr-section-summary-in' type='checkbox'  checked><label for='section-331146bd-2384-444c-a84f-4ef02258bf70' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>solidEarthTide</span></div><div class='xr-var-dims'>(height, latitude, longitude)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-10.35 -10.26 ... -8.698 -8.61</div><input id='attrs-f89c2694-23d6-416d-8cf3-140df49193a3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f89c2694-23d6-416d-8cf3-140df49193a3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-67eb2f24-3d57-4904-8bf3-9def41d8c06e' class='xr-var-data-in' type='checkbox'><label for='data-67eb2f24-3d57-4904-8bf3-9def41d8c06e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>description :</span></dt><dd>Solid Earth tide</dd><dt><span>units :</span></dt><dd>radians</dd><dt><span>long_name :</span></dt><dd>solidEarthTide</dd><dt><span>standard_name :</span></dt><dd>solidEarthTide</dd><dt><span>_FillValue :</span></dt><dd>0.0</dd></dl></div><div class='xr-var-data'><pre>array([[[-10.34811  , -10.257366 , -10.166645 , ...,  -7.4522157,\n",
+       "          -7.3765492,  -7.3015294],\n",
+       "        [-10.421266 , -10.330172 , -10.23909  , ...,  -7.5099363,\n",
+       "          -7.4337974,  -7.358306 ],\n",
+       "        [-10.494606 , -10.403168 , -10.311728 , ...,  -7.567852 ,\n",
+       "          -7.4912343,  -7.415271 ],\n",
+       "        ...,\n",
+       "        [-12.075015 , -11.977256 , -11.879147 , ...,  -8.828658 ,\n",
+       "          -8.741687 ,  -8.655411 ],\n",
+       "        [-12.152028 , -12.054019 , -11.955642 , ...,  -8.89082  ,\n",
+       "          -8.803341 ,  -8.716557 ],\n",
+       "        [-12.229186 , -12.130933 , -12.032291 , ...,  -8.953173 ,\n",
+       "          -8.865186 ,  -8.77789  ]],\n",
+       "\n",
+       "       [[-10.33175  , -10.240676 , -10.1496315, ...,  -7.428651 ,\n",
+       "          -7.352885 ,  -7.2777696],\n",
+       "        [-10.404974 , -10.313545 , -10.22214  , ...,  -7.4863677,\n",
+       "          -7.410125 ,  -7.334539 ],\n",
+       "        [-10.478385 , -10.38661  , -10.294843 , ...,  -7.544278 ,\n",
+       "          -7.467559 ,  -7.3914957],\n",
+       "...\n",
+       "        [-12.031064 , -11.932126 , -11.832861 , ...,  -8.757732 ,\n",
+       "          -8.67036  ,  -8.583699 ],\n",
+       "        [-12.108336 , -12.009143 , -11.909598 , ...,  -8.819904 ,\n",
+       "          -8.732018 ,  -8.644845 ],\n",
+       "        [-12.185753 , -12.086307 , -11.986494 , ...,  -8.882268 ,\n",
+       "          -8.793872 ,  -8.706183 ]],\n",
+       "\n",
+       "       [[-10.232278 , -10.139207 , -10.046215 , ...,  -7.2860804,\n",
+       "          -7.209724 ,  -7.134047 ],\n",
+       "        [-10.305912 , -10.212475 , -10.1191025, ...,  -7.3437657,\n",
+       "          -7.266925 ,  -7.190769 ],\n",
+       "        [-10.379741 , -10.285938 , -10.192191 , ...,  -7.4016457,\n",
+       "          -7.3243194,  -7.247679 ],\n",
+       "        ...,\n",
+       "        [-11.971619 , -11.871098 , -11.770274 , ...,  -8.662298 ,\n",
+       "          -8.574401 ,  -8.487237 ],\n",
+       "        [-12.049238 , -11.948448 , -11.847338 , ...,  -8.72448  ,\n",
+       "          -8.636063 ,  -8.548382 ],\n",
+       "        [-12.127005 , -12.025955 , -11.924563 , ...,  -8.786858 ,\n",
+       "          -8.69792  ,  -8.609719 ]]], dtype=float32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-97bbc948-1004-436f-9b94-ee1bc5404d1c' class='xr-section-summary-in' type='checkbox'  ><label for='section-97bbc948-1004-436f-9b94-ee1bc5404d1c' class='xr-section-summary' >Indexes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>longitude</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-1361d979-321f-4700-828a-5f626640ef98' class='xr-index-data-in' type='checkbox'/><label for='index-1361d979-321f-4700-828a-5f626640ef98' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Float64Index([             -119.2, -119.10000000000001,              -119.0,\n",
+       "                           -118.9,              -118.8,              -118.7,\n",
+       "              -118.60000000000001,              -118.5,              -118.4,\n",
+       "                           -118.3,              -118.2, -118.10000000000001,\n",
+       "                           -118.0,              -117.9,              -117.8,\n",
+       "                           -117.7, -117.60000000000001,              -117.5,\n",
+       "                           -117.4,              -117.3,              -117.2,\n",
+       "              -117.10000000000001,              -117.0,              -116.9,\n",
+       "                           -116.8,              -116.7, -116.60000000000001,\n",
+       "                           -116.5,              -116.4,              -116.3,\n",
+       "                           -116.2, -116.10000000000001,              -116.0,\n",
+       "                           -115.9,              -115.8,              -115.7,\n",
+       "              -115.60000000000001],\n",
+       "             dtype=&#x27;float64&#x27;, name=&#x27;longitude&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>latitude</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-ce37abc4-f091-466a-ade2-720c9f77aabd' class='xr-index-data-in' type='checkbox'/><label for='index-ce37abc4-f091-466a-ade2-720c9f77aabd' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Float64Index([              35.7,               35.6,               35.5,\n",
+       "              35.400000000000006, 35.300000000000004,               35.2,\n",
+       "                            35.1,               35.0, 34.900000000000006,\n",
+       "              34.800000000000004,               34.7,               34.6,\n",
+       "                            34.5, 34.400000000000006, 34.300000000000004,\n",
+       "                            34.2,               34.1,               34.0,\n",
+       "              33.900000000000006, 33.800000000000004,               33.7,\n",
+       "                            33.6,               33.5, 33.400000000000006,\n",
+       "              33.300000000000004,               33.2],\n",
+       "             dtype=&#x27;float64&#x27;, name=&#x27;latitude&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>height</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-054324d9-c41d-4ba5-bc34-6d1620de11ba' class='xr-index-data-in' type='checkbox'/><label for='index-054324d9-c41d-4ba5-bc34-6d1620de11ba' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Float64Index([-1500.0, 0.0, 3000.0, 9000.0], dtype=&#x27;float64&#x27;, name=&#x27;height&#x27;))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-43571e71-8729-474e-a97f-1d613f7caf2d' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-43571e71-8729-474e-a97f-1d613f7caf2d' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
+      ],
+      "text/plain": [
+       "<xarray.Dataset>\n",
+       "Dimensions:         (height: 4, latitude: 26, longitude: 37)\n",
+       "Coordinates:\n",
+       "  * longitude       (longitude) float64 -119.2 -119.1 -119.0 ... -115.7 -115.6\n",
+       "  * latitude        (latitude) float64 35.7 35.6 35.5 35.4 ... 33.4 33.3 33.2\n",
+       "  * height          (height) float64 -1.5e+03 0.0 3e+03 9e+03\n",
+       "    spatial_ref     int64 0\n",
+       "Data variables:\n",
+       "    solidEarthTide  (height, latitude, longitude) float32 -10.35 ... -8.61"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "set_ds_sec = compute_solid_earth_tide_from_gunw(gunw_path, 'secondary')\n",
+    "set_ds_sec"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8ba88428",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-02-28T20:36:39.668748Z",
+     "start_time": "2023-02-28T20:36:39.238837Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/cmarshak/mambaforge/envs/topsapp_env/lib/python3.9/site-packages/pysolid/grid.py:93: UserWarning: Input line 1 contained no data and will not be counted towards `max_rows=1062`.  This differs from the behaviour in NumPy <=1.22 which counted lines rather than rows.  If desired, the previous behaviour can be achieved by using `itertools.islice`.\n",
+      "Please see the 1.23 release notes for an example on how to do this.  If you wish to ignore this warning, use `warnings.filterwarnings`.  This warning is expected to be removed in the future and is given only once per `loadtxt` call.\n",
+      "  fc = np.loadtxt(txt_file,\n",
+      "/Users/cmarshak/mambaforge/envs/topsapp_env/lib/python3.9/site-packages/pysolid/grid.py:93: UserWarning: Input line 1 contained no data and will not be counted towards `max_rows=1062`.  This differs from the behaviour in NumPy <=1.22 which counted lines rather than rows.  If desired, the previous behaviour can be achieved by using `itertools.islice`.\n",
+      "Please see the 1.23 release notes for an example on how to do this.  If you wish to ignore this warning, use `warnings.filterwarnings`.  This warning is expected to be removed in the future and is given only once per `loadtxt` call.\n",
+      "  fc = np.loadtxt(txt_file,\n"
+     ]
+    },
+    {
      "data": {
       "text/plain": [
        "PosixPath('S1-GUNW-A-R-064-tops-20210723_20210711-015001-35393N_33512N-PP-6267-v2_0_4.nc')"
       ]
      },
+     "execution_count": 5,
      "metadata": {},
-     "execution_count": 4
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-02-07T02:10:14.391162Z",
-     "start_time": "2023-02-07T02:10:14.200716Z"
-    }
-   }
+   "source": [
+    "update_gunw_with_solid_earth_tide(gunw_path, 'reference')\n",
+    "update_gunw_with_solid_earth_tide(gunw_path, 'secondary')"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "source": [
-    "import geopandas as gpd\n",
-    "df_world = gpd.read_file(gpd.datasets.get_path('naturalearth_lowres'))\n",
-    "xmin, ymin, xmax, ymax = set_ds.rio.bounds()\n",
-    "\n",
-    "s = set_ds['solidEarthTide'].plot.imshow(col='height', \n",
-    "                                         col_wrap=4, \n",
-    "                                         extent=[xmin, ymin, xmax, ymax])\n",
-    "[df_world.boundary.plot(ax=ax, color='black') for ax in s.axes[0]]\n",
-    "[ax.set_ylim(ymin, ymax) for ax in s.axes[0]]\n",
-    "[ax.set_xlim(xmin, xmax) for ax in s.axes[0]]"
-   ],
+   "execution_count": 6,
+   "id": "894408de",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-02-28T20:36:40.862334Z",
+     "start_time": "2023-02-28T20:36:39.670917Z"
+    },
+    "scrolled": true
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stderr",
+     "output_type": "stream",
      "text": [
-      "/var/folders/13/168512yn66d8nmvt7g6jsybh0000gq/T/ipykernel_59692/183130835.py:8: DeprecationWarning: self.axes is deprecated since 2022.11 in order to align with matplotlibs plt.subplots, use self.axs instead.\n",
+      "/var/folders/s6/fbsc26cd0ddffbp3_knts_9c0wcxj1/T/ipykernel_39361/89806542.py:8: DeprecationWarning: self.axes is deprecated since 2022.11 in order to align with matplotlibs plt.subplots, use self.axs instead.\n",
       "  [df_world.boundary.plot(ax=ax, color='black') for ax in s.axes[0]]\n",
-      "/var/folders/13/168512yn66d8nmvt7g6jsybh0000gq/T/ipykernel_59692/183130835.py:9: DeprecationWarning: self.axes is deprecated since 2022.11 in order to align with matplotlibs plt.subplots, use self.axs instead.\n",
+      "/var/folders/s6/fbsc26cd0ddffbp3_knts_9c0wcxj1/T/ipykernel_39361/89806542.py:9: DeprecationWarning: self.axes is deprecated since 2022.11 in order to align with matplotlibs plt.subplots, use self.axs instead.\n",
       "  [ax.set_ylim(ymin, ymax) for ax in s.axes[0]]\n",
-      "/var/folders/13/168512yn66d8nmvt7g6jsybh0000gq/T/ipykernel_59692/183130835.py:10: DeprecationWarning: self.axes is deprecated since 2022.11 in order to align with matplotlibs plt.subplots, use self.axs instead.\n",
+      "/var/folders/s6/fbsc26cd0ddffbp3_knts_9c0wcxj1/T/ipykernel_39361/89806542.py:10: DeprecationWarning: self.axes is deprecated since 2022.11 in order to align with matplotlibs plt.subplots, use self.axs instead.\n",
       "  [ax.set_xlim(xmin, xmax) for ax in s.axes[0]]\n"
      ]
     },
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "[(-119.25, -115.55000000000001),\n",
@@ -592,139 +1081,180 @@
        " (-119.25, -115.55000000000001)]"
       ]
      },
+     "execution_count": 6,
      "metadata": {},
-     "execution_count": 5
+     "output_type": "execute_result"
     },
     {
-     "output_type": "display_data",
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABIAAAAD8CAYAAAAPB9/zAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/P9b71AAAACXBIWXMAAA9hAAAPYQGoP6dpAAB//klEQVR4nO3dd3gU1f4G8Hd2N733QiChCFIEQlGwASogoiJYULkCYvenCBZQLBQVBAvoRcGK4PXaBRtSRBBBQVoUBUEgJAHSey+78/sjZC8heyY7k8m2vB+f80imnHNmk++cycnMfCVZlmUQEREREREREZHHMji7A0RERERERERE1Lo4AURERERERERE5OE4AURERERERERE5OE4AURERERERERE5OE4AURERERERERE5OE4AURERERERERE5OE4AURERERERERE5OE4AURERERERERE5OE4AURERERERERE5OE4AURERERERERE5OE4AUREREREREREpMLWrVtxzTXXID4+HpIkYc2aNY3Wl5WV4YEHHkBCQgL8/PzQvXt3LFu2zDmdPY0TQEREREREREREKpSXl6NPnz5YunSpzfXTp0/HunXr8J///AcHDx7E9OnT8eCDD+Krr75ycE//R5JlWXZa60REREREREREraSqqgo1NTV2bevt7Q1fX1/VbUiShNWrV+O6666zLuvVqxfGjx+Pp59+2rqsf//+uOqqq/Dss8+qbkMPJqe0SkRERERERETUiqqqqtAxMRBZOWa7to+NjcXvv//eaBLIx8cHPj4+qtu++OKL8fXXX2PKlCmIj4/Hli1bcPjwYbz66quq69ILJ4CIiIiIiIiIyOPU1NQgK8eM1D2JCA5SfgNOSakFHfunISYmptHy2bNnY86cOarbfu2113DXXXchISEBJpMJBoMB77zzDi6++GLVdemFE0BERERERERE5LECAuuLEvPpl+NkZGQgODjYulzL3T9A/QTQjh078PXXXyMxMRFbt27F/fffj7i4OFxxxRWa6mwpTgARERERERERkceqgxl1UH79cR0sAIDg4OBGE0BaVFZWYtasWVi9ejVGjx4NAOjduzdSUlLw0ksvOW0CiFnA3MzQoUMxbdq0FtUxZ84c9O3b1+HtEpFj8XxB5NoYo0Seh3FN5JrMsmxX0UttbS1qa2thMDSecjEajbBYLLq1oxYngNqgRx99FJs2bdK9XkmSsGbNGt3rtcfzzz+PCy+8EP7+/ggNDbVrn8mTJ0OSpEZl0KBBrdtRAG+88QY6duwIX19f9O/fHz///HOj9XPmzMG5556LgIAAhIWF4YorrsDOnTtbvV9Etrj7+aK6uhoPPvggIiMjERAQgGuvvRYnTpxodr/m4pTIVbh7jN5zzz3o3Lkz/Pz8EBUVhTFjxuDvv/9u1TZlWcacOXMQHx8PPz8/DB06FH/99ZfT+0XUwN3j+ujRoxg7diyioqIQHByMm266CdnZ2a3aJuOammOBbFdRo6ysDCkpKUhJSQEApKamIiUlBenp6QgODsaQIUPw2GOPYcuWLUhNTcX777+PVatWYezYsa1whPbhBFAbFBgYiIiICGd3Q1c1NTW48cYbcd9996na78orr0RmZqa1rF27tkX9mDNnDiZPnixc/8knn2DatGl48sknsW/fPlxyySUYNWoU0tPTrdt07doVS5cuxf79+7Ft2zYkJSVhxIgRyM3NbVHfiLRw9/PFtGnTsHr1anz88cfYtm0bysrKcPXVV8NsFmeCsCdOiVyFu8do//79sWLFChw8eBDr16+HLMsYMWKEYow2Z/LkyYov61y0aBFeeeUVLF26FLt27UJsbCyGDx+O0tLSVu0Xkb3cOa7Ly8sxYsQISJKEH3/8Edu3b0dNTQ2uueaaFt31wLimlrJAhrmZonYCaPfu3UhOTkZycjIA4OGHH0ZycjKeeeYZAMDHH3+MgQMHYsKECejRowdeeOEFPP/887j33nt1Pz67yeRWhgwZIj/44IPyY489JoeFhckxMTHy7NmzG21TVFQk33XXXXJUVJQcFBQkDxs2TE5JSbGunz17ttynTx/r17W1tfKDDz4oh4SEyOHh4fKMGTPkiRMnymPGjLG73cTERBmAtSQmJrbOB9CMFStWyCEhIXZtO2nSpEbHaEtzn+XZZs+eLU+aNEm4/vzzz5fvvffeRsvOPfdc+fHHHxfuU1xcLAOQf/jhB8W+Ep2trZ8vioqKZC8vL/njjz+2Ljt58qRsMBjkdevWCffTEqdEWrT1GLXl999/lwHIR44csS47ceKEfNNNN8mhoaFyeHi4fO2118qpqanCOiZNmtTkc2xgsVjk2NhY+YUXXrAuq6qqkkNCQuTly5er6heRLW09rtevXy8bDAa5uLjYuqygoEAGIG/cuNG6jHFNjtLwu9ThgzFy5ok4xXL4YIwMoNHPr6fhHUBuaOXKlQgICMDOnTuxaNEizJs3Dxs3bgRQf/vj6NGjkZWVhbVr12LPnj3o168fLr/8chQUFNisb+HChfjwww+xYsUKbN++HSUlJTZvD1Vqd9euXQCAFStWIDMz0/q1LT179kRgYKCw9OzZs4WfkP22bNmC6OhodO3aFXfddRdycnKs67R8lkpqamqwZ88ejBgxotHyESNG4JdffhHu89ZbbyEkJAR9+vRR3SZRWz5f7NmzB7W1tY1iLj4+Hr169VKMObVxStQSbTlGz1ZeXo4VK1agY8eOaN++PQCgoqICw4YNQ2BgILZu3Ypt27YhMDAQV155JWpqauyuu0FqaiqysrIaxbiPjw+GDBkijHFb/SJS0pbjurq6GpIkNcqa5OvrC4PBgG3btgFgXJNzWOwsno5ZwNxQ7969MXv2bADAOeecg6VLl2LTpk0YPnw4Nm/ejP379yMnJ8d64n3ppZewZs0afP7557j77rub1Pfvf/8bTzzxhPVZxKVLl9p8FEqp3aioKABAaGgoYmNjFfu/du1a1NbWCtd7eXnZ8Sm03KhRo3DjjTciMTERqampePrpp3HZZZdhz5498PHx0fRZKsnLy4PZbEZMTEyj5TExMcjKymq07Ntvv8XNN9+MiooKxMXFYePGjYiMjGzZAVOb1JbPF1lZWfD29kZYWFij5bZiroGaOCXSQ1uO0QZvvPEGZsyYgfLycpx77rnYuHEjvL29AdTfPm8wGPDOO+9AkiQA9b/AhoaGYsuWLU0ma5vTEMe2YjwtLc3ufhEpactxPWjQIAQEBGDmzJmYP38+ZFnGzJkzYbFYkJmZCYBxTc7R8JhXc9t4Ok4AuaHevXs3+jouLs5658qePXtQVlbW5LnhyspKHD16tEldxcXFyM7Oxvnnn29dZjQa0b9//ybP6Sq1q0ZiYqLqfRrce++9+M9//mP9uqysTHNd48ePt/67V69eGDBgABITE/Hdd99h3Lhxdn2WP//8M0aNGmVdV1NTA1mW8fnnn1uXzZo1C7NmzbJ+3TDQNZBlucmyYcOGISUlBXl5eXj77bdx0003YefOnYiOjtZ8vNQ2teXzhYitmDubPXFKpAfGKDBhwgQMHz4cmZmZeOmll3DTTTdh+/bt8PX1xZ49e3DkyBEEBQU12qeqqsr6GXz44Ye45557rOsa7kB46aWXrMvefPNNTJgwwfq1PTGu1C8iJW05rqOiovDZZ5/hvvvuw2uvvQaDwYBbbrkF/fr1g9FoBADGNTmFWa4vzW3j6TgB5IbOnnWXJMk6AFgsFsTFxWHLli1N9lPKjmXrhKmmXTV69uzZZDb+TImJiU3e2t9g3rx5ePTRR1W3aY+4uDgkJibin3/+AWDfZzlgwADrW98B4LXXXsPJkyexcOFC67Lw8HAAQGRkJIxGY5O7CHJycpr8xSIgIABdunRBly5dMGjQIJxzzjl499138cQTT+hwpNSWtOXzRWxsLGpqalBYWNjoLqCcnBxceOGFNvdRE6dEemjLMdogJCQEISEhOOecczBo0CCEhYVh9erVuOWWW2CxWNC/f398+OGHTfZruKPh2muvxQUXXGBdPnPmTLRr1w5Tp061LmuI34Y7H7KyshAXF2ddbyvGlfpFpKStx/WIESNw9OhR5OXlwWQyWe866tixIwAwrskp6iChFsp/zKtrZr0n4ASQh+nXrx+ysrJgMpmQlJTU7PYhISGIiYnBb7/9hksuuQQAYDabsW/fPvTt21dV215eXna9Rb8lt5VGR0e32l0w+fn5yMjIsA4c9nyWfn5+6NKli/Xr8PBwlJSUNFrWwNvbG/3798fGjRsbpf7buHEjxowZo9g3WZZRXV2t4aiIxDz9fNG/f394eXlh48aNuOmmmwAAmZmZ+PPPP7Fo0SKb+7QkTon05ukxKnLmmNevXz988skniI6ORnBwsM3tg4KCGt1JEBQUhPDwcJtjcceOHREbG4uNGzdas7bU1NTgp59+avTHm+b6RaRVW4rrhtcX/Pjjj8jJycG1114LgHFNzmGR60tz23g6TgB5mCuuuAKDBw/Gddddh4ULF6Jbt244deoU1q5di+uuuw4DBgxoss+DDz6IBQsWoEuXLjj33HPx73//G4WFhaofd0hKSsKmTZtw0UUXwcfHp8l7Nxq0xiMd6enpKCgoQHp6Osxms/WunC5duiAwMBAAcO6552LBggUYO3YsysrKMGfOHFx//fWIi4vD8ePHMWvWLERGRlp/6dPyWTbn4Ycfxm233YYBAwZg8ODBeOutt5Cenm5NBVheXo7nn38e1157LeLi4pCfn4833ngDJ06cwI033qjPh0V0mqefL0JCQnDHHXfgkUceQUREBMLDw/Hoo4/ivPPOwxVXXGHd7vLLL8fYsWPxwAMPAGg+TokcxdNj9NixY/jkk08wYsQIREVFWe+g9fPzw1VXXQWg/nGNF198EWPGjMG8efOQkJCA9PR0fPnll3jssceQkJCgqk1JkjBt2jTMnz8f55xzDs455xzMnz8f/v7+uPXWW+3uF5FWnh7XQP37fLp3746oqCj8+uuveOihhzB9+nR069YNAOOanMMMCeZm7vBpbr0n4ASQh5EkCWvXrsWTTz6JKVOmIDc3F7Gxsbj00kuFjy/MnDkTWVlZmDhxIoxGI+6++26MHDnS+pyuvV5++WU8/PDDePvtt9GuXTscP35chyOyzzPPPIOVK1dav26Y/d+8eTOGDh0KADh06BCKi4sB1D87vX//fqxatQpFRUWIi4vDsGHD8Mknn1j/2qDls2zO+PHjkZ+fj3nz5iEzMxO9evXC2rVrrQOt0WjE33//jZUrVyIvLw8REREYOHAgfv75Z4dmR6O2oS2cLxYvXgyTyYSbbroJlZWVuPzyy/H+++836m/DbeoNmotTIkfx9Bj19fXFzz//jCVLlqCwsBAxMTG49NJL8csvv1jv9vX398fWrVsxc+ZMjBs3DqWlpWjXrh0uv/xy4Z0DzZkxYwYqKytx//33o7CwEBdccAE2bNhgHf/t6ReRVp4e10D9NfcTTzyBgoICJCUl4cknn8T06dOt6xnX5AycAKonybYeIKU2zWKxoHv37rjpppvw7LPPOrs7ROTCeL4gcm2MUSLPw7gmsl9JSQlCQkLw05/tEBhkUNy2rNSCIb1Oori4WPNkpKvjHUCEtLQ0bNiwAUOGDEF1dTWWLl2K1NRU6y2TREQNeL4gcm2MUSLPw7gmajkzDDBDeQKo+TdkuT/lT4DaBIPBgPfffx8DBw7ERRddhP379+OHH35A9+7dnd01InIxPF8QuTbGKJHnYVwTtZwsS7A0U2SZj4AREREREREREbmdhkfANuxPREAzj4CVl1ow4rw0PgJGREREREREROSOzLIBZrmZR8DawK0xnAAiIiIiIiIiIo9VCwNqoZw5r9ZBfXEmTgARERERERERkcey7w4gz78FyOMngCwWC06dOoWgoCBIkue/1InIHciyjNLSUsTHx8NgUP8uesY1kethXBN5HsY1kedpaVy7KwskWKB8HmpuvSfw+AmgU6dOoX379s7uBhHZkJGRgYSEBNX7Ma6JXBfjmsjzMK6JPI/WuHZXFjvSwFvg/DuAwsPDVW0vSRL27t2LxMREu7b3+AmgoKAgAMDmnVEIDGz8DS+2eNvcp8jsJ6yv0BJoc3mxYJ/CugCby0sU2iiu9bW5vKzO9vISwfYVtV7CNipqbR97ZY3tfWqqbT8vaa4VP0dpqRGsq7EdeIZawfJq8UysoUawvNb2PqLtjdXCJmCssX0iENVlqhZsr/BQqbHaos/yqjphG4Zqs83lUrXtjklVgg+lSnDgAOTKSpvLLZWN66qTa/Fz3RprfKqlJa4LzbZjEQCKLP42lzsirkvqbO9TVutjc3l5je3jA8RxXVVr+1Qvius6wfYAIAviVxjXouVKcS2IFUON7X2MovOA+EdVGNeic4H4PCC+UDBVic4FtuPXVGU7RkWxCwAGQcxLVYK4rrZ9gLJCXKOqyuZiS0XjeK+Ta/Gz+esWx/WmHdEIOCuuSyy246HYIo65AovtOC0y2473ojrby0UxCgDFtYL4Ndvub2mN7eVlguUAUFVne1wWjde1wrgWj9eyYLyWBPErCWNRHNeSME7VxbXSeG2oVRfXJg1xbRTEtVEQ18ZKUVwrjdcq41owXivFtVxZYXO5rfF6m/xNi+N6446YJnFdLIjrAoXxWhTzhWbb1+ei+BXFOwCUCsbfEsF1uCh+ywRjMgBUCa7Rq2psj7+1guVm0bU2IByXRXEtikXRckA8lovGcWFcK43XoutqYV2i84BCXKu+DtcQ18LxWnCCqrZ9gHKl7TG5fp3gOvysNupQi21Yqzmu3VWtbEKt3Mw7gFwgDXxRURGWLFmCkJCQZreVZRn3338/zGbxteLZPH4CqOF208BAAwLPSvtWZ7F9Aqw1i38wqgXrasy2P8pKwYVbtVk8OeMtGDC8VC43KQw8RsEvkUaT7X4ZjLaPT1a4oIRRsM4oGHhEyxVuGRbdtWg0CAYkQVVKpwKjYCZYNH9sFDw7qtiGRTDAmFUuNykMPHWCgUfwuUuiA1SYOJcl2ycfi2S7v1pvB9cS16LYBYAad4prL/EvisK4FkzoiOLaILjQBABZ8PMijGtBkCrGtejUIdjHKKhKFO+AOK6NgutD8fYKE0CCVBIGWTABZBJcUCoM6gaj4BdClXGt+Ei8IH4tkuCc0sK4DrAR12bReG0Rx3WlIH6rBctFEy3VguWAQlzXqYtfxbgW/KIoGq/NwrhWmAASjNfinyPBGKsQdKLxWnQuEMW10lhqkFTGtWi8VohroyCujYK4NgrjWmm8bv24lgXxa3O8llsnrkXjdZXieC0Yl0XxLohfby1xrXJcVr4OVxnXJsF1uOhaGxCOy6KfI1H8KsW1aFwWXp9ruQ4XxKPox9skimuLQlyrvg4XxLUgdgHAIDrPCq+3bX9YsmBMrl9n53X46Y+irT2WaZYlmJuZ4GluvaPcfPPNiI6OtmvbBx98UFXdHj8BRERERERERERtl9mOR8DMLvAImEUwISlSWlqqantOABERERERERGRx7LIBliayQJmaQNZwNrOa7+JiIiIiIiIqM2phQE1slGx1LrY9MjKlSvx3XffWb+eMWMGQkNDceGFFyItLU1TnW3mDiAj5CbvcBC+00Hh2UqDYJ3wuXPB9kaI2zAK6hK1IVquRLSPJFwuqEjpMUmV+wgfudTShtrtFeqRRQcv+KyE2yvdUijsl6htQQsKz/KK1gn30PJcsOg58bOX6/R8rZq4NijEnCiuhe2q3L5+H1G/1MW1KEaV1qmNa6U2hGvUxpYjzh0KRPEgqz2fKsWcQVCXsG11yxXbF8Wi6DygdBzCts++SNLnoskoyU3iRTj2Ko2lgnWi5WpjUalf4u31G8eFcSpcrroJYTyIfl40/d1Uz3jXqS5NbYhoCQu146+9Y2+jdfa930mSJSiEmd0MkJvEmJbrcNFYqrYupetwEdXXzgp1qR6vhfWI23Cn8Vop5tT+fqDr7xOqf89Qf6KVBXEqrElDXFM9CwywNJsFzLU+w/nz52PZsmUAgF9//RVLly7FkiVL8O2332L69On48ssvVdfZZiaAiIiIiIiIiKjtMcsGmJt5BKy59Y6WkZGBLl26AADWrFmDG264AXfffTcuuugiDB06VFOdrnWEREREREREREQ6skCyq7iSwMBA5OfnAwA2bNiAK664AgDg6+uLyspKTXXyDiAiIiIiIiIi8lg1sglGWXn6o8bF3gE9fPhw3HnnnUhOTsbhw4cxevRoAMBff/2FpKQkTXXyDiAiIiIiIiIi8lgWWbKruJLXX38dgwcPRm5uLr744gtEREQAAPbs2YNbbrlFU528A4iIiIiIiIiIPJYFBpjd7CXQoaGhWLp0aZPlc+fO1Vxnm5kAktD0didRxgAlwiwDoqwiKrOGAUqZSPTLXKI+y4DK7GCKlSnsY4OWbBxqJ291zfihKcOBXhmJ1G1ev4+6bEGK3/QmWYFal624FlHMKqIyhkSxqJRVRG2castIpO7nRZxFSGkndcs1ZeMQUF2XrsehIUb1ylKoQLfsfkpx7cLZ/ZQ4NWunu2X3E54L1GWiVM6oqW4fp547lOoSDDri7EYaMnTpOS4LmxCd05yf3U8p3lVfb+s4luq1XInq+NUyBukYc6pP+3qO1yq315YxVGVdWrLxOiDem+4jaUzb6N4ssgGWZl7y3Nx6ZygqKsJvv/2GnJwcWCz/O9dJkoTbbrtNdX1tZgKIiIiIiIiIiNoeMySYm5lRbG69o33zzTeYMGECysvLERQU1GjCUOsEkOtNcRERERERERER6aRWNqBWNjZTXGt65JFHHsGUKVNQWlqKoqIiFBYWWktBQYGmOnkHEBERERERERF5LHd8BOzkyZOYOnUq/P39davTtY6QiIiIiIiIiEhHZtlgV3ElI0eOxO7du3Wtk3cAEREREREREZHHkiHB0sw7fmQXewfQ6NGj8dhjj+HAgQM477zz4OXl1Wj9tddeq7pOTgARERERERERkceqtRhhsBib2Uac+dMZ7rrrLgDAvHnzmqyTJAlms1l1nW1mAsgo1ZczCVPBKqWfFKWsVJnKUikltSiVpdrttaSfFKeoVV2VcmpKVdsrpVRUt4umVLBOTF2rNiW1cipnURsqO2ZQf2vk2Sku9ZpbtxXXwpjTEteCdLNq08bXr1OXulZcj4Z00cLt1S1XrEy4ve0+CX+GNbShOk2rEl1TT6tLHS+Oa4VG1Ma1pvSxthtprbiW0PSwtIylalPHq41FQH2KaT1TUouI00Ur7aSqCX3HUrXbK6akFv3c6xhzws9X3QEqngNFlFLH2yBMLw1AVllXSxkh2x2TBsHYCyiljtdvLNUrpbxyG7aXq0737oj06Yr7aBjjbW6vfp36FO1KbQhWir9R4spE1F4+65LuvWH52Y0b2mQaeDMMMDfzjWhuvaNZWmFCqs1MABERERERERFR22ORJVia+etgc+s9ASeAiIiIiIiIiMhjWWCApZk7fJpb7wzl5eX46aefkJ6ejpqamkbrpk6dqro+TgARERERERERkceqtRhgsChP8NQ2s97R9u3bh6uuugoVFRUoLy9HeHg48vLy4O/vj+joaE0TQK51hEREREREREREOpJlAyzNFNnF0sBPnz4d11xzDQoKCuDn54cdO3YgLS0N/fv3x0svvaSpTtc6QiIiIiIiIiIiHZkh2VVcSUpKCh555BEYjUYYjUZUV1ejffv2WLRoEWbNmqWpzjbzCJgB9s92KWUCUcpMoLYu8T6ibCf6ZBtR2keYRUhtVgIlajNoKLWhJYOHSnplGFLcXm3GAk3ZjVRmZBBkPlDKKiLMlnB25rBWnF0XZ+NQH4uiDEPCLCSa2lDXXy1xrTojoGLMqa1LfT2aMvOo3d6ZWY9UH4eOmUBElLL7OTpbkI3sfsJtmd3PxvbqlitXJlquX3Y/h4ylKrfX8g5Q1ecIDRmJhOOvnln/zo53nV6Iqld2PxHxtbP6rGGicVlt28Jr52bW2d5efT3ijJOic4r6sVfPn3shnerS9dwhGDKV2lAdv8IMZErjNe/tUGKRm3/Js8XFsqN5eXlZf3ZiYmKQnp6O7t27IyQkBOnp6ZrqbDMTQERERERERETU9tTJRhhkY7PbuJLk5GTs3r0bXbt2xbBhw/DMM88gLy8PH3zwAc477zxNdXKakIiIiIiIiIg8llmW7CquZP78+YiLiwMAPPvss4iIiMB9992HnJwcvPXWW5rq5B1AREREREREROSxGl703Nw2rmTAgAHWf0dFRWHt2rUtrtO1jpCIiIiIiIiISEcWSLDIzRSVL4TaunUrrrnmGsTHx0OSJKxZs6bRekmSbJYXX3xRxyNTh3cAEREREREREZHHktH8BI+scgKovLwcffr0we23347rr7++yfrMzMxGX3///fe44447bG7boF+/fti0aRPCwsKQnJysmIBn7969qvoLtPEJIGH2AcXMAKLMPCqziihlLhHUpbSPLYrZB1TVpD4LSf0+tpc7ImOA2jY0Pe7piP6q3F45w4HtlaqzjSjRsk8L2MrupyWuRfGrOuuflgxdGjIPiYizAqnM+qfUhvBnT9RfDRm9HJDxQ3UMOfHcoWdci7KKaIr3VsruZyuutWT3E47LzO6nbp1ObajN7ufczHviVeJMZxoyo4moDSVN47XtRs4+F7TmqC4er5WukdWN8eJMfQoxp3Jc1jKO65eNV9iEgzLMqluuJa5FMSS87tByHa4hq5dNWrJmqs7aqb4N6ax9JFmCyktcj1BnMUKyNPMS6GbWn23UqFEYNWqUcH1sbGyjr7/66isMGzYMnTp1Eu4zZswY+Pj4AACuu+46Vf2xR5ueACIiIiIiIiIiz9bwmFdz2wBASUlJo+U+Pj7WSRmtsrOz8d1332HlypWK282ePdvmv/XCdwARERERERERkceynH4ErLkCAO3bt0dISIi1LFiwoMXtr1y5EkFBQRg3blyL62oJ3gFERERERERERB5LzR1AGRkZCA4Oti5v6d0/APDee+9hwoQJ8PX1VdwuLCzM7kfzCwoKVPeDE0BERERERERE5LHqLAZIFuUHoOpOrw8ODm40AdRSP//8Mw4dOoRPPvmk2W2XLFli/Xd+fj6ee+45jBw5EoMHDwYA/Prrr1i/fj2efvppTX3hBBAREREREREReSw1dwDp7d1330X//v3Rp0+fZredNGmS9d/XX3895s2bhwceeMC6bOrUqVi6dCl++OEHTJ8+XXVf2swEkPF0OZPorf1K2QeE9avMoKElq4jaTCD6Zh+wXY9SpjHVWUU0ZcBR14SeWUX0yiKk3IbKA3TZbCNn76PPyVVNXCvWI8z+o+4coRTXSlnIbFEbo1r2UYxfEbVZN3TMKqIptlS2oW+2IHVVacso5oBzhIOz+9miJbufSFvN7qfYhtrsfpp+jlQu10DtuKwto6Zeyx2RLUhhgNeSragFjFJ9adwF/cZr4fYargnEmcP0GccBbVk4bdejtFLdcj3HWEdk/FV97azYhrpznTgzmUIjDhivRY8NyU2y/rXN1wDLgB1p4NUpKyvDkSNHrF+npqYiJSUF4eHh6NChA4D6F0p/9tlnePnll1XWDqxfvx4LFy5ssnzkyJF4/PHHVdcHtNXvPhERERERERG1CQ13ADVX1Ni9ezeSk5ORnJwMAHj44YeRnJyMZ555xrrNxx9/DFmWccstt6juc0REBFavXt1k+Zo1axAREaG6PqAN3QFERERERERERG1PncUA2PkOIHsNHToUsqx839Ddd9+Nu+++W1W9DebOnYs77rgDW7Zssb4DaMeOHVi3bh3eeecdTXVyAoiIiIiIiIiIPJYz3wGk1eTJk9G9e3e89tpr+PLLLyHLMnr06IHt27fjggsu0FQnJ4CIiIiIiIiIyGPJsgS5mQme5tY7wwUXXIAPP/xQt/qc+g6gZcuWoXfv3tY0a4MHD8b3339vXT958mRIktSoDBo0yIk9JiIiIiIiIiJ3YoFkV3FVlZWVKCkpaVS0cOodQAkJCXjhhRfQpUsXAMDKlSsxZswY7Nu3Dz179gQAXHnllVixYoV1H29vb6f0lYiIiIiIiIjcjzs+AlZRUYEZM2bg008/RX5+fpP1ZrNZdZ1OnQC65pprGn39/PPPY9myZdixY4d1AsjHxwexsbEtbssoSTCelRpPbep2QH0qWmEqSS1pZYVpKbWkuBS1obIixTTwKperrQcKqfqE/VKfGlL1eUBLWlmVdQm/UQr39InaF3ZLlH5S6YekSZrJhn3OWi7rc/OhrbgWbqsQc2rTxKpNBVu/j7q00GqXK7dte7kwU6qm9PDqlmuLB9v90pby1TZNaaFF1KaoVfuNUqI2xBRT1woqa7KPPhdNxtPlTEpjprAeQZyKxn7h+K4Q72rT0IviV1vqdnV1afruOCCVs9p00bqOpY5Ib622HkB16mnRuUOUElpRK43XBjQ9LYliTmmMNQhiThSnorqU4loUp6JzhyOuCbR8KxWv0VVsr5zaXF0TmsZYR1yHq91H07lDEKcqx36luJZV/yLXtpgtBkjNvOTZrPIl0K3tsccew+bNm/HGG29g4sSJeP3113Hy5Em8+eabeOGFFzTV6TJHaDab8fHHH6O8vNz6hmsA2LJlC6Kjo9G1a1fcddddyMnJcWIviYiIiIiIiMidNLwDqLniSr755hu88cYbuOGGG2AymXDJJZfgqaeewvz58zW/F8jpL4Hev38/Bg8ejKqqKgQGBmL16tXo0aMHAGDUqFG48cYbkZiYiNTUVDz99NO47LLLsGfPHvj4+Nisr7q6GtXV1davtT4bR0Sug3FN5HkY10Seh3FNRK5KtuMRMFebACooKEDHjh0BAMHBwSgoKAAAXHzxxbjvvvs01en0O4C6deuGlJQU7NixA/fddx8mTZqEAwcOAADGjx+P0aNHo1evXrjmmmvw/fff4/Dhw/juu++E9S1YsAAhISHW0r59e0cdChG1EsY1kedhXBN5HsY1EbkqGYAsN1Oc3cmzdOrUCcePHwcA9OjRA59++imA+juDQkNDNdXp9Akgb29vdOnSBQMGDMCCBQvQp08fvPrqqza3jYuLQ2JiIv755x9hfU888QSKi4utJSMjo7W6TkQOwrgm8jyMayLPw7gmIldllg12FVdy++234/fffwdQf35944034OPjg+nTp+Oxxx7TVKfTHwE7myzLjW4dPVN+fj4yMjIQFxcn3N/Hx0f4eBgRuSfGNZHnYVwTeR7GNRG5KossQXKzLGDTp0+3/nvYsGH4+++/sXv3bnTu3Bl9+vTRVKdTJ4BmzZqFUaNGoX379igtLcXHH3+MLVu2YN26dSgrK8OcOXNw/fXXIy4uDsePH8esWbMQGRmJsWPHqm7LVvYB4bYasg+IiDKEaMk+IO6T+mxBqrOH6JihRFa5XFJ61b4D3trvkGxmemYPEVGfCkq/NhxIzywdwvgVZf3TMbuf2nqaW2eLMK61ZPcTEMa1UhYLdU1oilHV5whHZCQS0ZLdT21ca4ldZvdzSHY/tVk7NWX3E54LRNvbXqxnJh9N47gj2hDWJcrcpb4u1eOvlvFaU1op7Wxl9xNvq5B5T5hdVzReC+JHw4Meaq+3ldoQ/uipvQ7XlLVTVJfo5CFuQ7csnFriWtfrcNHK1s8+6pB4P3vAcLFJDkdpeMyruW1cRW1tLUaMGIE333wTXbt2BQB06NABHTp0aFG9Tp0Ays7Oxm233YbMzEyEhISgd+/eWLduHYYPH47Kykrs378fq1atQlFREeLi4jBs2DB88sknCAoKcma3iYiIiIiIiMhN2JPly5VeAu3l5YU///xT8Y+mWjh1Aujdd98VrvPz88P69esd2BsiIiIiIiIi8jRmiwGwKN+tbG5mvaNNnDgR7777Ll544QXd6nS5dwAREREREREREenF3R4BA4Camhq888472LhxIwYMGICAgIBG61955RXVdXICiIiIiIiIiIg8Vv0EUHOPgDmoM3b6888/0a9fPwDA4cOHG63T+mgYJ4CIiIiIiIiIyGO52zuAAGDz5s2619mmJ4BEmQEUs4qIsg8Il6ufRhRnDtMvq4iIaB9xVgLVTah/m78D2tCSuUSc8UNLRgZBXQZ1mRrEWQzUt63b9mg6Q62Y2U0FW9n9tMS1KHuI2qxAStn9xPuoyx6iZ3Y/cT1K69Rl8RMGkKaYU9hH7fYOyBYk2keULEvX7H4ibSi7nzgrELP7NV2nqgl9s/vpeO4QxpwTzx2q07UptC+pfTWF4slcUFmTfVov/kWxpTaDHyA+R4i3V8g0pjLjr9prZyWqs/Qq1mV7uTgWVS7Xuo9KauNa1+ycqjONKewgil89s/EK4rrpdXjb5I5p4FuDa73liIiIiIiIiIhIT7KdxcnGjRuHkpISu7efMGECcnJy7N5e8wTQzz//jH/9618YPHgwTp48CQD44IMPsG3bNq1VEhERERERERHp6/QjYEpF2y1k+vrqq6+Qm5uLkpKSZktxcTG++eYblJWV2V2/pkfAvvjiC9x2222YMGEC9u3bh+rqagBAaWkp5s+fj7Vr12qploiIiIiIiIhIV+6SBUyWZXTt2rXV6tc0AfTcc89h+fLlmDhxIj7++GPr8gsvvBDz5s3TrXNERERERERERC3hLi+B1vLi53bt2tm9raYJoEOHDuHSSy9tsjw4OBhFRUVaqiQiIiIiIiIi0p1skSBbmpkAama9IwwZMqRV69c0ARQXF4cjR44gKSmp0fJt27ahU6dOevRLd0ZIMJ71znNdsw+o3EdthhBAOROJ2u1VZxURLdcxq4ieGbpEtGTyUd22yqxhp9eqa0NEMTuKyso0ZP4RZYCRz65Lp9l1W3Gt5e1tomwgorjWkvlHbYYhPbP4qc/upyGunRhberYhjhNR9jOlLDuiFczup0Sv7H7C+pndz+66VGf3U+yA7cXOHJe1tKFbf7W8hVNttiAtGfwMZ3VMlLZQJaMkwXhWP9Vm7gKUzgUqs/Rqyu6nXzZe9dn9RMuVxmudri2V6BTXjsjc5dTsYIDqcbbJtXNDNWfH6JlcIGunS7PnJc8u8AhYa9N0Vr/nnnvw0EMPYefOnZAkCadOncKHH36IRx99FPfff7/efSQiIiIiIiIi0qS5F0Db84iYJ9B0B9CMGTNQXFyMYcOGoaqqCpdeeil8fHzw6KOP4oEHHtC7j0RERERERERE2rWBO3yao2kCCACef/55PPnkkzhw4AAsFgt69OiBwMBAPftGRERERERERNQi7vIOoNameQIIAPz9/TFgwAC9+kJEREREREREpDMJzb/AyfUmgOrq6rBlyxYcPXoUt956K4KCgnDq1CkEBwdrugHH7gmgcePG2V3pl19+qbojRERERERERES6c8OXQKelpeHKK69Eeno6qqurMXz4cAQFBWHRokWoqqrC8uXLVddp90ugQ0JCrCU4OBibNm3C7t27rev37NmDTZs2ISQkRHUniIiIiIiIiIhahWxncSEPPfQQBgwYgMLCQvj5+VmXjx07Fps2bdJUp913AK1YscL675kzZ+Kmm27C8uXLYTQaAQBmsxn3338/goODNXWktUmSBIOWVLpnEaafFKaRVpdeGlCfYlpTSnmHpJUVrVDVhDiNJRTSI+uVHr6Zdara1rENPVNZij5DUUp3bd90xxHNaivFnNpU0qK4VqI25auW1LUiwjTSqmvSENcOSMfq1DTSCnTrl+K5Q13qeElDiljRuaBJilqdMmcYIcF41kFr+bkXj8tqUzmL412YelpDuncRtSmm1Y7j9Tu18nId29byYyaOE/3SZIuypWsKC7VxqmXsdXC6aAPs/6uzUswZVI6/eo7Xaq+3taSBV/1tUUwDr89ybeO17X5pum7X6xrZAdfhep6fhFVpivezok90wvJw7vgOoG3btmH79u3w9vZutDwxMREnT57UVKem7/57772HRx991Dr5AwBGoxEPP/ww3nvvPU0dISIiIiIiIiLSnRveAWSxWGA2m5ssP3HiBIKCgjTVqWkCqK6uDgcPHmyy/ODBg7BY1M+0ExERERERERG1Clmyr7iQ4cOHY8mSJdavJUlCWVkZZs+ejauuukpTnZqygN1+++2YMmUKjhw5gkGDBgEAduzYgRdeeAG33367po4QEREREREREelNkpWfmmzYxpUsXrwYw4YNQ48ePVBVVYVbb70V//zzDyIjI/HRRx9pqlPTBNBLL72E2NhYLF68GJmZmQCAuLg4zJgxA4888oimjhARERERERER6c4i1ZfmtnEh8fHxSElJwUcffYS9e/fCYrHgjjvuwIQJExq9FFoNTRNABoMBM2bMwIwZM1BSUgIALvvyZyIiIiIiIiJqw9wwDTwA+Pn5YcqUKZgyZYou9WmaADqTO0/8GAUTfMpv7VeZfUBDhi61+xg1ZCtQm6FES+YS4T10et5bp2eWAWEbKpdroTJDl+rjVqL2TWBa2pDObkSf7AO2svtpiWsRYRYhldmFlPZRn1VEIa5VZxoTZRFSVY02WrL7CesS1SPexRHZ/cRtq8xIpET1cbhndj8RZvezsVzl9sqNqFuuGFcOyOSjV4Y9xXOQcJXomkddpj7FdarPjS3P+ifperHTmDCzroZ4EGfKVZe9V4nwelvP+NUzu5+wcdE1pKhthZ9VXToETRm6dM2gq+VcYLMeDWOp6JJY0/W2647XLsFNJoC+/vpru7e99tprVdevaQKoY8eOiieDY8eOaamWiIiIiIiIiEhfbjIBdN111zX6WpIkyLLcZBkAmxnCmqNpAmjatGmNvq6trcW+ffuwbt06PPbYY1qqJCIiIiIiIiLSnz1ZvlwgC9iZWdV/+OEHzJw5E/Pnz8fgwYMhSRJ++eUXPPXUU5g/f76m+jVNAD300EM2l7/++uvYvXu3po4QEREREREREelNstSX5rZxJdOmTcPy5ctx8cUXW5eNHDkS/v7+uPvuu3Hw4EHVderzIo7TRo0ahS+++ELPKomIiIiIiIiI2pSjR48iJCSkyfKQkBAcP35cU526TgB9/vnnCA8P17NKIiIiIiIiIiLNJNS/A12xOLuTZxk4cCCmTZuGzMxM67KsrCw88sgjOP/88zXVqekRsOTk5EYvgZZlGVlZWcjNzcUbb7yhqSOtzQgJxrO+pXrOfhkE2UOEy/XM0KVyeyVqs4doyUogen+4MAOOprfgq1yugdqsBJoeKdUrUxHgkOwhMOg6p9wsW3GthTgzj34ZusT7iDKUqI9rvc4FinGtV3Y/xZ9VHbPcqW3fAVlF1G7P7H7M7qeuLvXZ/XQLLS3Z/XSMOU2Zw1TSrQ0dMwhKBvVZw0TJXOSz69LpfRi2r8N1jF+VdSnFnNqMgHpm0BXHr5a4Foylwh1ULldYp2ssqq3LAVl6IYo5BaLPRFiTpqydgnG4yT6uNs3hIG7yDqAzvffeexg7diwSExPRoUMHAEB6ejq6du2KNWvWaKpT0wTQmDFjGg0cBoMBUVFRGDp0KM4991xNHSEiIiIiIiIi0p3ldGluGxfSpUsX/PHHH9i4cSP+/vtvyLKMHj164IorrlDMyq5E0wTQnDlzNDVGRERERERERORIDY95NbeNq5EkCSNGjMCIESN0qU/TBJDRaERmZiaio6MbLc/Pz0d0dLSmfPRERERERERERLqTofAM5BnbqLB161a8+OKL2LNnDzIzM7F69Wpcd911jbY5ePAgZs6ciZ9++gkWiwU9e/bEp59+an2k62yvvfYa7r77bvj6+uK1115TbH/q1KnqOgyNE0CybPuTqa6uhre3t5YqiYiIiIiIiIj01woTQOXl5ejTpw9uv/12XH/99U3WHz16FBdffDHuuOMOzJ07FyEhITh48CB8fX2FdS5evBgTJkyAr68vFi9eLNxOkqTWnwBqmIGSJAnvvPMOAgMDrevMZjO2bt3KdwARERERERERkcuQLBIki/J7c5pbf7ZRo0Zh1KhRwvVPPvkkrrrqKixatMi6rFOnTop1pqamYuvWrbjwwguRmpqqqj/2UDUB1DADJcsyli9fDqPRaF3n7e2NpKQkLF++XN8eOoFixg/Bm6FEWQm0tKG2bRGl7ANqs3dpyQKm+rVUOmYfENGSlUD1y+Cd2YYC8bGrq6xJhpAzqxKtOHsflSdXNUR5iLTEtbgNDdm+1GYo0XCOEMapyu0V2xDWZXu5MLuf0g+xEzN+6JnFzyHZgpjdT8idsvsp1uVO2f0UO6Ayu58jMvnoeE4RHYf4HKhA9TlCSxY/x2a6sZXdT0R5vFb3eaod3wEtWXdF5xqFrJ1q41e0XDGuVS7XQqfY0jPxkiOu9YXbaxku1caihgxkTcZx2bHjustQcQdQSUlJo8U+Pj7w8fFR1ZzFYsF3332HGTNmYOTIkdi3bx86duyIJ554osljYmcbNmyYzVfu6EHVBFDDDNSwYcPw5ZdfIiwsTPcOERERERERERHpRc1LoNu3b99o+ezZs1UnwsrJyUFZWRleeOEFPPfcc1i4cCHWrVuHcePGYfPmzRgyZIhwX9Erd/Sg6R1Amzdv1rsfRERERERERET6U3EHUEZGBoKDg62L1d79A9TfAQQAY8aMwfTp0wEAffv2xS+//ILly5crTgAB0JzmvTl2TwA9/PDDePbZZxEQEICHH35YcdtXXnmlxR0jIiIiIiIiImoxC9DsU92n1wcHBzeaANIiMjISJpMJPXr0aLS8e/fu2LZtW7P7P/300/D391fcRsu8i90TQPv27UNtbS0AYO/eva02I0VEREREREREpJtWyAKmxNvbGwMHDsShQ4caLT98+DASExOb3X///v2KGda1zsfYPQF05mNfW7Zs0dQYEREREREREZEjqXkHkL3Kyspw5MgR69epqalISUlBeHg4OnTogMceewzjx4/HpZdeimHDhmHdunX45ptv7JpPWb16tfNfAt1gypQpePXVVxEUFNRoeXl5OR588EG89957unROT4bT/53JKNxWv6k/LRk/1GYUU5tJQGkf9VlFlNbplFVEy1v7nZnhQMc2dMtKoNi2KHOJ7eWKs83CbC6SfduppCautRDFoiiuFTOXiOrSMbuf2n20ZPcTEsa7aHv1TYi4anY/1W0zu5+Qp2f30xLXemb3E7ahNrufnneHaxrP1G2uKeufTucOYfYzJWoT92jKDnZ2I62XLcgo6J6WeBCP16KxV/14rTYjoNL2asdlLYTffjfL0KU+hlRmHFRqw6Du+6HYhtrsXZrOEXxCx9F2796NYcOGWb9ueFXOpEmT8P7772Ps2LFYvnw5FixYgKlTp6Jbt2744osvcPHFFyvW25pPW2k6q69cuRKVlZVNlldWVmLVqlUt7hQRERERERERkS5kO4sKQ4cOhSzLTcr7779v3WbKlCn4559/UFlZiZSUFIwZM6b5rrZiFjBVE0AlJSUoLi6GLMsoLS1FSUmJtRQWFmLt2rWtcpuSHnbtrXZ2F4hIZwf/rnF2F4hIZ6lpdc7uAhHpLCvL7OwuEFEbJ8n1L4FWLK0376LKihUrEBIS0ip1q3oELDQ0FJIkQZIkdO3atcl6SZIwd+5c3Tqnp+tvy8W8WaF48J4gvsCayEOMHp+Dl58Px8SbAxjXRB5i9PU5eP2VcIwZrZz5gojcx1Vjc/H2G+EYdqmvs7tCRG2Vg18C3RKTJk2y/vvw4cPYsmULcnJyrKnlGzzzzDOq61Y1AbR582bIsozLLrsMX3zxBcLDw63rvL29kZiYiPj4eNWdcASzGXjy2SL88ls1lr0SgbDQ1nummYgco7oaeODRAmzfUY3FC8IQ4M+4JnJ3pWXAxLsLcO8dNXj2qRB4e3Nyl8jdFRTKuOHWfDw6LQgzpgfBKHoBEBFRK2mNl0C3trfffhv33XcfIiMjERsb2+gP3pIktf4E0JAhQwDUv926ffv2MBjc55etBc+EYvYLRfhufSUuuTITq96MROfzOPgQubPHpwdj0asl+Ojzcuz7owYfvBWJuM7O7hURtcS9dwZg+TvlWP5uGXbtrcaKZREIaefsXhFRS9xykx8++rQSLy4uxW+7avDm0jD4RDi7V0TUprjRHUANnnvuOTz//POYOXOmbnVqmsFJTEyEwWBARUUF/v77b/zxxx+NiiuaeGsgNn0di46JJqRlmDH8umyseL+8VV+wRESt68F7gvHdp9GIjTHi78O1GDIqC1982fQF9UTkPp58NASfvB+B0FAJe/bV4tIrs/HDxipnd4uIWmDBvFC8+e8wBPhL+GlbNYaMyMGOX/l+TiJynGbf/3O6uJLCwkLceOONutapaQIoNzcXV199NYKCgtCzZ08kJyc3Kq6q73ne2Pp9LK4Z5YeaGuDpp0tx3/3FKC21/ztthKyqiBgki7hAtl0kURHVJd5H3C/RPrBZNJFUFg2EL3VvuPfvrCJLEBZhGwr7qC1qPytZkmwWRZJku4gYBEXPNnRw8WBfbF8fi6EX+6CiUsZDDxVjxsxiVFY2/jkXxpXKmNYa1+J9lGJbnyJu23YRfRvri2yzqKYQ88I4UXmOUIw5nc5DmtpQSdu5w/Y30CHnjhYywICrhgdg+/o4DEj2RlGRjDumFGHB86Ww1MowAtaihVGyCIpsuyidD0R1wXYRHrNC/KqNOdH2igUqf1S1xJBOMafl3KE6fhToFu+Kx68y5rTEqMFgu7QSIyTcPC4Am9dGo3s3E7JzLJhwcyHe+HcZYJHtvswQXzvbLqrr0TBei84diseh+lpfdH7Q8O0XXAur3l7h+lnXa3q1bejYtm4xCoVrd73iXWGfhnf4nlnapFbIAtbabrzxRmzYsEHXOlU9AtZg2rRpKCwsxI4dOzBs2DCsXr0a2dnZeO655/Dyyy/r2kG9hYYY8OHbkXjjnVI89VwRvv22Cn/+WYu33gxFjx5ezu4eEWkQHWXEmv9GY+GSYrywuAT//W8lUlJqsXx5KDp11HSaIyIn65BgwvovY/DM80V4/Z1SLF9ejj17avD666GIj9M6/UNEztTtHC9s+jYaj84qwn8/q8CLi8rw2281WPJqKMLD3efVEkTkftzlHUCvvfaa9d9dunTB008/jR07duC8886Dl1fj+YqpU6eqrl/Tb0Y//vgjvvrqKwwcOBAGgwGJiYkYPnw4goODsWDBAowePVpLtQ4jSRL+765gdE824P77i3D8uBnXXJuPuXODceMNfgDngYjcjtEoYdYjoTivvxEPTi3GgQN1uOqqfCxaGIxRo3y13y5ARE7j7S3hhblh6D3QiEcfLcauXbW48so8LF4ciiGXemu8j5mInCnA34BlS8KRfIEJTz1Zgp+21OCqK/Pw6muhGDDQS/vdGkREStzkHUCLFy9u9HVgYCB++ukn/PTTT42WS5LkuAmg8vJyREdHAwDCw8ORm5uLrl274rzzzsPevXu1VOkU/ft5Y933kZg2vRibNlXj8cdL8PjjJQgOlhARZUREpOF0Of3vKAN8w+sQHmlEeJQR4ZFG+Pjy6pPIlVx6qQ/Wr4vA/z1QhJ07a3H//xUDKEZIqNQolq3/jjTAL8KM8EgjwiLr49rbh1efRK5k9FW+6NnDhHvvK8Kff9Zh0qRCSBIQGmZA+FnjdMO/fc6I67AII7yYTYzIpdw03h/n9fbC/fcW4dgxM266sQAGAxAaXh/HDbEdHmlARFT9/30jzAiLNCEs0ojQcCNMXoxrIrKPPe/4cYV3AKWmprZq/ZomgLp164ZDhw4hKSkJffv2xZtvvomkpCQsX74ccXFxevexVYWFGbDivVAsf7Mcr75ajvJyGSUlMkpK6pB6tPn9/QMlhEcaERzhjdBII0IjTQiLNCEkwoTQSBMMYTJCIr0QHOEF3wBD233mksiBYmON+OTjcLz8chneersc1dVAcZGM4qI6HDtia4/iRl8FBhkQFmlEcKTXGTFtRNjpuJbCZYREeCEk0gs+/ry1iMgRkpJMWLM6As8+V4r//rcCtbVAYYEFhQUWHD1c1+z+QSH1cR0UUR/XoafjuaGYwmUEn45rb/5xh8ghunf3wjffReDpp0qwZnUVLBagIM+Cgjz7fgsLDm2Ia2+ERpoQEmlC6OkYDzl9HR4c6Y3gSC94eTOuido0N7kD6Ezz5s3Do48+Cn9//0bLKysr8eKLL7Z+GvgG06ZNQ2ZmJgBg9uzZGDlyJP7zn//A29sbK1eutLueZcuWYdmyZTh+/DgAoGfPnnjmmWcwatSoJtvec889eOutt7B48WJMmzZNS7eFDAYJ998XiPvuDUBRkYxjOTLy8yynixn5uf/7d06ujII8MwrzLKipkVFRJqOirA443vzFp7evAcGRXgiJMMEvwg/BEV4IivBGUKR3/f9P/1sO8YJvkImTRUQtYDJJmDkzCI89Fvi/uM49HdN5FuTlWZCfW//vnDwZhXlmFOSZUVcLlJVaUFZqAVJrm23Hx9+AkAgvBEd6wT/c96x49rL+2xzqDZ8AxjVRS/j6Snj+uWDMmxuEwkILjuRIKLCO0+b/jd25ZmtcF+abYa4DSostKC22AEebj2vfAIP1jzd+EX7/i+mzxmxLmBd8/PmeMaKWCAw0YPGSULz4koyCAguO5kgoOH3dXXBGbBecvg4vzDOjqMAMixkoKbKgpMgCHGk+rv2CjAiO8EJwpDf8zhivA62x7YPACG+YQ3zg5ce4JvI07vIOoDPNnTsX9957b5MJoIqKCsydO9dxE0ATJkyw/js5ORnHjx/H33//jQ4dOiAyMtLuehISEvDCCy+gS5cuAICVK1dizJgx2LdvH3r27Gndbs2aNdi5cyfi4+O1dBcAYJQkGM/6xevsryFJiAwHTKEAutqup8jiDQCQZRnlpfWTQQV5ZqTneKEor65+UMqrqy/5dcjPtaAkvxbVlRbUVFmQd6IaeSeqAZQr9tc3yIQJ/x6IpP7h1mVK2XxsMShmK1JXlyjjiGL2H7URJNheVsx2ou6XaWHWj+YydehBoR7V2UhE22tIzSZqW1iTlgkMyaD8tUb2xLXRKCEqAvAKA9DNdj0FZl8A9XFdWmKpnwzKNeNErgmFDfGcV4eigvr4LsgzozivDjVVFlRXWJBTUY2cjGoAZYr9DQj3xuS3L0Bs1+Bmj00pE4l4H9uxojbeFYnq0hJbwjZsLxYehfD49IsHrRmDbBK2oSW2VO4jCr3mMo7Ys9yBk5tGo4TISCNM4QaILmWKLT4AAItFRmmxxTpen8gxWcfowrw6FOfXoSjPjPw8M0ryalFbI6Oq3IKq8mpkpzUf18Exvrhj1YUIjf/fxZmesahXXcrfYlFc63fuUDv+OiLm9Dxvabq+UF2XymsehWsC4Zqz97E4Lq5NJgnR0Ub4RIrvrC06I65LCi2n/yhrRnqO6XQs18d28elxuyDPjJL8WphrZVSWmlFZakb28SoAJYp9iUgMwO0fXAL/UO9m+y263tZz7HXIdbiwHqV1omt3dReXTo13De3rG++2d5I0XNOLfi9ysTkN53HDO4BkWbb5ff39998RHh5uY4/m2T0B9PDDD9td6SuvvGLXdtdcc02jr59//nksW7YMO3bssE4AnTx5Eg888ADWr1/vUi+XliQJgcESAoMN6NDJCx3MgTa3KzLXXxBWVdRfWBbn16E4rxaZuRJK82pQml+LkvwalObXoDSv/t9VZWZUldZh2/tHG00AEVHrkiQJwSFGBIcYkdgZ6Gjxt7ldkdkfslz/S2Jxfi2K82pRkleLk7nG07F8Oqbz62O8NK8G1RVmlBfU4Nf/pGLsvD4OPjKitstgkBASZkRImBEdzwE6C+I63xwIWZZRWWa2xnRxfi2ycqT/xfJZ8V1TaUFJdhV2fZKG4dO7O/jIiNoug0FCaIQRoRFGoBuQpHAdLssyKkrM1pguOX0dXpb/v1guOyOu66otyE8rx+9fZ2DwxM4OPjIiajVuNAEUFhYGSZIgSRK6du3aaBLIbDajrKwM9957r6a67Z4A2rdvn13baX28wWw247PPPkN5eTkGDx4MALBYLLjtttvw2GOPNbojSEl1dTWqq6utX5eUKM/wO4qvvxG+HYyI7lD/dcPEkC0H/5axdOxW/PNzLkrzqhAU6eugXhK5JleMa0mS4BdohF+gEbGJ9THaSXABCgApv1bivSk78Oe6TFz1eE8+NkJtnqvGtX+QCf5BJsR19AOgPF7//G0xPntsL1K+PoHLHuwGo4nvGKG2zVXjOiDEhIAQE+I618d1gWC8lmUZmz7Mwffz9yNldToG3daJj24TeQh3egRsyZIlkGUZU6ZMwdy5cxESEmJd5+3tjaSkJOuciVp2/wayefNmTQ00Z//+/Rg8eDCqqqoQGBiI1atXo0ePHgCAhQsXwmQyqUpvtmDBAsydO7dV+uooMV2C0L5PKDJ+L8Lv35zExbfzrw/UtnlCXCcNCEd4B38UpFfgrw2Z6Hdde2d3icipPCGuz708Fv5h3ijLq8bRX3LR9dIYZ3eJyKncPa4lScJ5VyVg48t/IfdoKU79VYR2vcKc3S0i0oE7TQBNmjQJdXX17xi+4oorkJCQoFvdTv9TVbdu3ZCSkoIdO3bgvvvuw6RJk3DgwAHs2bMHr776Kt5//31VM+9PPPEEiouLrSUjI6MVe996Gn453LvmBGTZRX4SiZzEE+JakiRrXO9bc8LJvSFyPk+Ia5OXAb1HtwMA7Fvjfv0n0psnxLVvsBfOvbw+q/HvjGsizyHbWVyEyWTC/fffD7PZrGu9Tp8A8vb2RpcuXTBgwAAsWLAAffr0wauvvoqff/4ZOTk56NChA0wmE0wmE9LS0vDII48gKSlJWJ+Pjw+Cg4MbFXfU68o4ePkakHusDCf+KHJ2d4icylPiuu817SAZgON7CpCfrvwieCJP5ylxnXx6YvfQ5myUF9Y4uTdEzuUpcd33uvp3Nuz//gRqq/T95YuInMhNJn8aXHDBBXa/isdeLvcSClmWUV1djdtuuw1XXHFFo3UjR47Ebbfdhttvv111vYbT/zVeph8DbGfs0ZLJxyhZEBBkRK/hsdj3zSns+yoDSX1DFLbXL6uIYjYBlduLE8cIMgaoarmhMpXLNVD9pn89sx7plZUAUP8Dr+WZdw0ZC1yBKE5FcS1ibGb7kFg/dBkchX+252LfmhO4Ymo3XbP7iajNHqL2PKC0jyiLn2J2P5VB5JDsfg7IKsLsfvXsytppXa7f1Vpz8WuLATLiuwUhvnswTh0swZ/fncDgf3UUby861+iaHUx1VWKOGP+EbavMLqRj+4qxq3pcFmTl0XStIKpLkEVIQ12txdZ1uCjXl5ZxziiILdE5wthMGx3Pj0RInB+KMytx6MdM9LoqQfU5QimuheOvqhaauQ4X7mN7uXhc1vFnRcdrZPWxqL4N8fnGAecnezNw2uPsgUHXtGvuQ7LUl+a2cSX3338/HnnkEZw4cQL9+/dHQEBAo/W9e/dWXadTJ4BmzZqFUaNGoX379igtLcXHH3+MLVu2YN26dYiIiEBERESj7b28vBAbG4tu3QS5nD1Mv7EJ2PfNKfyx9hRGz+gOeDm7R0TUUsnXJdRPAH19Apf9X1dnd4eIdJB8XXucOvgX9qzOwKAJSc7uDhG1kGSQ0Ofa9tj65mHsW5OOXlfp9/4NInIOd3oHUIPx48cDQKN3IkuSZE0Pr+XxMKdOAGVnZ+O2225DZmYmQkJC0Lt3b6xbtw7Dhw93ZrdcRscB4QhL8EPhiUr89UMWEke55220RPQ/3S+LgV+IF0qyq3B0Rx6iB3VwdpeIqIV6j47HupcOIvtwKTIPlsCva0DzOxGRS+szpn4CKHVnHoozKyBFMSsvkVtzozTwDVJTU3Wv06kTQO+++66q7Y8fP946HXFRBoOEfmPaYdPrR7BnzUkkjuLdAkTuzuRtRO+r4rHzozTsXZOBKzkBROT2/EO80f2yGPy5PhN712Tgohlxzu4SEbVQWEIAkgZG4viuPPz+dQb63hHu7C4RUQu44x1AiYmJutfp9JdAk7J+YxIgScCxnfkoOsmXxhJ5goZsYH//mI3KYr40lsgT9BtbH9d/fHcKddV8aSyRJ+h7erxOWZMB2eJivxkSkToWO4sLOnDgANatW4evv/66UdHC5V4CTY2Fxfuh8wUROLIjH399fRwX3dfT2V0iohaK6x6M2G7ByDpUgr+/T0fyzV2c3SUiaqHOgyIRHONb/3jnT6fQbUR7Z3eJiFqo+xVxWDt/P4pOVuDE3ly0HxDt7C4RkUbueAfQsWPHMHbsWOzfv9/67h+g/j1AADS9A4h3ANlghKy+SBabRcQgycJytn5j618899fXaTBYzDDC0qjo0YY9+6ipR5GkY3FmGwKyJAkKhEV8HJLNIhtgs2jpFwyCorJPilkJ1NSvgsHmf7BZlOJXdbuSRVDEsXLmecFkkNH/unYAgL++Pt4kpo2wwCjJNotyv/SJU0mSFYq6b724ER2LBsJY1LENUV1qzwOK5w7RD7ywTxq+gWrPES5CGKewXURsxqeN8ddglJB8bcN4napu7IUsLirjWjl+bReIirAR29vLCkUYD9AxE6/KmFM9JsNR5w61Y6ygaBmvdTnBtx611+ci4nG88XW8r78B510ZDwA48JXtuNYy9qq93hbGrhbCmEfrFw3Uxq+WuBZywPHpNo5rife2prkU8C6YCv6hhx5Cx44dkZ2dDX9/f/z111/YunUrBgwYgC1btmiqkxNAbqDn5THwDTKhJLMCabtynd0dItJB36vjYTRJyDpQhJzDxc7uDhHpIPm6+gmgtF+zUZpd4eTeEJEekk8/BvbPphOoLqt1cm+ISCtJlu0qruTXX3/FvHnzEBUVBYPBAIPBgIsvvhgLFixolBlMDU4AuQEvXyN6j6p/oeT+NWlO7g0R6SEgzBvnDqu/lXz/V4xrIk8Q0SEAif3CIVuAv75hXBN5goQ+oYjsGIi6KjMObchwdneISCPJYl9xJWazGYGBgQCAyMhInDp1CkD9y6EPHTqkqU5OALmJ/qcfAzv840lUlfClsUSeoP/puwX+WpsOc62LjThEpEnDY9t/fpVmfVafiNyXJEnWu/v++uq4cztDRNq54SNgvXr1wh9//AEAuOCCC7Bo0SJs374d8+bNQ6dOnTTVyQkgN5HQKwQRnYJQV23B3xtOOLs7RKSDcy6KRGCULyoLa3D050xnd4eIdNBzRBy8/IwoyijDyZR8Z3eHiHTQ55oESEYJmX/koyC1xNndISINlF55Z8/r75zhqaeegsVS/0fi5557Dmlpabjkkkuwdu1avPbaa5rq5ASQm5AkCb2vSwIA/MHHwIg8gtFkQM+rOwBgXBN5Ch9/E7qNrH9nyJ9rjju3M0Ski6AoX3S8KBYA8OfXx53bGSLSxg3vABo5ciTGjRsHAOjUqRMOHDiAvLw85OTk4LLLLtNUJyeA3EjP0e3r//rwZyHeu2kTflj0O/7ZcgrVpXwkjMhdnTcmEQBwdGsWVt76IzYv3o9j27NQW8EXTRK5q15jkgAAf31zHP+d+CN+/vefSNuZjbqqOud2jIg063ltEgBg738O45M7NuPXN//CiT25MNeoT8NMRI7njncA2RIeHg5JkpCTk6Npf5PO/aGzaE0xbUtQpD/639wJuz88itzDxcg9XIw9/z0KybATUeeGI35ADNoNjEFc32h4+Sl/aw06TW8qJRZUnZ5SVJlCI5rTOqqpR0O/1G4vC1M0qv0MdUz1qKUuN001KYpTo45vghPFdURSEHpc1R4H1mYg60ARsg4U4beV/8BglBDdMwLtBsai3cAYxJwXBZOPUVNad9E+WlPE214h2kF1EwqN67RcQxuiGJW1XCmI6jLoeNWhNk27ltht0oY+32zD6f8aL7NNyxgrbFdDvIvOEe36RiBpcAyO/5qNU38U4NQfBdj57t8weBkQ2zsK8QNiED8wFtE9I2D0MjbTL9vHqHaMVdpe9O0X7aPpU1cZp8Jx2ZnnFD3bUBujEH8mwpqaS/fuQEZJgvGsNs/++n/L9YtrI9THtegaudOl8YjtFY6sPwtwcm8eTu7Nw684AKOPEbF9oxE/IBZxA2MR2S0cBpNB0xgr7JMwRsX7aE4Tr4LaOHXVuNbr94lmfjFSWZeWcVkwWkpnL2+j94DIdrzk2UUmgPz9/ZGWloaoqCgAwJVXXokVK1YgLq4+MVR2djbi4+NhNqufgOYEkJsZPqM3LrqzG9J25yHtt1yk/ZaLgrQy5BzIR86BfKSsOgCDyYDoXhGISE5AzIA4RPaMhtGH32oiV3XN/IEYOq0X0nflIm1XLtJ35aL4ZAWy/shD1h952PPunzB6GxDTOwoR/RIQ0z8eET2iYDC10QGcyMVJkoQbll2C4pPlSN+Vi4zdOUjfmYOy3Cqc2pONU3uygTf/gMnXiNjkaIQnt0d0v3iEdYuAwci4JnJFRi8Dbll1GYoyypGxKwcZv+UgY3cOKgqqcXJnJk7urH+Xn1eAV31c92uP6P7tENI5HJKGCT8i0pks15fmtnEBVVVVjRJJbN++HZWVlY220ZpogrMCbsg/3AfdR7RD9xHtAAAnTgAnd2fh1O5snNiVhbKsCmSl5CIrJRd/rdgHo7cRkb1jENM/DjH94xHePcrJR0BEZwuK9kPP0R3Qc3T9O4FOpJlxcnc2Tu7Owsld2ajIq8Sp3dk4tTsb+7EHJj8TovrEIqZ/PGIGxCP0nHAnHwERnS2kXQDOaxeA865LgizLOHGsFqd2ZeHknmyc2pWFqqJqnPg1Eyd+Pf2LY6A3ovrGIfr0eB3SiXFN5EokSUJYh0CEdQhE7+s7QZZlpB+uxqndWTi1OwuZe7JRU1qDjG0nkbHtJADAO8QHUcnxiO4fj+j+7RCUGOLkoyBqm+x5xMsdHgFrIGm8k5MTQB4gMMYf3UZ3QrfR9QNR6ckynNidjeO/5SF7zylU5Vcie/cpZO8+BWAPTP5eCO8dj8h+7RCRnICQLhGQ+BdHIpcS3C4Qwe0C0X1MZ8iyjKK0UpzcnYXjO/OQvfcUaoqrkbnjBDJ31GcF9AryRnifdojol4DIfgkI7BiueWAgIv1JkoTQxGCEJgajxw1dIVtkFBwrwqld2Uj7LRc5+zJRW1aDU9vScGpb/UvhfUJ9EZ6cgIh+CYhIboeA9qGMayIXIkkSwjqHIqxzKHqOPxcWswUF/xTi1K4spO/KRW5KJmqKq3FySypObkkFAPhG+CEsuQPCkxMQ3i8B/nGcECJyCHte8uxGE0BacQLIw0iShOCEIPRICEL86PMgyzJK0oqQvTsT2XtOIWdvJmpKqpGzIw05O+ovML2CfBDRtx0i+7WDX++O8E+M4AUmkQuRJAlhScEISwpGwpg+kC0yio4VIHt3JnL2nKr/xbG0BtnbUpG9rf4C0zvUDxHJ9RNC/r07wq8df3EkciWSQUJElzBEdAlD++uTYTFbUHQ4v36s3nMKub9nobqoCpmbjyBz8xEAgE9kACL7JSCiXzv49uoE31j+4kjkSgxGAyLPjUDkuRFIvNkPljoLCg/mImfPSeTsOYW8/dmoyq9E5g+HkPnDIQCAb0wQIvq1R3hyAnx6dYJPZJCTj4LIM0lmG69DsrGNK5AkqdF1+9lftwQngDycJEkISQpDSFIYut7Qo/4XxyMFSP8tB3l7T6Dg91OoLa1G1s/HkPXzMQA/wyvMH2F92yO0b3uEJreHX3yosw+DiM4gGSSEdYlAWJcInHtzr/oLzEN5SN+VWx/Xf2SipqjyjF8ct8A7MhBhye0R2rcDwpLbwzcm2NmHQURnMBgNCO8ehfDuUej+rz4w15pRcDAXJ3bVj9dFf2WhOq8cJzccwskNhwD8CN/YEIQmt0dI3w4I7dMePpGBzj4MIjqDwWRAxHkxiDgvBt0n94O5ug75f+YgY1cOCvZmoPhgNqqyS3Hy+wM4+f0BAIBvQhhC+3ZASN9EhPRuD69QfycfBZFncKdHwGRZRteuXa2TPmVlZUhOTobh9Iu+tb7/B2hDE0AGSDCc9Wp2o+BV7UoZsoTZglTeL6aUlUBtXaLMJTaXG4GIbmHw6hiPzuP7wlJnQfHhHOTtPWn9xbG2sAI5mw8hZ3P9XyZ8ooMQMrAzEqYMhSnAx+5+ibOK2F2FHY0IMpQIG9evaUdkMtC1DZXZjYQ0vMjw7BlrvWawWzuu1W6vKduIypHGVlwbvICoXpHw6doe50zoB3ONGUUHs5G39wTy951EwV/ZqMkrQ/bGg8jeeBAA4BsXgtDBXZEw6RIYfLwa1afrfULult1PLSdn91Mdv8zupzq7n1KMisZf0blAdB6y1YbB24CYPjHw65GIcyYNhLm6DoV/ZiF/74n6CaGD2ajKKkbW98XI+v5PAIB/h3CEXnQu4m69CAaTcnYxuzgi855ebUO/MVPLuUPteUtxe7VP5euaAdSg/LWTCa95VY6/jhivbbbrY0J0/3j49+4I3HEB6ipqULg/E/n7TqBg7wkUH85B1YlCZJ0oRNa3vwMA/DtGInToeYgZN0jdy6T1ytrpzOt2pfYdcL7R8zpcXJe6ymSFnwHhmrP3sbjnuN5ibvQS6BUrVrRa3W1mAohsM5gMCOsRi7AesTjnX/1RWmFA8cEsFO7LQOG+DJQczER1TilyvktB6V8n0e25G+HNW1OJXJrR24iIPvGI6BMP3A4UlRpQ/NcpFO3LQFFKBkoOZaEqsxhZX+5C2d+ncM6c6+EV7OfsbhORAqOPCZH9ExDZPwHdABQXA8X7T6IoJR2F+zJQdiQHFekFqEj/BeX/ZKHzrOtg9PN2dreJSIHJ3xtRFyQi6oJEAEBhvoyS/SdQlJKOopR0VKTmnS6bUXk0G4kPXw2DF399I9LCne4AmjRpUqvVzTMINWLwNiGsTwLC+iQAkwfDXFmLwpQMHHzpB1Qez8WB6R+g67M3wj+JmcSI3IXR1wvh/RMR3r/+ArOuvBoFu47j0OIfUHbgJA4+/B90e+4m+PB9IkRuw+TvjYgLOiLigo4AgNqSSuT9chT/vPYjincfw98z/4uuc2+EV1iAk3tKRPbyCvJFxIVdEHFhFwBATWE5cn86hGPLt6Bw6wHUFpWj81PXwxjg6+SeErkfyVJfmtvG07nWfZ3kcox+Xogc3Ak9Ft8G34Rw1OSW4uCjH6Lkj3Rnd42INDIF+CB6aDd0f2kCvCODUHWiAAemf4DyI9nO7hoRaeQV7Ie4K3uh2wu3whTsh4p/snDw4Q9QdaLA2V0jIo28wwLQ7rp+6DJ3PAx+3ij7Iw2HZnyAmrwSZ3eNyP00PALWXHGysLAwhIeH21W04AQQ2cUnNgTdX/kXAnu0g7msGoee/BT5Ww86u1tE1AL+SVHosfhf8EuKQm1hOQ4+9l8U7011dreIqAUCz41H91dug09sKKqzinDwkQ9QdvCks7tFRC0QnNwRXRf+C6awAFQdz8WhR1aiMi3X2d0icisNj4A1V5xtyZIlWLx4MRYvXoynnnoKADBy5EjMmTMHc+bMwciRIwEATz/9tKb6OQFEdvMK9sO5C8Yj7MJzINeacXTB18j7eqezu0VELeAdFYzuL09AUJ8OsFTW4PDTn6Nw8x/O7hYRtYBvu3B0f+U2+J8Ti7qSShx64iOU/nbY2d0iohbw7xyLbi9Pgk9COGrzSnH4sQ9Q/udxZ3eLyH3IdhYnmzRpkrVs374d8+bNw0cffYSpU6di6tSp+OijjzBv3jz89NNPmurnBFArM0oWm8URdRklWVgMksVmETFIMgySDJOvCV2fGoOYa5IBGch6dwOyVmyEJFus2zQU1RwwDStLtgsUinAftZppx2bR6fiazWhi87glm0X5GCXbxU0ZIdsuGuJaVJeI2hhV2ufs2Dw7Rk0BPuj27I0IH9IdstmCk0u+Qt7n2yCh6b6ib7Gu33rBuUB1/Grgdm3oFb8GSVxETUtSk6KHhux+ZxajoBgAYVEbc8J4h0VYhMfQTMyp+zxkm6U5XmEBOHfhrQgZ0AmW6jqkL/gUhev22P6RkWSbRTUtY6mOsaW2X5rGOWEbtk+CsgE2iyYqY1Tx5Ky2rhYy2PxPXeyqzdgJaBtL9breFsWuUvyKYrGh+MaG4NyXbkNA93Ywl1chY+5/ULL9T53iVzT2ioswttD6v1crXfOqLerbtn3ucEQbijzsOlxvklm2q7iS9evX48orr2yyfOTIkfjhhx801ckJIFJNMhqQ9H9XoP2USwEAeWt2IP3l1bDU1jm5Z0SklcHbhM4zr0HsDecDALI+2IxTb66DbG4Db8Mj8lBGP290mX09IoefB1hknFq2FtkfboHsAu84ICJtTMH+6Dr/FoQO7gq5zoyTL3+B/K93OLtbRK7PTe4AOlNERARWr17dZPmaNWsQERGhqU5OAJEmkiSh3fhBaD/9WsBoQPHPB5A65yOYy6qc3TUi0kgySOhw5zDE3zkCkID8tXuQtvALWKprnd01ItLIYDIiafpViBp/CQAg99OfcfLf30CuMzu5Z0SklcHHC51mjUXYVQMBGch+bwOyVmyAbHGx316JXIgE4Y1u/ysq69y6dSuuueYaxMfHQ5IkrFmzptH6yZMnN7lbetCgQXbXP3fuXDz++OMYPXo0nnvuOTz33HO4+uqr8cQTT2Du3Lkqe1uPE0DUImHDeqPjMzfD4OeN8v1pOPrESmYmIHJzkdeejw4zrofkZUTJjkM49vSHqCupcHa3iEgjSZIQc+tQxP/faMAgoWjT70h7/hOYK2uc3TUi0kgyGhB715WInng5AKDgqx04ufhL3pFPJNIKWcDKy8vRp08fLF26VLjNlVdeiczMTGtZu3at3fVPnjwZv/zyC0JDQ/Hll1/iiy++QEhICLZv347Jkyer6msDk6a9iM4QlNwJnRdMROrcj1GVloujM1ag45xbgdh4Z3eNiDQKvag7TCH+SHv+M1T8fQJHZ65Exzm3AGFRzu4aEWkUPqIfTGGByFj0Bcr2HkXqk6uQ9MzNgH+os7tGRBpIkoTIcRfBFB6EU//+GiU//4W6wjK0f3w84BXo7O4RuRR7Xi+r9vVZo0aNwqhRoxS38fHxQWxsrLqKz3DBBRfgww8/1Lz/2XgHEOnCr1MsuiyaDJ+ECNTmleLozJWo+Ou4s7tFRC0Q2CsRnRdOgldkMKpP5uPIjPdRdSzT2d0iohYIHtgVHZ+bCGOwP6qOZuLojBWoOZXn7G4RUQuEDu2NDk/fAoOfNyr+TMPxWe+jLr/Y2d0icimSRbarAEBJSUmjUl1drbndLVu2IDo6Gl27dsVdd92FnJwcxe1LSkoa/VupaNFmJoCMkqFJMUiSzWKUICyizB5qswyIMgwYhVl89M02IjyOFmQr8IkNQZdFk+DfPQHm8iqcfHYVSn/Z3zQrgdpsX809qGmztH5GsdbO6KXUhpbMALplO9GS8qmVMhLoFdd6UYprtfuItxdn91PLnnOHb4codHlxMnwTo1FXWIaMZ95DecqRppU1+1A1s/s5NLufsC5mFdEru5CWusSZ+vQb++3J6OXfrR06LZwMr9gw1GYXIeOpd1H1T4b92f10HOfUxq9iPOjVL8X2W38sVd2GlhhVkx3MheiVnVN8Pa+UKVCfbIBa2hY5M8aDkjshaf4kmMICUZ2eg5NPv42aEzk2vs06Zf1T7JjtomW8dkxcOyBLob0nWC3X1E66Dnc7FjsLgPbt2yMkJMRaFixYoKnJUaNG4cMPP8SPP/6Il19+Gbt27cJll12mOKEUFhZmnSQKDQ1FWFhYk9KwXAs+Aka6MgX5ofOztyL95a9Q/OshZC7+HHWFpQi/erCzu0ZEGnlFBKPzCxNxfP5nKN+fhpMLPkTsfWMQPLSvs7tGRBr5xEeg88LJSHv2Y1QeycSJOSsR9/CNCBzQzdldIyKN/DrFouPC25E277+oOZGPk8+8g7jHboFfj47O7hqR00myDKmZd/w0rM/IyEBwcLB1uY+Pj6Y2x48fb/13r169MGDAACQmJuK7777DuHHjbO7z448/Ijw8HACwefNmTe0q4QQQ6c7g44XEmeOQvvwHFK3bhdwV61GXX4Ko24ZDMrSZm86IPIoxwBcd59yCtMXfoXTbfmQtXY3a/BKEj7sEUlv9SxKRmzOFBiLpuYlIW/glKvb9g1OLPkL0naMROmKgs7tGRBp5x4Si4wu3I+3ZT1F1KB0nn1uFmAeuR9CFvZzdNSLnsifN++n1wcHBjSaA9BIXF4fExET8888/wm2GDBli89964QQQtQrJaED0nVfBFBmCvP/8gMKvf0VdfiliH7wO/LEjck8GLxNip46DKSIYhV9tR/5Hm1BXUILoKVcBMDq7e0SkgdHPG+1m3oLst75ByY/7kPPWt6grKEXE+GHO7hoRaWQK8kP805OQ/drnKP/tILJf/QzmwhKEjr7Q2V0jcpoz3/GjtE1rys/PR0ZGBuLi4oTb/PHHH3bX17t3b9V94G/i1GokSULE2IthCg9C1utfoXT7n6grKkPU9AkwBvg5u3tEpIFkMCDqthEwhQcj9/11KF6/C3WFpYj8v/EweHs5u3tEpIFkMiLmvjEwRQSj4LOfUPD5T6jLL0H47WMhmTi5S+SODN5eiH14PPJWrEXx+t+Qt3Id6vJLEHLTKN6RT22TPWneVaaBLysrw5Ej/3s3ZmpqKlJSUhAeHo7w8HDMmTMH119/PeLi4nD8+HHMmjULkZGRGDt2rLDOvn37QpIkyM09riZJMJvNqvoLcAKIHCBkSB+YQgNx6sVPUPnXcWTOfQexMyfCFBHi7K4RkUZhowfBFBGMrFe/QPlvf6Ou8D3EPHYbjEH+zu4aEWkgSRIix18GU3gwct7+FiWb96G2oAzRD90Cg6+2dx8QkXNJBgMip4yGKSIE+f/diKJvf0FtXhki77kekhd/DaS2RbLUl+a2UWP37t0YNux/d8w+/PDDAIBJkyZh2bJl2L9/P1atWoWioiLExcVh2LBh+OSTTxAUFCSsMzU1VV0nVGLkk0ME9OmM9s/ejhPPfYjajGyceuZNxD4+Cd7tY5zdNSLSKGhQDxiDA3Bq4X9R/U8GMue8hZiZE+EVHe7srhGRRqHDB8AUFoTMVz5D5e//IHPeO4iZMRGmUPHFKhG5LkmSEHbdJTCFByN72WqU7/gD5uJSRE3jHfnUxrTCHUBDhw5VvFNn/fr1quoDgMTERNX7qMH7/1qZARabRVtd6lK0i7ZX2kdEjyyIvh3jkLjgTnjFR8FcUILMOW+j6kDq/+rTkMVUNQekmVRKUau2OOQ4hKlgYbsocdN00eKUrILUzBriWq8Uz5qOQ+V5QJQi1lYJ6NkBHZ6fAmNECGpP5SHzmbdQnXpK+QMHoJwmHoLS+inlWz0NrUIbWtJLC/fR6zzghLSyRsnQpBgkyWYxShAW9e3aTiOtVNTWJd5eFha9zh1qUk8HDuiGhLmTYQjyR83xU8ic/SZqM/P+t4GWWHRA/KoeY3WMa13b0OscYSulu5NSuxsgNSlGQRFdfmj5pUWUNl6xr2pjTsO1tvAavRXTxgdd2gfxT9wGydcHVQdTkfXs26grKNZ2TdkaY6OAbqnj9SRqQ0PMCY+vDV2HO0rDO4CaK67m6NGjePDBB3HFFVdg+PDhmDp1Ko4ePaq5Pk4AkUN5RYcifu5d8OnWAZaKKmQueB9lv+53dreIqAV82kcjft498O4QC3NxGTLnvYOKP8TZDYjI9fmdk4D4uffCFBOOutxCnJr9Jqr+SXd2t4ioBfx7d0bs03fCGBqE2hPZyJzzJmoysp3dLSLHaLgDqLniQtavX48ePXrgt99+Q+/evdGrVy/s3LkTPXv2xMaNGzXVyQkgcjhjoD/iZt0O//N7AHVm5Lz2CYrWbnd2t4ioBUzhwYibfSd8e3aCXFWD7EUfoPSnvc7uFhG1gFdsBOLn3APvTu1gKatA1vPvoXzPQWd3i4hawCcpHnFz7jl9R34xMue9haqDrfvOESKXIAOwNFNca/4Hjz/+OKZPn46dO3filVdeweLFi7Fz505MmzYNM2fO1FQnJ4DIKQzeXoh56GYEjxgEACj44HsUfPQdZIu2x+OIyPkM/r6IfXwiAi7qDZgtyFv+JYq/2dxsFgMicl3GkEDEPXUH/Pp2hVxTi5xXPkTp5p3O7hYRtYApKgyxs++GT9dEyBVVyHphBcp/sz/1NJE7kmTZruJKDh48iDvuuKPJ8ilTpuDAgQOa6uQEEDmNZDAgYvJohN8yEgBQum4b8pZ/Arm2zsk9IyKtJJMJUfffgJBrLgEAFH+xAYWrvuLkLpEbM/j6IOaRfyFwaH9AllG4cg2KvtjAyV0iN2YM9EfME7fDf2BPoM6M/OX/RcmGn53dLaLWY5EBi6WZ4lrjWlRUFFJSUposT0lJQXR0tKY6mQWMnEqSJIReewmM4UHIXb4aFTv/QHZxGaKn/gsGZiYgckuSwYDwW0fCGB6MglVrUbZ5J8xFpYi4dzwMPt7O7h4RaSAZjYi8ayxM4SEo+vJHlHyzGebCEoRPHgvJZHR294hIA4O3F6Km3oyCD75D6YYdKPr4O5gLihF601WQDLxPgDyMBc2/ENzF/l5511134e6778axY8dw4YUXQpIkbNu2DQsXLsQjjzyiqc42PQFkFPwEKJ3umsscYC+ljEFq2zBq+EkVZQ6QVGYUUNpeTV1BF/eFFBCC3Nf+g+q/jyFr/puIfuR2mMJDmslco3K5FoK6FLN0uVEb6uvRUFGTiwjPzEigJcOf2qx8mrL4ieJddU0KbdhYFnrlYBiCQpH35ieo3HcAOYveQfT0STAGBWg7k6qNdx0PUBSLSjGqOn4dcT7Tcj3vphlEROOcUjYf9W2oq0tt1h6lfbScC0SE4/VZyyUJCLvxMhhCQlGwcg3Kt+2BuagEkQ9MgMHXR2PjttsWZrdyxLio5bpDJT3Hd9FnpaUJ6ay6zv7a2UTXyM68dhZvr9+5Rss4bu91uGQwIHzi1TCGhKHos+9RumEbzEUliLjjJkheJsVGhD/HThyvRZrNrqt2H7Xb6zWfpiUmJYPy122EPY94udojYE8//TSCgoLw8ssv44knngAAxMfHY86cOZg6daqmOtvmd59ckl/PLoiddbc1M0HWs8tQcyLL2d0iohYIGNgLMTPugCHADzVHM5D13HLU5hY4u1tE1AKBQwYiauptkLy9UPXnP8he8BbMRaXO7hYRaSRJEoJHDUHEXeMBoxEVv/2BnMXvwVJR6eyuEenHDbOASZKE6dOn48SJEyguLkZxcTFOnDiBhx56SPMEPSeAyKV4J8Yj9un7YIqrz0yQ9fybqDp0zNndIqIW8O2ahNin7oUxIhR1WXn1k7tpJ53dLSJqAb++5yL68btgCApAbdopZD2/DLXZuc7uFhG1QMDgZERPmwzJ1wfVfx9D9oLlqCsscna3iPThhhNAlZWVqKioAAAEBQWhoKAAS5YswYYNGzTXyQkgcjmmyDDEPnUvfM6pz0yQs+QdlO/63dndIqIW8IqPRuzT98GrfSwsxWXIfmk5Kv865OxuEVEL+HRqj5in7oUpOhzm3EJkL3wd1cfSnN0tImoB357nIObxe2AMCULtyWxkL3wdNSd5Rz55ALNsX3EhY8aMwapVqwAARUVFOP/88/Hyyy9jzJgxWLZsmaY6OQFELskY6I/oGXfAf8DpzARv/RclG5mZgMidmcKCETvrHvj26Ay5uga5/34fZb/scXa3iKgFvGIiEfPUffDu2A6W8grkvPIWKn7/y9ndIqIW8O4Qj5gn76+/I7+wGNkvvoGqw0ed3S2iFnHHNPB79+7FJZfUZ9b9/PPPERsbi7S0NKxatQqvvfaapjo9/iXQDSlKS8qavoitTJCWuFQhXXGZxfazduWCfSrMZpvLKy3iVOdVZtvrqutqBcttZ9+oqa0RtlFrtn0cdTWi5bbrMdfZPj4AMNfY/kws1bb3sdQ2PY7wKeMg+QegfOtvKPr0W9Tl5CHkupHWzARSjWAOU3AcwuXV4mcoZdsfO2TRx1stWF6jcEIR1VUr2EewXK4V/+zKdbbXyYLvoUHwcyhaDgCSRXDwlsYHWHf6a60phJXiukRTXNte58y4rhEtrxXP29fW2V4nqEoc1wo/R+YaQfzW2B5OmsS1BETefzPyV3yDyj1/oOD9T1GXk4+gEZdYn2UWxnWtjnEtijnBcvH2+sW1rGtci+JXFO+CHxIAkkVwIIxrDXFtO05qbIx/DWrrVI7Xgp8js8LPqrnW9nEI47qmcX8lLxMiH5qI/Dc/R/XBf5D3xkqE3ng1Ai86/3/biOJUz7gW/RiLxmXR9hriWhS/EMSvQbQ9AIjGZeF4LVouvg509HhdaiOuRfGrLa5tfwYOieta28tF19oAUFtjO+ZF47VoXFaM65qWxbUhwA9R06Yg/82PUHMsHTlL3kbYhOsR0O886zZSte3xWhjvwrFUw3it8npbWA8ASbSPyutwg2BMBqAQ1+qutyXF8dr2hyLrHNduy55HvFzsM6moqEBQUBAAYMOGDRg3bhwMBgMGDRqEtDRtd9x6/ARQaWn9SwkT+x13bkdIF2VbdqBsyw5nd4N0UlpaipCQEE37AYxrT1GydhNK1m5ydjdIJ4xrAoCiz75F0WffOrsbpJOWxnXH/ul6d4kczWxB4arPULjqM2f3hHSiNa7dlkUWZp5stI0L6dKlC9asWYOxY8di/fr1mD59OgAgJycHwcHBmur0+Amg+Ph4ZGRkICgoSNObsktKStC+fXtkZGRo/pDdEY+bx92aZFlGaWkp4uPjNe3fkrhuq99joO0eO4+bce3J2uqx87gZ156qrR430HaP3d3i2m3JFkDhDkPrNi7kmWeewa233orp06fj8ssvx+DBgwHU3w2UnJysqU6PnwAyGAxISEhocT3BwcFt6kTUgMfdtjjyuFvyFwc94rqtfo+BtnvsPO7Wx7h2nrZ67Dzu1se4do62etxA2z12d4lrt+WGj4DdcMMNuPjii5GZmYk+ffpYl19++eUYO3aspjo9fgKIiIiIiIiIiNowiwzAvR4BA4DY2FjExsY2Wnb++ecLtm4eJ4CIiIiIiIiIyHPJluYf8XKxR8BaAyeAmuHj44PZs2fDx8fH2V1xKB43j9tTtaVjPVtbPXYet+cfd1s61rO11WPncXv+cbelYz1TWz1uoO0ee1s9bocz2zEB1Nw7gjyAJLe5/G9ERERERERE5OlKSkoQEhKCK+LvgcmgPMlWZ6nGD6feRHFxsce+h4p3ABERERERERGR55Jhx0ugHdITp+IEEBERERERERF5LjfMAtYaOAFERERERERERJ7LYgHAdwBxAoiIiIiIiIiIPBcngAAABmd3wFU8//zzuPDCC+Hv74/Q0FCb2zz00EPo378/fHx80LdvX5vbfPrpp+jbty/8/f2RmJiIF198sfU6rQO9jnv9+vUYNGgQgoKCEBUVheuvvx6pqamt1/EW0uO458yZA0mSmpSAgIDW7XwL6PX9lmUZL730Erp27QofHx+0b98e8+fPb72Oa8S4ZlyfjXHNuG7AuGZcM65dB+OacX02xrX7x7XLscj2FQ/HCaDTampqcOONN+K+++4TbiPLMqZMmYLx48fbXP/9999jwoQJuPfee/Hnn3/ijTfewCuvvIKlS5e2VrdbTI/jPnbsGMaMGYPLLrsMKSkpWL9+PfLy8jBu3LjW6naL6XHcjz76KDIzMxuVHj164MYbb2ytbreYHscN1A9O77zzDl566SX8/fff+Oabb3D++ee3RpdbhHHNuD4b45pxDTCuGdeMa1fDuGZcn41x7f5x7Wpk2WJX8XgyNbJixQo5JCREcZvZs2fLffr0abL8lltukW+44YZGyxYvXiwnJCTIFotFx17qryXH/dlnn8kmk0k2m83WZV9//bUsSZJcU1Ojc0/11ZLjPltKSooMQN66das+nWtFLTnuAwcOyCaTSf77779bp3OtgHEtxrhWxrh2XYxrMca1Msa162JcizGulTGuSaS4uFgGIF8eOlEeGXanYrk8dKIMQC4uLnZ2t1sN7wDSUXV1NXx9fRst8/Pzw4kTJ5CWluakXrW+AQMGwGg0YsWKFTCbzSguLsYHH3yAESNGwMvLy9ndc5h33nkHXbt2xSWXXOLsrrSqb775Bp06dcK3336Ljh07IikpCXfeeScKCgqc3bVWwbhmXDOuPQ/jmnHNuPY8jGvGNeOaFJnN9hUPxwkgHY0cORJffvklNm3aBIvFgsOHD2PJkiUAgMzMTOd2rhUlJSVhw4YNmDVrFnx8fBAaGooTJ07g448/dnbXHKa6uhoffvgh7rjjDmd3pdUdO3YMaWlp+Oyzz7Bq1Sq8//772LNnD2644QZnd61VMK4Z14xrz8O4Zlwzrj0P45pxzbgmRQ1p4JsrHs6jJ4BELwc7s+zevVu39u666y488MADuPrqq+Ht7Y1Bgwbh5ptvBgAYjUbd2mmOo487KysLd955JyZNmoRdu3bhp59+gre3N2644QbIDgwiRx/3mb788kuUlpZi4sSJrVK/Ekcft8ViQXV1NVatWoVLLrkEQ4cOxbvvvovNmzfj0KFDurUjwrhmXDOuGdctxbhmXDOuGdethXHNuPbkuHZnssViV/F0Hp0G/oEHHrCe+EWSkpJ0a0+SJCxcuBDz589HVlYWoqKisGnTJt3baY6jj/v1119HcHAwFi1aZF32n//8B+3bt8fOnTsxaNAg3dpS4ujjPtM777yDq6++GrGxsa1SvxJHH3dcXBxMJhO6du1qXda9e3cAQHp6Orp166ZbW7YwrsUY1/piXDOuWxvjWoxx3XKMa8Y147r1tbW4dmuyDKCZSdE2cAeQR08ARUZGIjIy0uHtGo1GtGvXDgDw0UcfYfDgwYiOjnZY+44+7oqKiiZ/WWn42uLAWVRnfb9TU1OxefNmfP311w5vG3D8cV900UWoq6vD0aNH0blzZwDA4cOHAQCJiYmt3j7j2jEY14xrxnXrY1w7FuOace0IjGvHYlw7Nq7dmtkCSM2846cNZAHz6AkgNdLT01FQUID09HSYzWakpKQAALp06YLAwEAAwJEjR1BWVoasrCxUVlZat+nRowe8vb2Rl5eHzz//HEOHDkVVVRVWrFiBzz77DD/99JOTjqp5ehz36NGjsXjxYsybNw+33HILSktLMWvWLCQmJiI5OdlJR6ZMj+Nu8N577yEuLg6jRo1y9GGopsdxX3HFFejXrx+mTJmCJUuWwGKx4P/+7/8wfPjwRn+NcAWMa8Y1wLgGGNeMa8Y1wLhmXLsexjXjGvDcuHY1skWGLCnf4ePIxyadxqk5yFzIpEmTGu4Ja1Q2b95s3WbIkCE2t0lNTZVlWZZzc3PlQYMGyQEBAbK/v798+eWXyzt27HDOAdlJj+OWZVn+6KOP5OTkZDkgIECOioqSr732WvngwYOOPyA76XXcZrNZTkhIkGfNmuX4g9BAr+M+efKkPG7cODkwMFCOiYmRJ0+eLOfn5zv+gJrBuGZcM67rMa4Z1w0Y14xrxrXrYFwzrj05rl1FQxr4YcZx8nDTeMUyzDhOBjw7Dbwky21hmouIiIiIiIiI2pKSkhKEhITgYulqmOCluG0darFN/hbFxcUIDg52UA8di4+AEREREREREZHH8fb2RmxsLLZlfWvX9rGxsY0eM/Q0vAOIiIiIiIiIiDxSVVUVampq7NrW29sbvr6+rdwj5+EEEBERERERERGRhzM4uwNERERERERERNS6OAFEREREREREROThOAFEREREREREROThOAFEREREREREROThOAFEqg0dOhTTpk3zmDYnT56M6667rlXqJnIHjGkiz8O4JvI8jGsiaimTsztAZI8vv/wSXl5e1q+TkpIwbdo0hw+CRKQPxjSR52FcE3kexjWRZ+EEELmF8PBwZ3eBiHTEmCbyPIxrIs/DuCbyLHwEjFqksLAQEydORFhYGPz9/TFq1Cj8888/1vXvv/8+QkNDsX79enTv3h2BgYG48sorkZmZad2mrq4OU6dORWhoKCIiIjBz5kxMmjSp0S2hZ95+OnToUKSlpWH69OmQJAmSJAEA5syZg759+zbq35IlS5CUlGT92mw24+GHH7a2NWPGDMiy3GgfWZaxaNEidOrUCX5+fujTpw8+//xzfT4wIhfHmCbyPIxrIs/DuCYiLTgBRC0yefJk7N69G19//TV+/fVXyLKMq666CrW1tdZtKioq8NJLL+GDDz7A1q1bkZ6ejkcffdS6fuHChfjwww+xYsUKbN++HSUlJVizZo2wzS+//BIJCQmYN28eMjMzGw1kzXn55Zfx3nvv4d1338W2bdtQUFCA1atXN9rmqaeewooVK7Bs2TL89ddfmD59Ov71r3/hp59+sv+DIXJTjGkiz8O4JvI8jGsi0kQmUmnIkCHyQw89JB8+fFgGIG/fvt26Li8vT/bz85M//fRTWZZlecWKFTIA+ciRI9ZtXn/9dTkmJsb6dUxMjPziiy9av66rq5M7dOggjxkzpkmbDRITE+XFixc36tfs2bPlPn36NFq2ePFiOTEx0fp1XFyc/MILL1i/rq2tlRMSEqxtlZWVyb6+vvIvv/zSqJ477rhDvuWWWxQ/FyJ3xZgm8jyMayLPw7gmopbiO4BIs4MHD8JkMuGCCy6wLouIiEC3bt1w8OBB6zJ/f3907tzZ+nVcXBxycnIAAMXFxcjOzsb5559vXW80GtG/f39YLBZd+1tcXIzMzEwMHjzYusxkMmHAgAHWW1APHDiAqqoqDB8+vNG+NTU1SE5O1rU/RK6GMU3keRjXRJ6HcU1EWnECiDSTz3pu98zlDc8EA2iUOQAAJElqsu+Z2yvVrcRgMDTZ78zbYO3RMOB99913aNeuXaN1Pj4+qvtE5E4Y00Seh3FN5HkY10SkFd8BRJr16NEDdXV12Llzp3VZfn4+Dh8+jO7du9tVR0hICGJiYvDbb79Zl5nNZuzbt09xP29vb5jN5kbLoqKikJWV1WgASklJadRWXFwcduzYYV1WV1eHPXv2NDomHx8fpKeno0uXLo1K+/bt7TomInfFmCbyPIxrIs/DuCYirXgHEGl2zjnnYMyYMbjrrrvw5ptvIigoCI8//jjatWuHMWPG2F3Pgw8+iAULFqBLly4499xz8e9//xuFhYVN/iJxpqSkJGzduhU333wzfHx8EBkZiaFDhyI3NxeLFi3CDTfcgHXr1uH7779HcHCwdb+HHnoIL7zwAs455xx0794dr7zyCoqKiqzrg4KC8Oijj2L69OmwWCy4+OKLUVJSgl9++QWBgYGYNGmSps+KyB0wpok8D+OayPMwrolIK94BRC2yYsUK9O/fH1dffTUGDx4MWZaxdu3aJrecKpk5cyZuueUWTJw4EYMHD0ZgYCBGjhwJX19f4T7z5s3D8ePH0blzZ0RFRQEAunfvjjfeeAOvv/46+vTpg99++61RpgMAeOSRRzBx4kRMnjwZgwcPRlBQEMaOHdtom2effRbPPPMMFixYgO7du2PkyJH45ptv0LFjRxWfDJF7YkwTeR7GNZHnYVwTkRaSrOVBT6JWZLFY0L17d9x000149tlnnd0dImohxjSR52FcE3kexjWR5+MjYOR0aWlp2LBhA4YMGYLq6mosXboUqampuPXWW53dNSLSgDFN5HkY10Seh3FN1PbwETByOoPBgPfffx8DBw7ERRddhP379+OHH36w+yV2RORaGNNEnodxTeR5GNdEbQ8fASMiIiIiIiIi8nC8A4iIiIiIiIiIyMNxAoiIiIiIiIiIyMNxAoiIiIiIiIiIyMNxAoiIiIiIiIiIyMNxAoiIiIiIiIiIyMNxAoiIiIiIiIiIyMNxAoiIiIiIiIiIyMNxAoiIiIiIiIiIyMNxAoiIiIiIiIiIyMP9P66320B8Ji+DAAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABIwAAAD3CAYAAAB//M++AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy88F64QAAAACXBIWXMAAA9hAAAPYQGoP6dpAACP0klEQVR4nO3dd3wUZf4H8M9sTe8dQgIEEESKcAp4CqgUK+LZGxyKp54N66l3UvzZUTzBenqoJ2fvihQLKiqKCB6ogIRAAklISO/b5vdHyMom+51kNptsdvN5v177gszMzjy72e88k2dn5qOoqqqCiIiIiIiIiIjoEEOgG0BERERERERERD0LB4yIiIiIiIiIiMgDB4yIiIiIiIiIiMgDB4yIiIiIiIiIiMgDB4yIiIiIiIiIiMgDB4yIiIiIiIiIiMgDB4yIiIiIiIiIiMiDKdANICIiIiIiIiLqCo2NjbDZbB1a1mKxICwsrItbFDw4YEREREREREREIaexsRH9s6JQXOLs0PJpaWnIy8vjoNEhHDAiIiIiIiIiopBjs9lQXOJE3qYsxERr35GnusaF/mP2wmazccDoEA4YEREREREREVHIioxqfmhxqt3TlmDCASMiIiIiIiIiClkOOOGA9oiQA65uak3wYEpakJk0aRJuvPHGTq1jwYIFGDVqVLdvl4i6F/cXRD0ba5Qo9LCuiXomp6p26EGeOGDUC91yyy349NNP/b5eRVHw7rvv+n29HXHvvfdiwoQJiIiIQFxcXIeeM3v2bCiK4vEYN25c1zYUwJNPPon+/fsjLCwMY8aMwVdffeUxf8GCBTjiiCMQGRmJ+Ph4nHzyyfjuu++6vF1E3gT7/qKpqQnXXXcdkpKSEBkZiTPPPBP79u1r93nt1SlRTxHsNfqXv/wFAwcORHh4OJKTkzFjxgxs3769S7epqioWLFiAjIwMhIeHY9KkSfj5558D3i6iFsFe17m5uZg5cyaSk5MRExOD8847DwcOHOjSbbKuqT0uqB16kCcOGPVCUVFRSExMDHQz/Mpms+Hcc8/F1Vdfret506dPR1FRkfuxcuXKTrVjwYIFmD17tjj/tddew4033oi77roLmzdvxvHHH49TTjkF+fn57mUGDx6MZcuWYevWrVi/fj2ys7MxdepUlJaWdqptRL4I9v3FjTfeiHfeeQevvvoq1q9fj9raWpx++ulwOuWkjI7UKVFPEew1OmbMGCxfvhy//vorVq9eDVVVMXXqVM0abc/s2bOxYMECcf5DDz2ERx99FMuWLcPGjRuRlpaGKVOmoKampkvbRdRRwVzXdXV1mDp1KhRFwWeffYavv/4aNpsNZ5xxBlwu3y/3YV1TZ7mgwtnOgwNGXqgUVCZOnKhed9116q233qrGx8erqamp6vz58z2WqaysVOfOnasmJyer0dHR6uTJk9UtW7a458+fP18dOXKk+2e73a5ed911amxsrJqQkKDedttt6mWXXabOmDGjw9vNyspSAbgfWVlZXfMGtGP58uVqbGxsh5adNWuWx2v0pr33srX58+ers2bNEucfc8wx6lVXXeUx7YgjjlD/9re/ic+pqqpSAaiffPKJZluJWuvt+4vKykrVbDarr776qnva/v37VYPBoK5atUp8ni91SuSL3l6j3vz0008qAHXXrl3uafv27VPPO+88NS4uTk1ISFDPPPNMNS8vT1zHrFmz2ryPLVwul5qWlqY+8MAD7mmNjY1qbGys+vTTT+tqF5E3vb2uV69erRoMBrWqqso9rby8XAWgrl271j2NdU3dpeVvqZ2/pqpF+9I1Hzt/TVUBeHx+ezueYRSEXnzxRURGRuK7777DQw89hEWLFmHt2rUAmk/HPO2001BcXIyVK1di06ZNOProo3HSSSehvLzc6/oefPBBrFixAsuXL8fXX3+N6upqr6eram1348aNAIDly5ejqKjI/bM3Rx55JKKiosTHkUce2cl3qOPWrVuHlJQUDB48GHPnzkVJSYl7ni/vpRabzYZNmzZh6tSpHtOnTp2Kb775RnzOs88+i9jYWIwcOVL3Nol68/5i06ZNsNvtHjWXkZGB4cOHa9ac3jol6ozeXKOt1dXVYfny5ejfvz8yMzMBAPX19Zg8eTKioqLw5ZdfYv369YiKisL06dNhs9k6vO4WeXl5KC4u9qhxq9WKiRMnijXurV1EWnpzXTc1NUFRFFitVve0sLAwGAwGrF+/HgDrmgLD1cEHeWJKWhAaMWIE5s+fDwAYNGgQli1bhk8//RRTpkzB559/jq1bt6KkpMS9o168eDHeffddvPnmm7jyyivbrG/p0qW44447MHPmTADAsmXLvF6apbXd5ORkAEBcXBzS0tI0279y5UrY7XZxvtls7sC70HmnnHIKzj33XGRlZSEvLw//+Mc/cOKJJ2LTpk2wWq0+vZdaDh48CKfTidTUVI/pqampKC4u9pj24Ycf4oILLkB9fT3S09Oxdu1aJCUlde4FU6/Um/cXxcXFsFgsiI+P95jureZa6KlTIn/ozTXa4sknn8Rtt92Guro6HHHEEVi7di0sFgsA4NVXX4XBYMBzzz0HRVEANP/BGxcXh3Xr1rUZ3G1PSx17q/G9e/d2uF1EWnpzXY8bNw6RkZG4/fbbcd9990FVVdx+++1wuVwoKioCwLqmwGi57Ky9ZcgTB4yC0IgRIzx+Tk9Pd58Zs2nTJtTW1ra57rmhoQG5ublt1lVVVYUDBw7gmGOOcU8zGo0YM2ZMm+uMtbarR1ZWlu7ntLjqqqvw8ssvu3+ura31eV3nn3+++//Dhw/H2LFjkZWVhY8++ghnn312h97Lr776Cqeccop7ns1mg6qqePPNN93T7rzzTtx5553un1s6xhaqqraZNnnyZGzZsgUHDx7Ev/71L5x33nn47rvvkJKS4vPrpd6pN+8vJN5qrrWO1CmRP7BGgYsvvhhTpkxBUVERFi9ejPPOOw9ff/01wsLCsGnTJuzatQvR0dEez2lsbHS/BytWrMBf/vIX97yWMxwWL17snvbMM8/g4osvdv/ckRrXaheRlt5c18nJyXjjjTdw9dVX4/HHH4fBYMCFF16Io48+GkajEQBY1xQQTrX50d4y5IkDRkGo9ai+oijuDsPlciE9PR3r1q1r8zyt9DBvO1g929XjyCOPbDPaf7isrKw2qQYtFi1ahFtuuUX3NjsiPT0dWVlZ+O233wB07L0cO3YstmzZ4p7++OOPY//+/XjwwQfd0xISEgAASUlJMBqNbc5SKCkpafONSGRkJHJycpCTk4Nx48Zh0KBBeP7553HHHXf44ZVSb9Kb9xdpaWmw2WyoqKjwOMuopKQEEyZM8PocPXVK5A+9uUZbxMbGIjY2FoMGDcK4ceMQHx+Pd955BxdeeCFcLhfGjBmDFStWtHleyxkTZ555Jo499lj39Ntvvx19+vTB9ddf757WUr8tZ1YUFxcjPT3dPd9bjWu1i0hLb6/rqVOnIjc3FwcPHoTJZHKf1dS/f38AYF1TQDigwA7tL/8c7cz31Z49e3DPPffgs88+Q3FxMTIyMnDJJZfgrrvucp/h9tNPP+GBBx7A+vXrcfDgQWRnZ+Oqq67CDTfc0CVt6igOGIWYo48+GsXFxTCZTMjOzm53+djYWKSmpuL777/H8ccfDwBwOp3YvHkzRo0apWvbZrO5QykDnTnNNSUlpcvOsikrK0NBQYG7o+nIexkeHo6cnBz3zwkJCaiurvaY1sJisWDMmDFYu3at+5RiAFi7di1mzJih2TZVVdHU1OTDqyKShfr+YsyYMTCbzVi7di3OO+88AEBRURG2bduGhx56yOtzOlOnRP4W6jUqObzPO/roo/Haa68hJSUFMTExXpePjo72OFMhOjoaCQkJXvvi/v37Iy0tDWvXrsXo0aMBNJ8d/MUXX3h82dNeu4h81ZvquuV2Cp999hlKSkpw5plnAmBdU2C41OZHe8t0he3bt8PlcuGZZ55BTk4Otm3bhrlz56Kurs591tymTZuQnJyMl19+GZmZmfjmm29w5ZVXwmg04tprr+2ahnUAB4xCzMknn4zx48fjrLPOwoMPPoghQ4agsLAQK1euxFlnnYWxY8e2ec51112H+++/Hzk5OTjiiCOwdOlSVFRU6L78Ijs7G59++imOO+44WK3WNvcNadEVl5jk5+ejvLwc+fn5cDqd7rN+cnJyEBUVBQA44ogjcP/992PmzJmora3FggUL8Kc//Qnp6enYs2cP7rzzTiQlJbn/SPTlvWzPTTfdhEsvvRRjx47F+PHj8eyzzyI/Px9XXXUVgOYb8N17770488wzkZ6ejrKyMjz55JPYt28fzj33XP+8WUSHhPr+IjY2FpdffjluvvlmJCYmIiEhAbfccguOOuoonHzyye7lTjrpJMycOdPdGbdXp0TdJdRrdPfu3XjttdcwdepUJCcnu8/QDQ8Px6mnngqg+fKRhx9+GDNmzMCiRYvQt29f5Ofn4+2338att96Kvn376tqmoii48cYbcd9992HQoEEYNGgQ7rvvPkREROCiiy7qcLuIfBXqdQ00349o6NChSE5OxrfffosbbrgB8+bNw5AhQwCwrikwnFDgbOcMopb51dXVHtOtVqvHjdz1mj59OqZPn+7+ecCAAdixYweeeuop94DRnDlzPJ4zYMAAfPvtt3j77bc5YET+oygKVq5cibvuugtz5sxBaWkp0tLScMIJJ4iXU9x+++0oLi7GZZddBqPRiCuvvBLTpk1zX2fcUY888ghuuukm/Otf/0KfPn2wZ88eP7yijrn77rvx4osvun9u+Xbh888/x6RJkwAAO3bsQFVVFYDma7+3bt2Kl156CZWVlUhPT8fkyZPx2muvub/N8OW9bM/555+PsrIyLFq0CEVFRRg+fDhWrlzp7piNRiO2b9+OF198EQcPHkRiYiL+8Ic/4KuvvurW9DjqHXrD/mLJkiUwmUw477zz0NDQgJNOOgkvvPCCR3tbTptv0V6dEnWXUK/RsLAwfPXVV3jsscdQUVGB1NRUnHDCCfjmm2/cZxNHRETgyy+/xO23346zzz4bNTU16NOnD0466STxzIT23HbbbWhoaMA111yDiooKHHvssVizZo27/+9Iu4h8Fep1DTQfc99xxx0oLy9HdnY27rrrLsybN889n3VNgaBnwKh1ct78+fOxYMECv7anqqrKfeuSzizT1RTV2wWw1Ku5XC4MHToU5513Hu65555AN4eIejDuL4h6NtYoUehhXRN1XHV1NWJjY/HFtj6IijZoLltb48LE4ftRUFDgMXjZ2TOMWsvNzcXRRx+NRx55BFdccYXXZb799ltMnDgRH330EaZMmeK3bevFM4wIe/fuxZo1azBx4kQ0NTVh2bJlyMvLc5/CSUTUgvsLop6NNUoUeljXRJ3nhAFOaA8YtdzhKyYmpkNnuy1YsAALFy7UXGbjxo0el5oWFhZi+vTpOPfcc8XBop9//hkzZszA3XffHdDBIoADRgTAYDDghRdewC233AJVVTF8+HB88sknGDp0aKCbRkQ9DPcXRD0ba5Qo9LCuiTpPVRW4VO1L0tR25rd27bXX4oILLtBc5vCb2xcWFmLy5Mnue2R688svv+DEE0/E3Llz8fe//11Xe7oCL0kjIiIiIiIiopDTcknamq1ZiGznkrS6GhemHrUXVVVVPt9PS7J//35MnjwZY8aMwcsvv+z1HmQ///wzTjzxRMyaNUtM9O1uPMOIiIiIiIiIiEKWUzXAqbZzSVoXnUpTWFiISZMmoV+/fli8eDFKS0vd89LS0gA0DxZNnjwZU6dOxU033YTi4mIAzaFIycnJXdOwDuCAERERERERERGFLDsMsEM7WdDeRdtes2YNdu3ahV27dqFv374e81ou+HrjjTdQWlqKFStWYMWKFe75WVlZ3Zo+3hovSSMiIiIiIiKikNNySdo7Pw1CZLT2gFFdjRMzR/7WJZekBauQP8PI5XKhsLAQ0dHRUBR9N7Eioq6hqipqamqQkZEBg0H71FBvWNdEPQ/rmij0sK6JQk9n6zpYuaDABe39UHvze6OQHzAqLCxEZmZmoJtBRF4UFBS0OS2zI1jXRD0X65oo9LCuiUKPr3UdrFwwwAntATIXePFVayE/YBQdHQ0AGHvynTCZwjzmOa3eRxBdZnlk0WXyPs9pEZY361sPALh0r0taXv7Aq9K6hOdI21DNLnEbENalCM8xmJ1epxtN3qcDgFlYl8Xk8Do9TJgebpavWJWeE2GyeZ0eZWzyOj1SWB4AIoXnRBkbdS0fbWgQtxFtELYhPEdcXpHfqyiD999HlMHz9M+aWheOGnvAXZ96edS1uVVdW4S6FqYDGnUt1YlUo1p1LaxL2neo/qxrk1DXwrpUjW1AqDmxrk3ep5uEegcAszDPKuwLwkzeP5PhwvTm5+isa5NUi3JdR5mEfYFU7wbv24gW9gMAEKUIzxHWFSXUdbRBo64V75+HKIPnh7Sm1oVhY4s7Xddjprata6lf1qprp1CPUv06pW1oHCnJ+wJhulCjWjUn9v1S/Qr17ktdy/2y9+WNGnVtFevaey1K0yPMcs1JNS/VtVS/Uu0Ccr8s9f1SXUvTASBG53OiDMLrULy/hwAQbfD+eY8yeH6oa2pdGDRmf+fr+pS7YGzdXws1J/V/gEYfL/WxUl0LywO+1LVUcxrb0Hu8bRGOt4V6BwDF4r3mpH5ZOt62COsB/NcvS30y4L9+WauupX45xigdI0t9r3wcLva/ir5+OUqoXQCIVLx/6CJa1XV1rQtZR+/xua6DlV01wa62cw8jNbjOMEpISNC1vKIo+PHHH5GVldXh54T8gFHL6a8mU1ibA1BF7EQ0DkCleULnItStuG0AUPSuS/gtKhb9B6DSIA/Eg1w/DhgJHZLWgJF0cGo0ed8ZmMzSdHm02WzyPs8svO8WofOWpgOA1ej9PQkzen994dJ0g1zSEUbvnXGkwft7EimcohqlyO+VlFQZLazL19PT3XVt7nhdi7Wr8Rzpcy/XqNY2hBk6B4ygUdfiwan02RPW5dcBI2G61h+WRrP3z6q0L5Dq1yTULuBDXQuvw2rUqGvhoFysa6F+w40adS3Wr/fpUVJda5ySHi0MGHVnXUv9slZdQ5gn1a+4vMYffeK+QOyXvU/XGgiW9kNSHyvVr08DRnr/4PSlrqV+WezH5d+5WRgklPtr79Ol2gXk+tVb1xFe4pTd8/T2y8L0aM3+2vt71VV1bdTRX2sN5kAYMJL72O6oa+lLGXkbuo+3/TlgJPXLQh9rtMiDOf7ql6U+uXme9+l6+2Vf6lrqf6Ua1aprvcfVYl1rDBhJ64rwc10HK6eqwNnOgFB783uayspKPPbYY4iNjW13WVVVcc0118DplPtqb0J+wIiIiIiIiIiIei9nBy5JcwbhJWkXXHABUlJSOrTsddddp3v9HDAiIiIiIiIiopDlUg1wqe3cwyjIAuRdLo2rfbyoqanRvQ0OGBERERERERFRyLLDAFt79zAKwjOMulqvGTBSXCoUl+cHwCBcvqc18KgInzGDU7jeUViX1mdVEdolbVsRBhYVl8b9VFzC/YWE16FI9+nQ2IYqbEMVnqMK23ZpXKvrEtblcnl/46XrUh3C8lrzpOlNLu+/KKswHQDswrXQ0o3Z5OlySUs7SOk54jakDygAu+r9w9h6ukNYTi/FqUIxeH7OpM+9VO8AoBqEejAK9aCzRpvb5X261C6n8JEU9zUAnEKdSu+J1CZo/HqkOlWF90qqd6fG6zAahfoVvkWxC7Vo1tiZO4R50nSbcCdSu0G+t4NdqHm7cCMMcbpGhyHVr1zv0nSNuhY+8F1X10Dr2zCI/Z9GXet9jtTPafalevtrP+47pOlSzUHrW1OxX/ZeDy7hvZL6ZEDuM006+1iprpqf432eNF1aV5PGnc7DemR/7X0/ZNe4P4ld+Dy03hdI/bpe3vpr6dZpUn/SvB5huj9rTnqO0F7dx86+PEfqe4XjF0CuX1Vn/UrH1ID/+mWp79WaJ9a1VKNax+FC/9sk3OzKpni/sbZWXUv7ApvwwbJJxyMaNSn1185Wz2n9c2/hggGudlPStOf3ZC+++CKSkpJw2mmnAQBuu+02PPvssxg2bBheeeUVXTe6PlzwviNERERERERERO1wqoYOPYLVfffdh/DwcADAt99+i2XLluGhhx5CUlIS5s2b5/N6e80ZRkRERERERETU+7igwAXtFLT25vdkBQUFyMnJAQC8++67OOecc3DllVfiuOOOw6RJk3xeb/AOoRERERERERERtcOmmjr0CFZRUVEoKysDAKxZswYnn3wyACAsLAwNDQ0+rzd43xEiIiIiIiIiona4VAUu4X62hy8TrKZMmYIrrrgCo0ePxs6dO933Mvr555+RnZ3t83p5hhERERERERERhSwXDHC28wjmm14/8cQTGD9+PEpLS/HWW28hMTERALBp0yZceOGFPq+315xhpLhUKM5WaUpiQoG8HjFZTXqOlG7i1EhO0JnMBB/SY8TnCM2S1qWZTCilpehMT9NKZ3AJ65Lu/u9wem+w0yCnBTjFBBedaSxaCRBSGoyf0lia5+lNU9KXxgLIiSyt01ikdBa9FFfbpCCDQ/h8aaYQ6UtWk9alVdeQUl90JyDJmxDrVEx2EZbXqmvpmxfd6Wlade39RUq1KE23C/UOAGbhl6s3mUkrTckqJKjprV+t06PFdQk7eZswXWv/JCWo2Vt1GP6KovWafuhD0pFcv/6pd0AjwcxPKUuARnqbn1KWADlpqTtSTZ3SdF9STXUmMOlNXwKARpf31CSrIiWVMf0Q6IHph5o1J0zX2V/783XIf2donA0hHW+LiWtCH6txbOOUnqOzX5b6ZEArldh7nVil1EDNmtNXW42qxev0MNWusQ3/pBJrJRdK8xyt1uXQisMNYS7VAFc7N7Vub35PFhcXh2XLlrWZvnDhwk6tt9cMGBERERERERFR7+OEAmc7N7Vub35PV1lZie+//x4lJSUeX8AqioJLL73Up3VywIiIiIiIiIiIQpZdNcCoeRq99hlcPd0HH3yAiy++GHV1dYiOjoZy2JUfnRkwCt5zroiIiIiIiIiI2tFySVp7j2B18803Y86cOaipqUFlZSUqKircj/Lycp/XyzOMiIiIiIiIiChkOVUDnO0MCLU3vyfbv38/rr/+ekRERPh1vcH7jhARERERERERtUOFAlc7DzWI72E0bdo0/PDDD35fL88wIiIiIiIiIqKQZXcZYdBIwWxeJnjvYXTaaafh1ltvxS+//IKjjjoKZrNnqueZZ57p03p7zYCR4lShKK1jeoWoTY2ISjk6U1iXEN8rrad5XcJ04fMtJVE6Nc4fMwiRmk4pflR4T7QiQ4X0ZjnOU4zfln8fTmFdRqMU8+n9jbdrxPSa/RTTa9OI37ZL8dvCTk2M6RWmA1qRof6J722eJ8Vve06XQ0f1UZwuKK2KSRF+975F6OqNsxY3oTuy27eYXml/oy8yW2sbqhTZLdWpFMstRGYDgFPYeRmN3t8UvbHczfOk+vX+C3EIn22t+G29Mb16pwNadaovvtcm5b0DsEn7tFY3hrSpcvSyHoqqtvnMSjWnkcQs15b0HHF5+XXp7uOFVfnzmEB3LDegUb/69h2qRl/qEtYlRWabhOlSXDcgR3Y7hOhvsY8Vlgfk9toN+urXJtSo1nPswofUJky3a1xaIffXnr8nu/Sh1UlxqlAMretaWNanvlTfPkKrHvxVc9L+AYBYW+LxtrSP0Nh3yHWqr192aR2Hi3Wqr1/WugxIb78s13V39NdyXevvr4W/DRT592EX+uHW9R7MN3buDCcMcLZzgVV783uyuXPnAgAWLVrUZp6iKHA6tf5wl/WaASMiIiIiIiIi6n1cqgKXxpeJLcsEK1cXnR3FASMiIiIiIiIiClkuGOBq5wyi9ub3RhwwIiIiIiIiIqKQZXcZYNC4rLllmWBWV1eHL774Avn5+bDZbB7zrr/+ep/WyQEjIiIiIiIiIgpZqmqAS+N+WS3LBKvNmzfj1FNPRX19Perq6pCQkICDBw8iIiICKSkpPg8YBe87QkRERERERETUDieUDj2C1bx583DGGWegvLwc4eHh2LBhA/bu3YsxY8Zg8eLFPq+315xhZHCqMLRKfpBuEG9wyIkQ0qCjlITgUzqDzmQmMdlFMzlBeI7UXul1+7ANSDcT05me1rwN7w2TbvolpznIY6fSPCkpRUxQ0UhTkhIg/JumpC81SW8aS/O6hNfeKp1Bo8R0UVxtP4NiWolQV4BGnRr0paH5khqoO41FK01Jqmud07XCM6T9kLSPkFMR5W1ICS5SeppLSDTyJU3JLHwY5GQkjXQxIRlRTEX0KZlQb8qhvv0A0Dbl8PfnuFr9LK5CF4NDhaFVMpOUzuffxFH9n9XuSDUVk1v9lbIEiElLelNNtdKUpHkuqS8V3hSnxjGB3pRSiy/ph0LSUpOwjTCd6WkA0w97avqhmEgmrcqH/ZN4vO3X9EOhFqXfh3AsBOiva6lflvpkQH+/3CTUr9WHutbbLze6zF6nA0CY4j0jWG8qsZRwCHS8v3b00pQ0l9r+Ta01/lzo8bZs2YJnnnkGRqMRRqMRTU1NGDBgAB566CHMmjULZ599tk/r5RlGRERERERERBSyHKqxQ49gZTaboSjNA2KpqanIz88HAMTGxrr/74tec4YREREREREREfU+TlWBs50zjNqb35ONHj0aP/zwAwYPHozJkyfj7rvvxsGDB/Gf//wHRx11lM/r5RlGRERERERERBSyXIduet3eI1jdd999SE9PBwDcc889SExMxNVXX42SkhI8++yzPq+XZxgRERERERERUchyQWn/HkZBfNPrsWPHuv+fnJyMlStX+mW9HDAiIiIiIiIiopClQml3QEgN4gGjrtJrBowUl5d0Bof3O8QrRvlUNCl9RE5D05l4Bv3pSHqnN29f2raUruL9dUhpRlrbkN4TvWkOAKAKo8RSmpLRKKWnyduwCykMZuGURelmaQ6NVIMmp5Dg4tc0JSFFxY9pSlIiS+s0FpvfUtK81LXwWRXeSgBy4o9UQwYhXUUr0U/vc/SmL/nyHF/2HWLNS0k6wvKqRiyUS9hHSGks0vXmWilpUrqKnIoo1LVW6or4HClxzX917a/0tOZ5wn5I8XzfHX46yPJa10L9KA79fane9FKt9ENFbx8fyFRTH5KnxFRTqa61UtKklEOxXw5gqqlG+mF3pJoy/VBeT7ekH4p9v/fpvu07/HO8rV3Xwi9P3D/pSzxrnuf9zZJqy6SzFgH/9ctSkq/W9v2Vnqb5HJ2pxFqvQ0pQs7dKCreL0X6hzeEyQtE4bmtZJpgcffTR+PTTTxEfH4/Ro0e7b3rtzY8//ujTNnrNgBERERERERER9T4utQOXpAXZTa9nzJgBq9UKADjrrLO6ZBscMCIiIiIiIiKikOXqwCVpwXYPo/nz53v9vz9xwIiIiIiIiIiIQlYonmHUHYI3N46IiIiIiIiIqB0Ol6FDj66wZ88eXH755ejfvz/Cw8MxcOBAzJ8/HzabzevyZWVl6Nu3LxRFQWVlpbje+Ph4JCQkdOjhK55hREREREREREQhK5BnGG3fvh0ulwvPPPMMcnJysG3bNsydOxd1dXVYvHhxm+Uvv/xyjBgxAvv379dc72OPPeb+f1lZGf7v//4P06ZNw/jx4wEA3377LVavXo1//OMfPre99wwYOVWg1R3ixeQgrVQDIb1ATBsSkgh8SToS01V8SVPyU+Kab8kuQmKFMKCraiTKSWEEUpqElJ7m0khE8VfqitaItZTIYnMJySc609O05vk3TUl4TqsPqV1cgz6Ko/lqZI9pBn3pH4BGApOYaKQ/rUTv/san/ZOYjiTth3xJcdSXuqIa9CcsSvPElDShrp0GeQclJavZhHQMs5A84tBKXRHmNbnMXqdbXVIamUbNCfP8Ve/a62pV1/5KP3SoUNC6v5ZqVN6onGgk1a+0Df1poP5KaNPeRgBTTXWmLAFyqqlU19JBu10jYdEk9KVOoRalPtbikne0UvqhlKbUKNW7Qe4Je336oQ9JwroTzDST2ITPvd5UU40TFfzV92unvUlphsK6dC4PaNSv1F/rTDsF/NcvS/UOaBxXS/Uu9b0a/bW/Ug6lROLmbUhpxa5WP/fOlDQV7d+jqOWdqa6u9phutVrdN5f2xfTp0zF9+nT3zwMGDMCOHTvw1FNPtRkweuqpp1BZWYm7774bH3/8seZ6Z82a5f7/n/70JyxatAjXXnute9r111+PZcuW4ZNPPsG8efN8ajsvSSMiIiIiIiKikNVyhlF7DwDIzMxEbGys+3H//ff7vT1VVVVtLhX75ZdfsGjRIrz00kswaJzQ4M3q1as9BqVaTJs2DZ988onP7ew9ZxgRERERERERUa/jcBmAdu5R1HJFSEFBAWJiYtzTO3N2kTe5ublYunQpHnnkEfe0pqYmXHjhhXj44YfRr18/7N69W9c6ExMT8c477+DWW2/1mP7uu+8iMTHR57ZywIiIiIiIiIiIQpaeexjFxMR4DBhJFixYgIULF2ous3HjRowdO9b9c2FhIaZPn45zzz0XV1xxhXv6HXfcgaFDh+KSSy5pd7veLFy4EJdffjnWrVvnvofRhg0bsGrVKjz33HM+rRPggBERERERERERhTBVVcT76R2+jB7XXnstLrjgAs1lsrOz3f8vLCzE5MmTMX78eDz77LMey3322WfYunUr3nzzzUNtab6jUlJSEu666652B6Zmz56NoUOH4vHHH8fbb78NVVUxbNgwfP311zj22GN1va7DccCIiIiIiIiIiEJWc1ROO2cY6bzRf1JSEpKSkjq07P79+zF58mSMGTMGy5cvb3OPorfeegsNDQ3unzdu3Ig5c+bgq6++wsCBAzu0jWOPPRYrVqzo+AvogIDe9Pqpp57CiBEj3Kd8jR8/3uNO4LNnz4aiKB6PcePGBbDFRERERERERBRM9Nz02t8KCwsxadIkZGZmYvHixSgtLUVxcTGKi4vdywwcOBDDhw93P/r37w8AGDp0KFJSUnRtr6GhAdXV1R4PXwX0DKO+ffvigQceQE5ODgDgxRdfxIwZM7B582YceeSRAJoj6JYvX+5+jsVi8WlbilOFonhGCBqc3nMitaJnhdRFOaZXiKI0SJGdGuuSniNHBIub8F/Et1Ysqc7YTkgRj1rx20K8rkuIAhZjPjV2Dk7h5mh2p/c3xSJkuzqEaE6teVKcp0NqkxDrC2jF9PozfluKBnW0+llchS5eY3qFSGnNmhMifP0Z0wthntReKVZYqkWt7YvTdda71nPEj4VUv8LrBuTfhyqkRbiEdUm1qzVPmi7VnDQd0IrfFupXZ41qzbPpjOm1Q96GTZhnbxXf25V1LfZ/mtHY0nSh5sS+V96GuC/wUyw3IEdz6653jfdKeh/9Fcut9RyX2I97f4JLq66Fvlxv/Uqx3FrzxH5c6JftWhHfUmS3X/traV3OVj+Lq9BFcahQ0Kq/Fo7VxPqB/JmUP/f6+tjmdnmf7s9jAt31K7wlmnUtvUbhfYfU9wr7LUCuR6lflmrO5EN/rbeupT4ZABy6j5H199eNqve/YcNUu7AuffsBALALnYm91Q7YX3UdbJwuA5R2bnqtdezYGWvWrMGuXbuwa9cu9O3b12OeKv0NrFN9fT1uu+02vP766ygrK2sz3+nUONjQENAzjM444wyceuqpGDx4MAYPHox7770XUVFR2LBhg3sZq9WKtLQ096N19BwRERERERERkaTlHkbtPbrC7Nmzoaqq14dk0qRJUFUVcXFxHdrGrbfeis8++wxPPvkkrFYrnnvuOSxcuBAZGRl46aWXfG57j7mHkdPpxBtvvIG6ujr3Xb0BYN26dUhJSUFcXBwmTpyIe++9V/OUrKamJjQ1Nbl/7szpV0TUM7CuiUIP65oo9LCuiainUjtwyVlXDRh1hw8++AAvvfQSJk2ahDlz5uD4449HTk4OsrKysGLFClx88cU+rTegZxgBwNatWxEVFQWr1YqrrroK77zzDoYNGwYAOOWUU7BixQp89tlneOSRR7Bx40aceOKJHh1Ra/fffz9iY2Pdj8zMzO56KUTURVjXRKGHdU0UeljXRNRTqWi+A4rmI9CN7ITy8nL3fY9iYmJQXl4OAPjjH/+IL7/80uf1BnzAaMiQIdiyZQs2bNiAq6++GrNmzcIvv/wCADj//PNx2mmnYfjw4TjjjDPw8ccfY+fOnfjoo4/E9d1xxx2oqqpyPwoKCrrrpRBRF2FdE4Ue1jVR6GFdE1FP5VQNHXoEqwEDBmDPnj0AgGHDhuH1118H0HzmUUcva/Mm4JekWSwW902vx44di40bN+Kf//wnnnnmmTbLpqenIysrC7/99pu4PqvVCqvV2mXtJaLux7omCj2sa6LQw7omop7KpSpQ2rnkrKtS0rrDn//8Z/z000+YOHEi7rjjDpx22mlYunQpHA4HHn30UZ/XG/ABo9ZUVRUvOSsrK0NBQQHS09N1r1dxuqC0ihKQ0gMUh8bJaGLCiZS6IrRHI0lEd1KZH5OOxDQWMbFJI8lC73PEZCSNNCUxwcX7dDElTUhpAQCnwXsEhZjGIiWo+JK6IkwX0xk0EiDE1BU/pbEAciJL63U5/LQzVhwuKK3ixxSj9/dMM3VFql8/posZxPQRYV0+JB2J83QmIGklmOlNqJG2rZ2mpK9+xbrWTF3Rl5goJhZqpJU4VH2JiU1CapJViueE/qQWuUY1EpukdbXqMLznvOjnrb8WP3cOuSDEfYGwLjkByZd+Tljel7qW0pG6I9XUTylLgJy0JB2cS+lLTo1oPIeQXir248I2bE65HqQkVCn9UEpsajLI2whj+qHIIByjy4mFPiSOSkFC/jwOF48v9B07a6e9+ed427/9tZRQqpFW7Kd+WeqTAaBJqHmL0P/6M9VUb8qhdn8ttFfxfA8dCN5Bkc5oueysvWWC1bx589z/nzx5MrZv344ffvgBAwcOxMiRI31eb0AHjO68806ccsopyMzMRE1NDV599VWsW7cOq1atQm1tLRYsWIA//elPSE9Px549e3DnnXciKSkJM2fODGSziYiIiIiIiChIdCQFLVhvem232zF16lQ888wzGDx4MACgX79+6NevX6fXHdABowMHDuDSSy9FUVERYmNjMWLECKxatQpTpkxBQ0MDtm7dipdeegmVlZVIT0/H5MmT8dprryE6OjqQzSYiIiIiIiKiIOF0GQCNs8/dywQhs9mMbdu2QVH8P+AV0AGj559/XpwXHh6O1atXd2NriIiIiIiIiCjUhPolaZdddhmef/55PPDAA35db4+7hxERERERERERkb80Dxi1d0laNzWmC9hsNjz33HNYu3Ytxo4di8jISI/5vt74mgNGRERERERERBSyQvkeRgCwbds2HH300QCAnTt3eszrzKVqvWbASHGpUJytUleEZKzWKQ6HExMdhMQBOXVF3IQPSUdSwpNGcoK0DSmNRWebAI1kFzE1SWqTxgdceO3S70MVUkxcGr9z6VpWabpdSGkxSx8GyCkqUgJE96Qp6UtjAeREltZpLDY/pTMoatvUldZ1/vt0rXoQasihL11F41eskeAiTPchEUVMcNFZc2JCDAAp7E96jvhx0dg/SfP8lYrYPE9fXUvTpdrVmiemKfk1dcU/aSxaz2m9Dbu/0g9dapvkQim91Kc0ULHPlJbX35f6M2ExZFJNhWMuKYXOKWzDKKTfAYDTFcBUU6G/tht8SDWVnsP0Q40kVL39tcZnVUj0E/8GkBKUfUgm9Ou+w1/H276kHwr17jJ637iUcAgATuE5evtlrf5aTjnUWdcB76+ldTlb/SyuIqS5VAVKO8cqUnJnMPj888+7ZL29ZsCIiIiIiIiIiHohFeLJER7LkAefbwP+1Vdf4ZJLLsH48eOxf/9+AMB//vMfrF+/3m+NIyIiIiIiIiLqlEOXpGk9NK9s6YHOPvtsVFdXd3j5iy++GCUlJbq24dOA0VtvvYVp06YhPDwcmzdvRlNTEwCgpqYG9913ny+rJCIiIiIiIiLyu5aUtPYeweS9995DaWkpqqur231UVVXhgw8+QG1tra5t+HRJ2v/93//h6aefxmWXXYZXX33VPX3ChAlYtGiRL6skIiIiIiIiIvK7ULzptaqqGDx4cJduw6cBox07duCEE05oMz0mJgaVlZWdbRMRERERERERkV+oLkUMSjl8mWDiy42u+/Tpo2t5nwaM0tPTsWvXLmRnZ3tMX79+PQYMGODLKruc4lShoINpSkIyEgAoUhKCkJygN+2geRvepxukVBKd6Uva2/A+XQg7ENsEAE6dKU9i0oNmYpPONCVh1FgrTUlOTfL+HCmNxamZuuL9xTtU7y9eTG3wazqDvjSW5ud0NE1JXIUuikOF0iruQzFJCSoa6YdCApOU3iOnH2rsO6R9hLhPEdajkYiiN5VR3obG6xDO1RU7WDFhUeNDIK5Lql8p/VCOqJHSUkw601W0ko6kOhXrV1xeK9nFP3WtlabU0QSm1iksPnOobWN8hLo2CP04IH8mpTBJMenIh77Un+mH4jZ0piz12FRTMf1Qf13rTy8VEpuYfnjYz8Gdfuhbfy1M11uLft13SP2iL+mHwhOk90o41m7evn+Ot7WSqfSmocl9qf7+2i6mIkr7Af11rTeVWEokBtqmEv++rlbph0F22ZXfhOBNrydOnNjl2/DpHkZ/+ctfcMMNN+C7776DoigoLCzEihUrcMstt+Caa67xdxuJiIiIiIiIiHzS3g2vO3LJWm/k0xlGt912G6qqqjB58mQ0NjbihBNOgNVqxS233IJrr73W320kIiIiIiIiIvJdkJ1B1BP4NGAEAPfeey/uuusu/PLLL3C5XBg2bBiioqL82TYiIiIiIiIiok4JxXsYdQefB4wAICIiAmPHjvVXW4iIiIiIiIiI/Ew59GhvGTpchweMzj777A6v9O233/apMUREREREREREfhWCN71uzeFwYN26dcjNzcVFF12E6OhoFBYWIiYmxuerwTo8YBQbG+v+v6qqeOeddxAbG+s+w2jTpk2orKzUNbBERERERERERNSlQnzAaO/evZg+fTry8/PR1NSEKVOmIDo6Gg899BAaGxvx9NNP+7TeDg8YLV++3P3/22+/Heeddx6efvppGI3N8X1OpxPXXHMNYmJifGpIl3O42uTAivHbmhGVQgSo8BzFoTPSEv6MxtYftSklNeqO1tVol5QuLy6v8V7pjt8WXrdBIzJUjAAVIjX1xvoCgFn4peuO79WIDO1J8dsOfyUQuFxtPpyKw/uHUjHKoZBi/Ur1LkXVCss3b1/47Omud42eTIoF1xm/LcZyQ2N/o7OupbYCgJTOLsUgS/shqXa15jml6cJnVjN+W4rj1Tm9yWUWt2F1ec+ItytCTK803Yf47db1bvPTQZbickFp9SE0CHXt1IrGFiK7xTqR6t2n/to/9d7cLmG69ByhHgxSvw/AKRwv+CuWG5CjuVVhG9J76HTKNWc0Cp8Toa6l+nVKByoAbC7v9WBxeX/xUsS3L/Hbgeiv7dIOWS+H2nZnLRyHG5xyJyTdX8TgfVcofo58ibyXakved2jsn8S+Ue+2xU2Ix9vSuuTpWv21VL/CqoT6dQm1CwAO4Tkm4f2V6lrqY7XmSfVuFz5wUr0Dcv/bpHjv422Kzft6NOpa2hfYWh2k2cU1hLZQv4fRDTfcgLFjx+Knn35CYmKie/rMmTNxxRVX+Lxen+5h9O9//xvr1693DxYBgNFoxE033YQJEybg4Ycf9rlBRERERERERER+E+JnGK1fvx5ff/01LBaLx/SsrCzs37/f5/XKQ60aHA4Hfv311zbTf/31V7hcGl9NExERERERERF1J1Xp2CNIuVwuOJ1tTzvct28foqOjfV6vT2cY/fnPf8acOXOwa9cujBs3DgCwYcMGPPDAA/jzn//sc2OIiIiIiIiIiPxJUZsf7S0TrKZMmYLHHnsMzz77LABAURTU1tZi/vz5OPXUU31er08DRosXL0ZaWhqWLFmCoqIiAEB6ejpuu+023HzzzT43hoiIiIiIiIjIr1yK5j253MsEqSVLlmDy5MkYNmwYGhsbcdFFF+G3335DUlISXnnlFZ/X69OAkcFgwG233YbbbrsN1dXVANBzb3ZNRERERERERL1XiN/DKCMjA1u2bMErr7yCH3/8ES6XC5dffjkuvvhihIeH+7xenwaMDhcsA0XeUlcgpSkJqQ2AnIRgENJYVCF5REpKaX6O3gQX/yVA+DVNSRihVVThvRITz+RtQEq005uepnG9qpimJDxHSknTSlOSn+P9FyVNbxLSHADA6vKeieCv9LTmed2cpuRwQWmVuiLVnKKRuiJ+VsWUNCktUf4cyelI+talXXPCdJ0pS92x79BKWBQ7a3FdUnqaXHMuYd8h1alJZyqi1rrE9EMxTUnehr/SlGw+pK7YW8X5CCFF+jm9HNEJ90dUNBKzpPRDg1C/UtqPdn8tbFtnApJmOqvOvrE7Uk11pywBuvtlqb1aCTa6U019ST/UmcAkTtdIU2oUkhGtis5UxJ7UXwdR+qFUQ1LSoO79gMb29ffjGu+VcLwtpR+KHxeN/ZNcv/qOt6UaBQCnsDOQ+l9fjsP19ssOn46R/ZNyKCUcaj2n9TbsQXyfnk4J8QEjAAgPD8ecOXMwZ84cv63TpwGj/v37Q1HkD9ru3bt9bhARERERERERkd+E4IDR+++/3+FlzzzzTJ+24dOA0Y033ujxs91ux+bNm7Fq1SrceuutPjWEiIiIiIiIiMjvOpKCFmRnX5111lkePyuKArXV2YUtJ/p4S1DrCJ8GjG644Qav05944gn88MMPPjWEiIiIiIiIiMjfFJf2rR1algkmrsMu2f/kk09w++2347777sP48eOhKAq++eYb/P3vf8d9993n8zbkizl9cMopp+Ctt97y5yqJiIiIiIiIiEhw44034p///CemTZuGmJgYREdHY9q0aXj00Udx/fXX+7zeTt/0+nBvvvkmEhIS/LlKIiIiIiIiIiKfKQCUdu5RFFwXpHnKzc1FbGxsm+mxsbHYs2ePz+v1acBo9OjRHje9VlUVxcXFKC0txZNPPulzY7qUwwmora7bE9LQFCG1AQAUo/AcIUFATlnSSDXQmYYmpy+Jm5DTVbojTUnahnC+m9Y2pFSM1r9q93RxeY3UFYOQhiak8zgNQpqDxjWxNiGFwSy8EL1pLIBGCoOUzCSlrgjTNbfRKrXBb+kMThdaf5gV6fpcrTQlIXVFfyKYVtKRNF1fyqFmsouf6leqRUArvU1n2ptmXXufLNWpVNdSYpLWPDFNSWdaIqA/XcUh1btGmpK/UtK0kl2kRJauqmvF6YSCVu+FQ/gcGTX6a/E5OtOUfEgXk/cd/ks11dv3+zPVVHfKEqA71VRvyhKg0S8LnxOH03uDpX4c0J/A5Ev6obgunammPSn90GuqqSlw6Yda9aC7tsT9gP50Md3HyL7sn/SuS6MvVYXfhyr8DqVkWKfGcbhR+NvLIda793VJtQjo75fluu6O/lqu6473177dyyboBfAeRnv27ME999yDzz77DMXFxcjIyMAll1yCu+66CxaLxWPZF154AY8++ih27tyJuLg4nHPOOVi2bFm72/jDH/6AG2+8ES+//DLS09MBAMXFxbj55ptxzDHH+Nx2nwaMZsyY4TFgZDAYkJycjEmTJuGII47wuTFERERERERERH7V9ntm78t0ge3bt8PlcuGZZ55BTk4Otm3bhrlz56Kurg6LFy92L/foo4/ikUcewcMPP4xjjz0WjY2NHU6g//e//42ZM2ciKysL/fr1AwDk5+dj8ODBePfdd31uu08DRgsWLPB5g0RERERERERE3UVRO3BJWjvzfTV9+nRMnz7d/fOAAQOwY8cOPPXUU+4Bo4qKCvz973/HBx98gJNOOsm97JFHHtmhbeTk5OB///sf1q5di+3bt0NVVQwbNgwnn3yyx8k+evk0YGQ0GlFUVISUlBSP6WVlZUhJSfE5so2IiIiIiIiIyK/UQ4/2lgFQXV3tMdlqtcJqtfq1OVVVVR73f167di1cLhf279+PoUOHoqamBhMmTMAjjzyCzMzMDq1TURRMnToVU6dO9Vs7fRowUoVr2puamtpcg0dEREREREREFDA6BoxaD9DMnz/fr1dZ5ebmYunSpXjkkUfc03bv3g2Xy4X77rsP//znPxEbG4u///3vmDJlCv73v/95HWd5/PHHceWVVyIsLAyPP/645jZ9TUrTNWDU0ghFUfDcc88hKirKPc/pdOLLL7/kPYyIiIiIiIiIqMdQXIoY8nD4MgBQUFCAmJgY93Tp7KIFCxZg4cKFmuvcuHEjxo4d6/65sLAQ06dPx7nnnosrrrjCPd3lcsFut+Pxxx93nyH0yiuvIC0tDZ9//jmmTZvWZt1LlizBxRdfjLCwMCxZskR+XYrSPQNGLY1QVRVPP/00jMbf78RusViQnZ2Np59+2qeGdDmXq83t/6U0NOkO/gCgOIVEBzHtQEpd0UpT0pfooDedCNBIkxDTY4RtayU2ie0VpgtviVYChCrNk95eYXkpjaV5nvcUBpfwvksJKtJ0rXlSUoreNBZAToDwb5qSkKzW6jl2cQ06eatr6bOtkX4oJSYahHqXPi8GjTgZf9WWdpqSzqQyvfWjtX3diXLyNuS6FupUZ8qS1jwpPU1MU9JI6fJbXWumKelLavGlrqVEltZpLDZ/XffvJf0QYuKoRkqa8H7q7ZeltDVAf5KiL6mmUnullFCx5roj1VTrZqFinfonZQnwJf1Qf6qplEZqc3mvE4sv6Yd+qt+elH6o5zi8O9IPpVoEtPprfSnGfk1ik46RfalrnevSTD8U+2WhrsX9gNzPuaQ61Xm8rXUcrrdfbhLq1+rXuu7YMXVHntNl/XWw0XGGUUxMjMeAkeTaa6/FBRdcoLlMdna2+/+FhYWYPHkyxo8fj2effdZjuZZks2HDhrmnJScnIykpCfn5+V7XnZeXhy+//BITJkxAXl5eu+31ha4Bo5ZGTJ48GW+//Tbi4+O7pFFERERERERERP7QFTe9TkpKQlJSUoeW3b9/PyZPnowxY8Zg+fLlMLT6QvC4444DAOzYsQN9+/YFAJSXl+PgwYPIysoS1zt58mSv95f2F5/uYfT555/7ux1ERERERERERP6n4wwjfyssLMSkSZPQr18/LF68GKWlpe55aWlpAIDBgwdjxowZuOGGG/Dss88iJiYGd9xxB4444ghMnjxZbrJwf2l/6fCA0U033YR77rkHkZGRuOmmmzSXffTRRzvdMCIiIiIiIiKiTmt7ZazXZbrCmjVrsGvXLuzatct99lCLwwd8XnrpJcybNw+nnXYaDAYDJk6ciFWrVsFsNmuuX1H8dPmwFx0eMNq8eTPs9uY7j/z4449d2igiIiIiIiIiIr8I4BlGs2fPxuzZs9tdLiYmBs8//zyef/55Xev/xz/+gYiICM1lfD2pp8MDRodfhrZu3TqfNkZERERERERE1J264h5GPcXWrVthsVjE+Z052cenexjNmTMH//znPxEdHe0xva6uDtdddx3+/e9/+9ygrqK4XFBanWOmSolnTo3IASG1Q3FIyQlCe7RSDYRkATlRQV/6ki/t0psEo70unekTBo2EGp2JTXI6g0aakpAAIaWxyOkM8jakRBankMYiJZ45hDQWQE5Q82+akpAkBc/X4fLT+Z6K0wml1WtWhUQpRUhCAwCDkNTilD6rQr1LqUWAVrqK0Cad9Q7oT0fSu21A3AWKSWxSApKUmARoJbUI63IK69J4r6TUJCmNxSXVqA+pK3J6mlDXGqkrTUIyk9XlPYtQb71rzWudxqIREqiLt7qGSWif9IGEVgKTkIoo1LVmcqqUmKjzM6xIn2Ho738DmmqqmTwlzfBPylLzPH11HdBUU630w25INe32NCWHE2hd10bv7euW9EOtmvNTGppWPehOFtWZWNi8Lv8cb2tewiPt64R1qcL7rnVsI6Yf6uyXpVrUfo6+ftkuHLdrbV9vvywlEms9x97qA+ev/pp6jnfeeafLbnqtsZuRvfjii2hoaGgzvaGhAS+99FKnG0VERERERERE5BdqBx9BpqtvFaTrDKPq6mqoqgpVVVFTU4OwsDD3PKfTiZUrV3bZyFZnVTQWITkiO9DNICI/qmk6iPjwPoFuBhH5UZ29ErHW1EA3g4j8qNFRiyijNdDNIKJeTFHbv+l1MF6S1tUpabrOMIqLi0NCQgIURcHgwYMRHx/vfiQlJWHOnDn461//2lVt7ZRNxW8jr/KHLn9Diaj7fF/0BvZVb2VdE4WQ7/e/iuLanYFuBhH50fcF/8XBuj2BbgYR9WYheobR8uXLERsb22Xr13WG0eeffw5VVXHiiSfirbfeQkJCgnuexWJBVlYWMjIy/N5I/1Cxo/wLVDTuw1HJ02E2hrX/FCLq0VQ4se3gGpQ37sOwpJNhMmhHThJRz+dU7dhy4H1kNR6NIYkTYdC6+Q4RBQW7qwGb9r+OgQkTMDBxAhStm+8QEXWBUL3p9axZs9z/37lzJ9atW4eSkpI29++7++67fVq/rgGjiRMnAgDy8vKQmZkJg8YN+3qaIQkTsbN8PUrqc/HN/v9gVOoZiLFkBrpZRNQJA+LGYXfldyis/QXVTQcwKvUMRFrSAt0sIuqErNijsbfqR+yt+hGVjYUYmXoGwsOSA90sIuqEjJjhKKzehtzyb1DRuB8j0k6HxSon+hAR+V1HziAKwgGjFv/6179w9dVXIykpCWlpaR73NlIUpXsGjFpkZWUBAOrr65Gfnw+bzeYxf8SIET41pitlxhyFhPBMbDnwARocVdiw/1UMST0R/eKO7vIbRRFR1xgQNxZJ4f3wU8lHqLWX4dv9L2NY2nRkxA4PdNOIyEeDEo5DYngWtpZ8jKqmYny77z8Y3vcMpEQPCnTTiMhHQ5NPQmJEFn45sAbl9Xvxzd4XMKLfTCREZQe6aUTUSyiuDtzDyD9BzgHxf//3f7j33ntx++23+3W9Pg0YlZaW4s9//jM+/vhjr/OdWrH0geJwItaYhAlpF2Jb2VocaMjF9gNrUVGXj+Ep02A67EZ8ilM+/V0VYnohRHYbhGhQrVhYg5B1KEVO+hKhK6Wai/GjYjSnxjak7UuFqHc65KJWxXVJ8b0acZ5CBKhBiAwV4z+7IaZXKzLUIUR9itGgfo3fNrb62U/D9y4XEqx9MCHjYvyv9GOUNRZga9GHqKjPxxHJJ8F42CVqUsQ2AKgmIX5biOyW6sQgRNUCcpSsHL/tfbpWRybvC3TGCvsSv61zP+RL/La0H5LqXTt+2/t0uX6l+F55G04h8tcm1Jy5deT0IVLtas0Ta1Gqd0UjpleY15V1nRLeHxMyLsGW0g9R1VSMzflvIDv+GAxKPsHzEjWh7wU04rfFfk6aLjfV4BCi38XPvdCXdkfN+bTv8E8st+b2/RTLDcjHSU5hX240em+UXVgeAEzC2fVOnX2sNB2Q69Rfsdxa8+ytIrv9Fb+tuFzoEzkUsX1TsKX4fdTay/BD3goMSj4B/ZPGe355q/H+S325YhTqXfqsavTX4jGv8BmW+n6tqHhxf6N3H6Gx2xX7WZ3H577013qPt8XjdgAu4fPgEurXISxv0vh9+Ktf1qxrqU79eBxu62Bd24Xjk5AX4mcYVVRU4Nxzz/X7en26puzGG29ERUUFNmzYgPDwcKxatQovvvgiBg0ahPfff9/fbfQrsyEMo5JOxxFxJ0CBAQdqd+DbgpdQ3VQS6KYRkY+sxkiMTT0bA2PHAQD2Vf0P3xWsQJ2tPMAtIyJfhZtjcGz6+ciKORoAsKfie2wseAWN9uoAt4yIfBVlScS4vhcjI/pIACp+K/0CP+a/DpujPtBNI6IQ13IPo/Yewercc8/FmjVr/L5en84w+uyzz/Dee+/hD3/4AwwGA7KysjBlyhTExMTg/vvvx2mnnebvdvqVoijIjjkasVGZ+Kn4A9TbK/Fdwcs4Ivkk9Ik+EgbwmmqiYKMoBgyKH4+4qH7YWvwhappK8G3+SzgydRpSowbDAN4QmyjYGBQjhiZOQlxUP/xcvBKVDfvxzd4XcFTaaUiM7I9e+h0pUVAzGSwYkXIKEqKz8UvRahys241vd/8bR/U5E/ERfQPdPCIKVSF4htHjjz/u/n9OTg7+8Y9/YMOGDTjqqKNgNnv+7XP99df7tA2fBozq6uqQkpICAEhISEBpaSkGDx6Mo446Cj/++KNPDQmEuPAMjO93GbYVr0Rp/W78UrIGv5SsgckQBqspEpZDj8P/bw6LgdUcCYspChZzpMclL0QUeEmR2RifNQv/K/oAFQ378L+iDwAAZmN4m5q2Gg/VdUQMLIfq2mqOhMHg066RiLpIWvQQxFhTsKXwPdQ0HcCP+98EAJiNEbCYI9v22eaW/jrqUG2zrol6mj5xIxATloYt+95Bva0cG/euAKDAYopormdzJKymKPf/LaYomMOjYTE399VmUyQMwmU7REStheI9jJYsWeLxc1RUFL744gt88cUXHtMVReneAaMhQ4Zgx44dyM7OxqhRo/DMM88gOzsbTz/9NNLT031qSKBYjOEYnXE29lR8j9zyb+FU7XC4GuGwNaLOVtbu840GCyzmKFgsUc3/mqNgsUQe+n/LH6LN841GC2+wTdQNwkzRGNv3AuSWrceeih/gUh2wOxtgdzagrulgu883Ga3Ng8LW3+vabI50H6SaImOba/5QXRNR14uwxOPYfpdgR+nn2Fe5BSpcsDvrYXfWow6l7T7fZAyD1RwFs+XwPjvS/X9TRMxhdc0vg4i6Q3RYCsb3n41fi9egsOpnACpsjjrYHHVAY/vPN5vCmweSrIfV9WH/GiOjYbFEw2KN4qAxUW8XgmcY5eXldfk2fNpz3njjjSgqKgIAzJ8/H9OmTcPLL78Mi8WCF198scPreeqpp/DUU09hz549AIAjjzwSd999N0455ZQ2y/7lL3/Bs88+iyVLluDGG2/0pdkiRVHQP+FYZMcfA7urETaDHTZHHZqcdYc6rVo0Heq8mpz1zdPstXCpTjhdNjQ0laOhqf17pRgMZncnZg6LgsUa/fuBq/XQQaw1GqbIaBhNYRxcIuoEg2LAoKQTkJN4POyuBtgU2+917PCs7SZXPWz25p9V1QWHswkOZxPqmzowaGy0wHzowNQcFuU+MP29tpvr3KjEwGiysq6JOsFoMGFY6hQMTTkJNmcDmow22By1v9e1/bAad/7+c3NdN8LhbAQa2x80Nhqt7sEjc1i0+49RszX60L/NtW6KiobRZG13fUQkMxmtOKrPGTgy4zTYnfVoUpp+76fttYfVdm3zcbi9FnZ7ffOgsaMBdkcD0Nj+oLHRFNa2rq2t6toaDYMxBkYTvwwiCjUduUdRMN/DaNGiRbjlllsQERHhMb2hoQEPP/ww7r77bp/W69OA0cUXX+z+/+jRo7Fnzx5s374d/fr1Q1JSUofX07dvXzzwwAPIyckBALz44ouYMWMGNm/ejCOPPNK93LvvvovvvvsOGRkZvjS3mcuF1rf/V1olmCkArGg+swCmeK+rUcOav3VUVRUOV9PvB6doaO7U7M2dm+3Qv03OOthstXC57HC57GhsrEBjYwVQo91ckykcw8bOQmxC/8PaKyQq+JCIYhBSGORkF2G6X5NdpFQKjeQpMYVBeIK0Lo2kI2meS0gYENOUNBIJpJQ0u5DYZxGitbTSGZqc3svdIsTy6U1jAeTkBlurdAabv3bGDmebmDHF6NmG5roOg8USjShLotfVqJbm9qmqCoez0f0HZxMa0HRYPTf/23zQarPXweWyw+m0weksR2NjOdDOvXjNlkgcdcxcRMb8fiamWCdiMqFGsoufkhQ105TE9uqcrpXsIqWeialuwsp8SFNShc+9S9h3aCUTmoR5/kpFBDTSlDqYWNjedK15rVOhpJQo3bzUNUxe6toQDqs5BjB7P+5wWX/vr+3Oht//4DzUX9vstbDZDtWzrbnm7bZauFQHnM4mNDQ0oaGhDKjSbq4lLBYjJ1yNsIjfjxv0Jh35Nf2wp6aa6kyE9CXVVG9iok+ppkJfLtavlKbU29IPnU6gdeJUq2McAwCrEgGLJRbRwniNGtbSXzcPFrUMKDWpDb/31bba32vc3nwcrqpOOB2NaHA0oqG+/UHj8MgkjDj+rzBbIn/ftvBZ1ZtiDPgvIVVaDyCHzckpcELam+YxsjRd3/G21jbk420psdB7o6S+V2ue3n7ZrlnX/umXtftr73XdOj3Nb8fhwSYEzzA63MKFC3HVVVe1GTCqr6/HwoULu37A6KabburwSh999NEOLXfGGWd4/HzvvffiqaeewoYNG9wDRvv378e1116L1atX96ibaSuKArMxDGZjGCKR6P6DszWntblAnU7b7x2Yrbb5jAZbrftht9XCZquBzVYLp7MJDkcD9u3+wmPAiIi6lqIoMJvCYTaFIxJJcFm917XLYoSqqs11fdjBaZNaD1tTSz23PGpgt9XC6bTBbqvD/j3rMXiE/yMvicg7RWm5J0oEgGSoVu8H2y5rS103efTPja66VnXdXNO2puYvg2yNVSjauwH9h7Y9O5qIuoaiGJovKTVHIgrQ6K8NzV8GORrdx9l2Wy0aDx2H25sOTWuqdf/scjnQUHcQJQWb0GfgCd37woio64T4gJGqql6vZPjpp5+QkJDg83o7PGC0efPmDi3n6+UWTqcTb7zxBurq6jB+/HgAgMvlwqWXXopbb73V44wjLU1NTWhqanL/XF3dM+J3jUYLwsMTEB7e/MtyWeTR4WpbCX78agnKS3fA1lQDizW6u5pJ1CP1xLpWFAUmkxUmkxUR4c1nLrmEP0QBoKwmD1u/exalRf/DwGFn8jIW6vV6bl2HwWQKQ0RE85lLTrP8jfGBsq3Y/uN/cWDfJmQPmQqFN+ClXq6n1rXZHA6zORyRkc2hPU6hv1ZVFfv3b8Dure/iQP5GZAw4npeSE4WIUL0kLT4+HoqiQFEUDB482GOf5XQ6UVtbi6uuusrn9Xd4wOjzzz/3eSNatm7divHjx6OxsRFRUVF45513MGzYMADAgw8+CJPJpOuO3vfffz8WLlzYJW3tLpHRaYiO64eaynyU7P8RfQdMDHSTiAIqFOo6NmEAwiIS0VhfhoPFW5Had2ygm0QUUKFQ14lpR8JkiYS9qQYVpTuRkDo00E0iCqhgr2tFUZDSdzT2/Pwh6msOoLZyH6LjMwPdLCLyg1AdMHrsscegqirmzJmDhQsXIjY21j3PYrEgOzvbfUKOLwIeFzBkyBBs2bIFlZWVeOuttzBr1ix88cUXaGhowD//+U/8+OOPukb277jjDo/L56qrq5GZGXw7+tS+Y1FTmY/ifT+gT/8T+O0G9WqhUNeKoiC171js3bkaxft+4IAR9XqhUNcGgwkpfUahMO9rFBf8wAEj6vVCoa5N5nAkpg9H6f4tOFDwAweMiEJFiF6SNmvWLDgczfekPfnkk9G3b1+/rt9Pd6j0ncViQU5ODsaOHYv7778fI0eOxD//+U989dVXKCkpQb9+/WAymWAymbB3717cfPPNyM7OFtdntVoRExPj8QhGyekjYTCY0VBbgprK/EA3hyigQqWuU/scDUBBdXkeGurav+kmUSgLmbrObB78LT/wK+y2ugC3hiiwQqau+/0BAFC6bzOcTnuAW0NEfqO28whSJpMJ11xzDZxOrYQLH9ft9zV2kqqqaGpqwqWXXoqTTz7ZY960adNw6aWX4s9//rP+9TqcUFulQSkm4V4DLjnmQ3F4n6eavE9XhIgCreQvg1OFxWBFctpwHCjcjJKCHxAX009MCPIlOUF/Gpr+dDFxXWJqg77pms+RXruUjKT5XknPEVIbDEJKmhRXAcBpEBIdpDQWP6auSMlqUhqalMYCaKSuGLoqdcXlJXVF+GUKiXPN84S0IadQ10I6hlZdKy4VYdZYxCcNQsXBnThQ8AP6D54mpymJqYgaNae3hvTWD/SnPMlpUVrvlc7ERDF1RX/Copya5EOaks7ERCllTEpWaZ7n/ZclpiZJde1DSlrXpSm1rWvF4f11qka53Yq4LxDq16EvibR5G0B0ZAaiYvqgtno/Sgs2o0/2H8XPqm/9tb6+P6Cpphqfge5INRXr2k8pS4CcpqQ37dRh0J9+2OTy3sdahbRTX+q6y1JNna62MXbC8baicRyu6u6vhc+qcDwPAIrRgLiEAbCGx6GpoRLlhduQ0meU7gRCrZoT+19p3yGmhMqb8Nc+wpcUR/F4W0pi0zhGVoXjBb39stQnA/7rl21CjQKA3SX01zr7Zd/6a892ed9jhD7Fpf15blkmWB177LHYvHkzsrKy/LregA4Y3XnnnTjllFOQmZmJmpoavPrqq1i3bh1WrVqFxMREJCZ6RmCbzWakpaVhyJAhAWpx90rNGNs8YFT0EwYecTqAsEA3iYg6Ka3P2OYBo8IfkT1oCnrAiZ5E1Empfcei9pf9KN73AzKyjgPAy8iJgpmiGJDadwzyf/sUBwo2IqXPqEA3iYg6KVTvYdTimmuuwc0334x9+/ZhzJgxiIyM9Jg/YsQIn9Yb0AGjAwcO4NJLL0VRURFiY2MxYsQIrFq1ClOmTAlks3qMuIT+CAtPQGNDOQ4e+BlJ2WMC3SQi6qTE1GEwmSNga6xCxcFdiOtzRKCbRESdlJI+Crt//RB1NUWorS5ERJh/7x9ARN0vNXMs8n/7FJUHc9HYUAGzNbH9JxFRzxWi9zBqcf755wOAR2CYoihQVRWKovh8uVpAB4yef/55Xcvv2bOnaxrSQymKAakZR2Nv7ico3v8DB4yIQoDBYEJK+kgU5n+LA/t/4IARUQgwWyKQlHokSov/hwP7f0D/FA4YEQW7sIgExCYORFVZLkoKNqFP3NRAN4mIOiHUzzDKy8vrkvXyWogeLq3PGAAKKstz0VhfHujmEJEfpPZpvknuwZJfYLfVB7g1ROQPLcmHJYWb4eJNcolCQstN7Q/s2wRV495WRBQEXB18BKmsrCzNh6963E2vyVNYeDziEgeismwXDhT8gKwh/HaDKNhFxWQgMjoddTVFKN2/BRn9JwS6SUTUSfFJg2AJi4WtsQrlxb8gqc/IQDeJiDopKX04cre9i8b6clQfzENs8sBAN4mIfBTqZxi1+OWXX5Cfnw+bzeYx/cwzz/Rpfb1nwMjpbJumJKSuKBqpK6qU6CCkLShGfelpzfM8P6np6WNQWbYLJQWbkJVzEpRWMWNSuoqUrOJtG7+3txuS2IRC9GuyizBd/HJIa+cgrktKgPD+u3VpJDbpTV2Rpjs0EpukeXadCRD+SFNy+ClNSXU4oLZKmlFM3ndrUsoSAEBKTNSZciilLAGeqWAKgLSMMcjd8SFK8jeiT7/xXrahrxaB5oRFb6R9gd7ltbbvr4Q2X9YlphxqvA45WU3fdCmlpXmef+rXl7r2VyoioCN1xU8HWc2ppq1S0oQkUjEVEYAipFOpUjqSyft7ZhDSlwDPz4UCBWkZRyN/9+co2fMDktPaDhjJ/bW4CR+SjgKYaqqVsKhzXT6lHwr7bCllySkkTxmNGjUnbMMp7G/kVFP96Ydi/fqxv26dKCclzOkWROmHh/dPRsWC5PSRKC74HiV53yMuYUCH16XdX+tL7fUpwcxP/bUv2xCPt8W0RB9STYXfuUv428uhkZbrFJ4jpRyahZ25Zn+tt1+WpguJxFrzuizVNNiE+D2Mdu/ejZkzZ2Lr1q3uexcBzfcxAuDzPYx4SVoQSEo+EkZTGJoaKlBZtjvQzSEiP0hNGwVFMaK2aj/qqosC3Rwi8oO0jOZ7DVaU7kRTQ2VgG0NEftFyuWlZ4VY47I0Bbg0R+UpR1Q49gtUNN9yA/v3748CBA4iIiMDPP/+ML7/8EmPHjsW6det8Xi8HjIKA0WhGamrzN5UHCjYGuDVE5A9mSyQSk4cCAIr3/RDg1hCRP4RHJiE2PhuAipJ9Pwa6OUTkB9Fx/RAemQyX046D+38KdHOIyEeKq2OPYPXtt99i0aJFSE5OhsFggMFgwB//+Efcf//9HslpenHAKEi0fGtZVrwNDntDgFtDRP7QUtcl+zfD5XIEuDVE5A9ph25qf6Bgo/t0cCIKXoqi/H5T+3x+wUMUtNQOPoKU0+lEVFQUACApKQmFhYUAmm+GvWPHDp/XywGjIBEd0xcRUSlwuRwoLeS3G0ShICFxECzWaDhsdSgv2R7o5hCRHySnHgWD0YLGujJUl+8JdHOIyA9S+xwNKAbUlO9FfU1JoJtDRD5ouel1e49gNXz4cPzvf/8DABx77LF46KGH8PXXX2PRokUYMKDt/dc6igNGQUJRFKRm/gEAcICXrxCFBMVgRErf5rOMDhSwrolCgdFkRXIGLyMnCiWWsBjEpwwBwLOMiIJWiJ9h9Pe//x2uQwFd//d//4e9e/fi+OOPx8qVK/H444/7vN7ek5IWAlL6jEbe9o9RU1mAH798DLGJAxCXlIPo1AEwWcID3Twi8kFq37HYl7sO5SW/YvP6xxGXmIPYxIGISh8Ao8ka6OYRkQ9SMsfiQMFGlBRsQkNtKWITByIuaSAi0/rDaDQHunlE5IPUrLGoOPArCnd9iZryvYhNzkFs0kBEpGbBYOSfVEQ9XUfOIArmM4ymTZvm/v+AAQPwyy+/oLy8HPHx8e6kNF/0nr2b0wG0jjoU4re1YnohRTJKMfVS/LZGTK8Up221RKFPv/HYv/dr1NUUoa6mCIV7vgagICquL2KTmg9IYxL6w2iyQBHaBACKEP+qOyrXn1HAYuSuVsS39L4Lr8+H16E3ZlsVImg147eF5ziF50ixnU4hshOQI3x1x3n6FL/dRXGeLlfb7FaHcC8gk8YvWYj2lWK2FSGWW9GIYpYi7CMjkpGSMRolhZtRW7UftVX7sW/3F1AUA6LiMxGblIPY5IGISciCwWgWY7kBQJXq2p8xvTrXBWFdUqQwADh1xoLLsb4anzNp+8J7KNWoVl07xbr2/jmR4nstGr90/fUrxfrKn12p5ruurp0AWr1moa4VjbpWhbpWhLo2CHUtxaUDEPvZ2NgsxCUNQuXB31BTsRc1FXuxb9dnUAxGRCdkITZ5IOKSchCVkAmDwaTdz0nHFzr7ce19h7Bt4Veqez/gw7rERHitmHeh5uV+XIjldsk7Qal+9U7XjN+W9hFi/fqzv/Y8NhZS6XVTHU6orT6Eikl4nzWOwxVhP6kK9Sv24xr9g9RfJyQPRVRcJmorC1BdlofqsjwUYC0MRjOiE7MRm5KDmJQcRMX1gWIw+lZzYhy9sLzGNvT28YrQLypSnwyN422dr0Oq0ebn+Od4W+rHAf11Ki+vUXM6++Uml/e/U60G+Z6XUl3bWtW1LYgHRTpF7cBNrUPsvUlISAAAlJSUICUlxad19J4BoxAxcOgZyBw4GVXlu1FZlovKslw01B9EbWUBaisLsH/XOiiKEdHxmYhOzUFscg6iE/vBwG80iXqsI0ZegP5DTm2u6fJdqCrbjcaGctSU70VN+V7s2/kpFIMJMQlZiEnNQWxKDiITMmHQ+GOAiAJHURQcdcwVaKwvR2VZbnOffXAXbE3VqD64G9UHd7v/0IxJ7I+YtEGISRmIyPi+UIQ/HogosAwGE0b+8Vo01peh6uAuVB7MRdXBXNhttagq+Q1VJb8BAIymMMQk90d02iDEpOYgIi4NivStKBF1H1VtfrS3TJCJiIjA3r17kZycDACYPn06li9fjvT0dADAgQMHkJGRAafWSTEaOGAUhCyWKCSnjUBy2ggAQIOzGlUHcw91XLvQ1FCJ6vI9qC7fg/2/ftL8h2ZSNmKScxCbMhCR8Zngr56oZ7GGxSC1z2ik9hkNAKhzVKDqYC6qSneh8uAu2Btrmn8+mIuCn1fDYLQgJrk/YlIODSDFZUDzVDki6nZhEQlIi0hAWuYfoKoq6u1lqDy4C1WluagqzYXDVofKkp2oLNkJADCawxCTPBAxKQOb/9CMTQNvN0nUcyiKgvDIJIRHJiEtaxxUVUVtUwmqSnehqmQXqkt3w2lvQEXRr6go+hUAYLJEIDp1IGJTcxCTOghh0ckAfL88hIh8E6qXpDU2Nnqksn799ddoaPBMVe9MaitHDUKANTwOKZljkJI5Bqqqoqm+HJUHd6GyfDeqSg/9oVnS3JEV/AwYTFZEp/RHTGrOoW8+MviNJlEPExaZgLDIBKRmNf+h2VBb2jwwXJaL6pJdcNjqUVm8A5XFzTGZRnM4olMHNNd1Wg7CY9M6db0yEfmXoigIj05GeHQy0vuPh6q6UF99AFWluagsz0V1SS6c9kZUFP6MisKfAQAmaySiUwciJi0H0ak5CItJZl0T9SCKoiAiNg0RsWlIz/kjVNWFuspCVJc0n4FUU7obDls9Kgq2oqJgKwDAHBaN6PQcRKcPQkxaDqzRiQF+FUS9REduat1FA0Z79uzBPffcg88++wzFxcXIyMjAJZdcgrvuugsWi8W93MaNG/G3v/0NmzZtgqIo+MMf/oCHHnoIo0aN6tT2eQ8jclMUBWGRiUiLTETyoOZvPhpqSlBdsgtVpc3ffDhs9agq3I6qwuYYb6Ml3P1tZmTfQQiLS+UBKVEPoigKIqJTEBGdgtTBE5r/0KwqRnVJrsc3mpX7fkblvt//0GwZPIrsOwjW6CTWNVEPoigGRMamIzI2HamWE6C6XKir3I/qA81f8NSU7oajqQ4V+f9DRX5zTK45PKZ58Mhd1wkBfhVEdLjm+w/2RVR8X6QNnwyXy4m68gJUH9iF6gO7UFO6B/bGGpTnbUZ53mYAgCUyHtHpOYhJG4SIfjmwRMYG+FUQhSbFKd8z9/BlusL27dvhcrnwzDPPICcnB9u2bcPcuXNRV1eHxYsXAwBqamowbdo0zJgxA08++SQcDgfmz5+PadOmYd++fTCbA3OLGQ4YhThFURARk4qImFSk5Rx36A/NIlSU5TZ3XCW74bQ1oGLfNlTs2wZsAkxh0YhOH4jotOZvP5q/+eAfmkQ9haIYEBmXgci4DKQPPh6qy4nayv3NZx8d2IXakjw4mupQnv8TyvN/Ar4HzBGxzd9opuUgOj0H1ij+oUnUkygGA6ISMhGVkImMoZPhcjpQV16AyoPNf2jWlu6FvaEaZXk/oizvRwCAJSoB0RnNNR2VngNLBP/QJOpJDAYjopOyEZ2UjT5HngyX046ag3tRdTAXNcW/oa40H7a6CpTt2oiyXRsBANbYZERn5CAqYxCi0gfCHB4V4FdBFBoCeUna9OnTMX36dPfPAwYMwI4dO/DUU0+5B4x27NiBiooKLFq0CJmZmQCA+fPnY8SIEcjPz8fAgQO9t1lRPL4Ubv1zZ/WaASPV6YLa+rboYuqK/LYoYpqScO8QKU1JSG1o3oaUiCIlrnU8KUyBAVExfRCe1BcZQyZCdTlRV7EPVS3ffBzMg6OxBhV5W1CRtwUAYImIQ0y/oejzh9NgtIS32oZGcoKYtiA8QWeCCgD5li1SAoSYzqCxDSm5QUxdkbahkZImJTroTG3wJXXFISSridM1EiBcBu+vw94q6cGulV6lh9PZ5gOiCgmEYu0CYv1KaWiqWIv60w+lGpJCMLwloSkwIiauHyKTs9DniBPhcjpQW5aP6pJDf2iW7YW9vgrluZtQnrsJAGCNSkRM9nBkjD0FBpPnNxa+JCz6s+b0JizKaTNyzemtU1XYn0mfeQBwOoV0FYOQxiUkuEi1qDVPb/1qpil18Dl2zR2pDi4noLaqayG1yq91LSQ2KRr7Vbn/FaY7Op5CZIQRMQnZiEzrjz7Dp8DlsKP24B73mQq1ZQWw1ZajbOf3KNv5PQAgLDYFcQNGIu3oKVBa/04DnWoqvVdCDYlJNlrJU1I9dkuqqX9SlpqfozPVVKx3ph9K6YdSqiigkUAofIalNDRv2zAqZsQl5yC6Tw4wchqc9ibUluQ113XxLtSX7UdTVSmaqkpx8NdvAQBh8emIH3w0UkZNanPzbM3XobNf1ptspjVPd/qhVn8t9L/SuuRjaq2UNKGudfbLPvXXOvtlKQlNa16X1XWw0XHT6+rqao/JVqsVVqvVr82pqqpyp5gBwJAhQ5CUlITnn38ed955J5xOJ55//nkceeSRyMrK0miyisGDB7sHiWprazF69GgYDt1ypjP3LwJ60YAReacYjIhKzEJUYhb6DDsJDoMDdQf3orq4ueOqO5gPW30lDm7/FrUH9iBn2lyeKkvUwxmMJsSkDEBMygBg+FTYDHbUlexBdfEu1BTvQl1ZAZpqy1C67QvUl+zFgKlzYAqLDHSziUiDwWRuTlNLGwQAsClNqD2Qh5qi5rquL9uPxqoSFG9ei/qDBcg+6TIYzf49uCUi/zKarYjtcwRi+xwBAGhyNaC2eHdzXRftQmNFERorilD03UdoKNuPfpMvhMHIP9+IfKHnDKOWM3xazJ8/HwsWLPBbW3Jzc7F06VI88sgj7mnR0dFYt24dZsyYgXvuuQcAMHjwYKxevRomjRNali9f7rd2ecM9DnkwGE2ITh2I6NSB6HPom4+aA7nI2/AGGiuKsOODx5EzbS7C49MC3VQi6iCjyYKYjMGIyRgMAHDaGlFVuB17N7yJupI92PnBUgycfiXvh0IURIzmMMT2HYrYvkMBAI6melTmb0P+hrdRXbAdv334JAZOuwLmiOgAt5SIOspkjUBc1nDEZQ0HANgbms/63/f9+6jctQWO+lr0nzYbRmt4O2siotYUl8aZdIctAwAFBQWIiYlxT5fOLlqwYAEWLlyouc6NGzdi7Nix7p8LCwsxffp0nHvuubjiiivc0xsaGjBnzhwcd9xxeOWVV+B0OrF48WKceuqp2LhxI8LDvdf9rFmztF9UJ3HAiDQZzVbE9R2GIWdcj12rn0VTVSl2frgMA07+M6LTvV9HSUQ9m9EShoTsUbAkpyF31aG6fv9xDJx2BSKS+ga6eUTkA5M1AkmDjoE1KRW7Vz+PhoP7sPP9pRg4fS7C4pID3Twi8oE5PBopw46HNTEFeWteRG3hLvz23hMYcOoVsETFBbp5RMFFxyVpMTExHgNGkmuvvRYXXHCB5jLZ2dnu/xcWFmLy5MkYP348nn32WY/l/vvf/2LPnj349ttv3ZeT/fe//0V8fDzee++9drfTVZilTh1ijU7AkNOvQ2RKNpy2Buxa9Qwqdm8JdLOIqBPC49Mw+MzrERafDkdDDX776ElU79sR6GYRUSdEpmRh0JnXwRKdCFtNGXa+/zjqDuwNdLOIqBOiM4cgZ8Y1MEVEo7G8CL+98zgayosD3SyioNJySVp7Dz2SkpJwxBFHaD7CwsIAAPv378ekSZNw9NFHY/ny5e5BoRb19fUwGAweN6xu+dkl3MsxPj4eCQkJHXr4igNG1GGmsEgMOuUqxGYNh+pyIu/zl1H605eBbhYRdYIlMg6Dz/grotJz4LI3IXf1cyjf8UOgm0VEnRAWm4zBZ16H8KS+cDbV47ePnkJ13s+BbhYRdUJEUl8MOut6WOOSYa+rwq53l6F2365AN4soeKgdfHSBwsJCTJo0CZmZmVi8eDFKS0tRXFyM4uLfB36nTJmCiooK/PWvf8Wvv/6Kn3/+GX/+859hMpkwefJkr+t97LHHsGTJEixZsgR///vfAQDTpk3DggULsGDBAkybNg0A8I9//MPntveeS9K8pClBSjQSUhsAaKShSelp3sfkpJQWAFCMwnN0px3In3g9iQ6Hb8NoMGPgpFko+O4dlG7/BoXfvAdHbSUyjj3dS3KDvvZKbRKChg6tS1/ylJhUppkAIbyPYpqS9wa7hGQtQCNNySikKfmQuqI3wUVORtJIXelgOoPDT2lKqsMBtdXnTjELuzWnHK0jJS2pRiFlSVqX1odVSggSUhGhM6UFkBMI5Zpr3obBGI5BU+Ziz1evoCJvCwo+ewWO2iqkjDqxTSyn3vrVux/Qmid96yMmsQnJKgAAqR71pqdp1JxL2HforV/tNCXv82xO72+8Rahfh19SV/xU13YvdS3d7FH4xg2QUwvFxDWxRvX31wahrsWERY30HrG2hPa29OOWsGgMPvUa5H32Eqr3bceej/+Nvsf/CYlHjm+7/Z6Yaqo3ZQnQ6Jd1pixp7MtdYr+sL2XJppE4ala9v/igTj90ONrE66lCXQdd+qFUP35MEm7p58KiEjD4zOuwe/W/UXdgD/a8+wwyp1yMuEGjvGxDWJfuhGGtJDY/HW9rpeeK/a++hGGpTwb81y/7klYsHVdL/bI/UtIcvTQlTXGqUAzar13rOLsz1qxZg127dmHXrl3o29fz9g8tKWZHHHEEPvjgAyxcuBDjx4+HwWDA6NGjsWrVKqSnp3td7+H3L/rTn/6ERYsW4dprr3VPu/7667Fs2TJ88sknmDdvnk9t5xlGpJtiMCBz3NnoM+ZUAEDJ/77Ans9WwOXUGGgjoh7NYDSh/8SLkTp8EgCg6PuV2L/+bfGPayLq+YxmKwZOmYPEQX8AVBX7vnwTxd+v6nTELhEFjiksEjmnXYXY7OYz/vNX/welW74IdLOIer4AnmE0e/ZsqKrq9XG4KVOmYP369aisrER5eTk+/fRTjBs3rkPbWL16NaZPn95m+rRp0/DJJ5/43HYOGJFPFEVB2oiTkDXpQkAxoDJ3C3JXPgtHU0Ogm0ZEPlIUA/r+4Qz0mTADgIKDv3yDPWtfhMthD3TTiMhHisGIfsefj9QxUwAABzatRcG616BqnHVJRD2bwWRG/5NnIfGo4wCoKFr/HgrXvw/VX2eEEYUgBR24h1GgG9kJiYmJeOedd9pMf/fdd5GYmOjzenvPJWnUJRIGj4UpIhp5a19EbVEufnt/GQaeMpfJDURBLPmoE2COjMXez/6Lqj3bkPvh0+g/fQ5MYZGBbhoR+UBRFKQdMx3mqDjs+/JNVGzfCEddDbKmXQaj2XtUMBH1bIrBgIwTzoY5Kg7F336Eg1vWwV5XhcyTL4TByD/xiNrQkZIWjBYuXIjLL78c69atw/jxzZefb9iwAatWrcJzzz3n83p5hhF1WkzfIRh0xl9hCo9GY0Uxdr7H5AaiYBc3YCQGnnoljJZw1B3Yg9/eW4qmmvJAN4uIOiFx2Dj0nz4HismMmoLtyH3vSdjrawLdLCLykaIoSBlzEjKnXAQYDKj6bTPy3n8GTp7xT9RGV6Sk9SSzZ8/GN998g7i4OLz99tt46623EBsbi6+//hqzZ8/2eb0cMCK/iEjqg8FnXQ9rXArsdVX47f1lqN3P5AaiYBaVMRA5M66FOSoOTZWl+O3dx9FQui/QzSKiTojJHoaBZ14NY1gkGkr3Ydfbj6OpoiTQzSKiTogfMhb9T58Lg9mKuv25yH1rKew1lYFuFlGPorjUDj2C2bHHHosVK1bgxx9/xObNm7FixQoce+yxnVpnrzlfUbU7oSqeN2WWUldUKT0NGskNelMbNBKzpKQAg5j44v1qS4PGPajbS0NrM1261cFhL9samYDBp1+H3WufR92BPch77xn0O/kixOWMarUu4epQX9KUdCZA6H59gJhWpepMhhATIwC4dCY9OIUbEUtpLIBGuoqQqOCQUlo0kl26PU3J6YLa6pen2L1/8KU0FkBOU5KS1RQhgUrrBtGKkLojdUwGKQFJI/mrKxLMIuLSMPjM65G76l9oLC9C7ltPIGv6bET3G+L5JN0pjt6nA1rpMfoSpjQ7fd1pSsJ0jZoT61p4jpSypJW64tRb11IyklZdC0lLXZV+6DXVVEov1ahrMRlRqF8I/bUipJ0C8r5D/kx6X4+UqgZo1anObRz2dkQnZWHwjOuQu/JfsNWUIfeNpcg+/XJEpmXrXtfhfEo1FU7/9ynVVLqUQG/KkmZd60tHMvkx/VBMWdK5H2h+Tnf31862/bUPdS2mmkrH4X5MPxTXJU7X6K/9dJx6+LZj+gxGzll/xe6P/oXG8mLsfvVxZJ91JcIS0zyfpLe/1jhG1v06xJQ0+b3y1/G21CcDWmlo+vplqU9ufo5/+mWtY4KO9tf2IL7sqlNc0O5D0IH5PUx1dTViYmLc/9fSspxePMOI/MoUFoGcU65CbNZRUF1O7F3zMkp/+jLQzSKiTrBExmLwGX9FVHoOXPYm5H30L1Rs3xjoZhFRJ4TFJmPwjOsQkZwJZ2Mddr/7FKrzfg50s4ioE8KT+mDQzENn/NdWIveNpajdxzP+iYDmLyg68ggm8fHxKClpPks4Li4O8fHxbR4t033Va84wou5jMJnR/6TLUPD9uyjb9jUKv34P9tpKpE84HYrCMUqiYGS0hGPgKXOx96tXUfnbZhR8+grstVVIHnMSFCWYMyWIei9zRDRyTr8aeZ+9hJq927Fn5b/RZ+KfkDh8QqCbRkQ+ssQkIGfmdchb9W/UF+Vhz7vPoO/UixE3eFSgm0YUWOqhR3vLBJHPPvsMCQkJAIDPP/+8S7bBASPqEorBgD7Hz4QlKg5FGz5C6U9fNCc3nHQhYDYHunlE5AOD0YTMKRfDHBWH0s2fo/i7lbDXVSLj+LPBE1aJgpPRbEX2qZdj37o3UPHr99i/7k3Y66qQesx0BHfAMFHvZQqLQP+z/4KCVStQnbsVBR//B466KiSNnhjophEFTEfuURRs9zCaOHGi1//7EweMqMsoioKUo0+EOTIW+Z+/ispdW2Cvr0HWmXNgtIYHunlE5ANFMSB9whkwR8aicP17KNv2Dex11eh72iUwmCyBbh4R+UAxGtH3xPNhjopDycY1KNm4FvbaKmRMPReKUb4PDhH1XAaTBf1OnYXCL95B+f++RtGX7zWfGXwiz/inXkpV5XvdHb5MEPnf//7X4WVHjBjh0zY4YERdLn7IGJgiorBn1YuoK8xF7htL0X/GlTBHxwW6aUTko6SRJ8AcFYv8tStQnbcNeW89jawzL4cpPDLQTSMiHyiKgrRjp8McFYv9695Exa/fw95QjczTZ8FosQa6eUTkA8VgQMaks2GJjkPx1x/h4I/rYKuvQsYpF8KgFRpAFIIUl3boSssywWTUqFFQFAVqOwNdiqLAKYWBtIN7CuoW0ZlDkDPzr9j94b/QVFaM3NcfR/aMuQhLSg9004jIR7EDR2JAeDT2rHweDUV7sPv1pcg+ay4ssYmBbhoR+SjxyPEwR8Rg7+qXULtnO/JefwJZM6+AOdK3dBUiCixFUZA89iSYomKxb+2rqN6+GY66amSeNQfGMJ7xT71ICJ5hlJeX1+Xb6DUDRs1xnp6nX6pCnKdi1h/TK0XrqmLkrjx8aRCiPp1CrLMixfEKyzdvX4oAFZbXGevrbV0R8X0w+Kzrkfvxv9BUUXIoxncOovrkHFqXsB6NutUb2ymtS2s0WUyUFSN/dUYEA1CFiEyX8DmR4z814reFeTYhYtpiEOJ7hemARjSooYtieu0OqK1uuKwK35iJ8b2AGOEr1rXwe9GO6ZWeI0XI64+Kl6KupUh4eT8gf1YNreKDo1P7Y9CMa5vjuStKsPu1x5F95lyEp/Q9tA3v69GqOTl2V9/yPtW1FKctxfRqvVcGfdG+Uly3UyPiW2/8tkOM3/ahrltNt2v0a3qoDidUpVW9OoV732nUtSLuC4RCEWK5oVXXJiF+W6otYV1SjHfzuoT6FWO2hRVpXFnWur2xWcOQM+Ma7F75HBpL9mH3K4+j/1lXwhqforkuX+pafB3CW6L57a9Qj6rBP7HcgA/1KyyvVddSNLdD9U8sN9Dx+G2Hv/prL3WtOL3XqHR8DgCKVKdCfy3Vr1S7gFy/rfu/FtJbpNVfS59j/f24uIk28xIGj4U5LAZ7P16O+oJc7PnvUmSf/fsZ/8LHy7e6lo63xdcnb0Psl6V6F94rf9a13r4XAGxCPVp09suta9RjnrQvUEytlguuQRF/CcV7GGVlZXX5NngBK3UrS3QCBp5zHSLS+8Nla0Teu8+g8rctgW4WEXVCWEIaBp53PcKS0uGor8Hut55Azd4dgW4WEXVCRGo/DDzvelhiE2GvLkfu60tRX7Qn0M0iok6I7jcY/c+7FqbImOYz/l95HI0HiwLdLKLu0XKGUXuPIJabm4vrrrsOJ598MqZMmYLrr78eubm5nVonB4yo25nCIjHgrL8gZuBRUF1O5K96CaWbvwh0s4ioE8xRcRjwp2sR2XcQXPYm7PngX6j4dWOgm0VEnWCNS8bA865HeEomnI112P32U6jevS3QzSKiTghP6YMBF14Pa0IKHLWV2P3aUtQV7Ap0s4i6norms9W1HkE8XrR69WoMGzYM33//PUaMGIHhw4fju+++w5FHHom1a9f6vF4OGFFAGEwWZE2fhcQRfwQAFK1/D8Xr3oPqp1Ofiaj7Ga3hyJ4xF7FDjgZcLuxb+wpKN3zS7o34iKjnMkVEo/+frkF09lCoDjv2frgcFVu+CXSziKgTLDEJ6H/+dYjI6A9XUyP2vP0Mqn/dEuhmEXUpRVU79AhWf/vb3zBv3jx89913ePTRR7FkyRJ89913uPHGG3H77bf7vF4OGFHAKAYDMk6YibQJpwMAyjZ9gX0fvQyX1r1miKhHMxhNyJx6EZLGTAYAlKxfiaJP3hLv+0REPZ/RYkXWGXMQf+SxgKqiaO2bKFn/MQeDiYKYKTwS2X/6C2JyjoLqdGL/ey+h7Hue8U8hzKUCLlc7j+Dt13799VdcfvnlbabPmTMHv/zyi8/r5YARBZSiKEgZcyIyp14MxWBE9Y4t2Pv2M3A2NgS6aUTkI0UxIP24M5A+cSYABRU/fYOC91+Ay24LdNOIyEeKwYg+J52HlGOnAgAOfrsWhatehepjTC8RBZ7BbEHm6bOQMKr5jP+Sz97DgU95xj+FqPYuR2t5BKnk5GRs2bKlzfQtW7YgJSXF5/X2mpQ0uJxtIjekgxzFLp/hIicw6Utd0UpTUk1CooNTZxqLVjqDmMwkLK8zzQHQSDzwsq74QWNgjIpG/ofNyQ15ry5F9szm5AYx8QVaKSpSqozwXglpRs3rEmYI08XUFY00JSnRQUxtEBIjtFLSpOQGMY1FSFqQpgOAXVyXQfNnn3mrayn9UEhj0XyOmJokfCiN8nsjJa4pwnshJ5hp1LXwGdObhibtB5rX1fHpyUcdD1N0DPZ9vAI1u7Zhz+tPIWvG5TCFR2luQ6otg9Bep1F4T3SkOLZQ9a5LK3VFqlNhX+4UkvQcQpIhADgN+pIUpdrTTlPqWFKL39IPvaSaKna794WFPhmAnKCmt6610pSkPkVILxU/91opRNI2dPbXelJNpW0oUJB2zHSYYuJQ+MmbqNq2Ec7aavQ9YzaMFqt2qqneFFadKUuAxnGHn1KWALmP15+epr+/Dub0Qzi9HYdLx7sav2TpOX5NP5T6a319rEHjhHkxyUt3XcvbEI8XWm1bgQHpE2fCFBuHki8+RPnGL+CoqULGqRfBYDK1k5Lmn+Nt7VRT//TLUp8MyPUrpRn6M61Yb78spSUCcoJaV6UfBpuOXHIWzJekzZ07F1deeSV2796NCRMmQFEUrF+/Hg8++CBuvvlmn9fLM4yox4jKGoz+5x6W3PAqkxuIgl3soJHI/tNVMFrD0VC0F7tfWwpbVVmgm0VEnRA/Yhz6nTUHismC2j07sOe1J2Cvqw50s4jIR4qiIOnYE9HntIsBgxHV27cg/w2e8U8hJsRT0v7xj3/g7rvvxtKlSzFx4kSccMIJWLZsGRYsWIC77rrL5/VywIh6lPCUPhhwwWHJDa8vRV0+kxuIgllknwHof/71MEfHw1ZRit2vPo6G4n2BbhYRdUL0gGHIPu9qGMMj0ViyD3mvPI6mspJAN4uIOiH2yDHod85cGCxW1BfkYs9/l8JeXRnoZhH5R4gPGCmKgnnz5mHfvn2oqqpCVVUV9u3bhxtuuAGKIp9h1x4OGFGP0zq5If+NZ1C1fUugm0VEnRCWmIoBF1yPsKR0OOprsPeVJ1C7e3ugm0VEnRCRnoX+F14PS1wi7FXl2PufpWjYvyfQzSKiTojKHozsCw+d8X+wGHtfeBxNJTzjn0KAU+3YI0g1NDSgvr4eABAdHY3y8nI89thjWLNmTafWywEj6pFMYa2SG95/CWUbmdxAFMzMUbHof961iMwcBJetCflvPYfKrRsD3Swi6gRrfDL6X3g9wlIz4Wyow97/PoWa37YFullE1AlhqX2Qfcn1sCSkwFFTib0vLUX9Xp7xT8Gt5R5G7T2C1YwZM/DSSy8BACorK3HMMcfgkUcewYwZM/DUU0/5vN6Qv+l1S+SrA3ag1e9fEW4GaNC4KRp03qBWlUYphZv2AYBLuNmfFDfvEm606zTK44EuYazQKdyMziWcxqZ1AznploVOSOtqOy3j5PNhjIxExU8bcODz92CrPIjk40+BcujGidK9GKXp0u/DpXF/RZf0uxVuaqpKN1LUusGiMM9p9v47N5j1LQ8ADqP3eQ6z95vJ2k3SdDnpyibMazJ6rstW1/yzr5HMvtW1xvi4eCNLYftC/Yr1DkAVblysu66FGxADgEu4C7xY10ItSjXa/BzvxLpu8wQFfU+9FEXr3kL1jp9QuPIVNFWUIvGYye7TZaXdoyrUqVSjWnUt7wuk+pVubqxx40jhJqxOkzBd5/IA4BDqVJpuN3uvUaneAcBmFOra1EV1rbZti9QvKxo3/9QdWCDWtUZIhdhfS/2yL3Ut1KnUL/tS19I9ZaV1td7vGs3od9Yc7FvzCurzdmLfm/9GykkzEDfy2N/XpbN+pXuyukzy58sl1LW4bxZDRjSO0exCnZp1Tjdp9NdCv6y3rqXaBQCz0fu6Wtd1UxfWtVS/vtxkWTrwk373Wul++o+3hf5do+akmtdf1zKprqUbObde3hgWgX7nzsW+D19G4/69yP/v00g79VxEHzHy9+f46Xhb2g80P0fYiLAvEOtXujE6/NcvSzWqNU9vvywdawOASajr1vXe2boOWh255CyI35Mff/wRS5YsAQC8+eabSEtLw+bNm/HWW2/h7rvvxtVXX+3TekN+wKimpgYAsB4r285sEp4kTQcA3tMxoCo2f42KzV8HuhnkJzU1NYiNjfXpeYAf65oCquzbT1D27SeBbgb5Sefr+qM2A8FoFJ4kTaeAK/n0PZR8+l6gm0F+0tm6/sr5vpeZnW0VdSuXC8UfvobiD18LdEvIT3yt66DlUuUIzsOXCVL19fWIjo4GAKxZswZnn302DAYDxo0bh7179/q83pAfMMrIyEBBQQGio6N9utlTdXU1MjMzUVBQgJiYmC5oYc/E183X3ZVUVUVNTQ0yMjJ8en5n6rq3/o6B3vva+bpZ16Gst752vm7Wdajqra8b6L2vPdjqOmipLvm0uMOXCVI5OTl49913MXPmTKxevRrz5s0DAJSUlHTqcxXyA0YGgwF9+/bt9HpiYmJ61Y6rBV9379Kdr7sz32j4o6576+8Y6L2vna+767GuA6e3vna+7q7Hug6M3vq6gd772oOlroNWiF+Sdvfdd+Oiiy7CvHnzcNJJJ2H8+PEAms82Gj16tM/rDfkBIyIiIiIiIiLqxVwq2l7z7m2Z4HTOOefgj3/8I4qKijBy5O/3GjvppJMwc+ZMn9fLASMiIiIiIiIiCl2qq/1LzoL4kjQASEtLQ1pamse0Y445plPr5IBRO6xWK+bPnw+r1RropnQrvm6+7lDVm15ra731tfN1h/7r7k2vtbXe+tr5ukP/dfem13q43vq6gd772nvr6+52zg4MGLV3j6NeSFF7XZ4eEREREREREYW66upqxMbG4uSMv8Bk0B6Uc7ia8EnhM6iqquqV99HyhmcYEREREREREVHoUtGBm153S0uCCgeMiIiIiIiIiCh0hXhKWlfhgBERERERERERhS6XCwDvYaQXB4yIiIiIiIiIKHRxwMgnhkA3oKe49957MWHCBERERCAuLs7rMjfccAPGjBkDq9WKUaNGeV3m9ddfx6hRoxAREYGsrCw8/PDDXddoP/DX6169ejXGjRuH6OhoJCcn409/+hPy8vK6ruGd5I/XvWDBAiiK0uYRGRnZtY3vBH/9vlVVxeLFizF48GBYrVZkZmbivvvu67qG+4h1zbpujXXNum7BumZds657DtY167o11nXw13WP41I79iAPHDA6xGaz4dxzz8XVV18tLqOqKubMmYPzzz/f6/yPP/4YF198Ma666ips27YNTz75JB599FEsW7asq5rdaf543bt378aMGTNw4oknYsuWLVi9ejUOHjyIs88+u6ua3Wn+eN233HILioqKPB7Dhg3Dueee21XN7jR/vG6guTN77rnnsHjxYmzfvh0ffPABjjnmmK5ocqewrlnXrbGuWdcA65p1zbruaVjXrOvWWNfBX9c9jaq6OvSgVlTysHz5cjU2NlZzmfnz56sjR45sM/3CCy9UzznnHI9pS5YsUfv27au6XC4/ttL/OvO633jjDdVkMqlOp9M97f3331cVRVFtNpufW+pfnXndrW3ZskUFoH755Zf+aVwX6szr/uWXX1STyaRu3769axrXBVjXMta1NtZ1z8W6lrGutbGuey7WtYx1rY11TZKqqioVgHpS3GXqtPgrNB8nxV2mAlCrqqr83o4zzjhDzczMVK1Wq5qWlqZecskl6v79+z2W2bt3r3r66aerERERamJionrdddepTU1Nfm+LHjzDyI+ampoQFhbmMS08PBz79u3D3r17A9Sqrjd27FgYjUYsX74cTqcTVVVV+M9//oOpU6fCbDYHunnd5rnnnsPgwYNx/PHHB7opXeqDDz7AgAED8OGHH6J///7Izs7GFVdcgfLy8kA3rUuwrlnXrOvQw7pmXbOuQw/rmnXNuiZNTmfHHl1k8uTJeP3117Fjxw689dZbyM3NxTnnnHNY85w47bTTUFdXh/Xr1+PVV1/FW2+9hZtvvrnL2tQRHDDyo2nTpuHtt9/Gp59+CpfLhZ07d+Kxxx4DABQVFQW2cV0oOzsba9aswZ133gmr1Yq4uDjs27cPr776aqCb1m2ampqwYsUKXH755YFuSpfbvXs39u7dizfeeAMvvfQSXnjhBWzatMljhxdKWNesa9Z16GFds65Z16GHdc26Zl2TJlXt2KOLzJs3D+PGjUNWVhYmTJiAv/3tb9iwYQPsdjsAYM2aNfjll1/w8ssvY/To0Tj55JPxyCOP4F//+heqq6u7rF3tCekBI+lmaIc/fvjhB79tb+7cubj22mtx+umnw2KxYNy4cbjgggsAAEaj0W/baU93v+7i4mJcccUVmDVrFjZu3IgvvvgCFosF55xzDtQuLLrWuvt1H+7tt99GTU0NLrvssi5Zv5buft0ulwtNTU146aWXcPzxx2PSpEl4/vnn8fnnn2PHjh1+246Edc26Zl2zrjuLdc26Zl2zrrsK65p1Hcp1HcxUl6tDDwCorq72eDQ1Nfm1LeXl5VixYgUmTJjgPhPw22+/xfDhw5GRkeFebtq0aWhqasKmTZv8un09TAHbcje49tpr3R2FJDs722/bUxQFDz74IO677z4UFxcjOTkZn376qd+3057uft1PPPEEYmJi8NBDD7mnvfzyy8jMzMR3332HcePG+W1bWrr7dR/uueeew+mnn460tLQuWb+W7n7d6enpMJlMGDx4sHva0KFDAQD5+fkYMmSI37blDetaxrr2L9Y167qrsa5lrOvOY12zrlnXXa+31XVQU1UA7QyiHhpkzczM9Jg8f/58LFiwoNNNuP3227Fs2TLU19dj3Lhx+PDDD93ziouLkZqa6rF8fHw8LBYLiouLO71tX4X0gFFSUhKSkpK6fbtGoxF9+vQBALzyyisYP348UlJSum373f266+vr23xz0/Kzy9V9d5oP1O87Ly8Pn3/+Od5///1u3zbQ/a/7uOOOg8PhQG5uLgYOHAgA2LlzJwAgKyury7fPuu4erGvWNeu667GuuxfrmnXdHVjX3Yt13b11HdScLkBp5x5Fh1LSCgoKEBMT455stVq9Lr5gwQIsXLhQc5UbN27E2LFjAQC33norLr/8cuzduxcLFy7EZZddhg8//BCKogCA+1+PJqmq1+ndJaQHjPTIz89HeXk58vPz4XQ6sWXLFgBATk4OoqKiAAC7du1CbW0tiouL0dDQ4F5m2LBhsFgsOHjwIN58801MmjQJjY2NWL58Od544w188cUXAXpV7fPH6z7ttNOwZMkSLFq0CBdeeCFqampw5513IisrC6NHjw7QK9Pmj9fd4t///jfS09NxyimndPfL0M0fr/vkk0/G0UcfjTlz5uCxxx6Dy+XCX//6V0yZMsXj246egHXNugZY1wDrmnXNugZY16zrnod1zboGQreuexrVpUJVtM8warmMMyYmxmPASKL3DLOWAcbBgwdj6NChyMzMxIYNGzB+/HikpaXhu+++83huRUUF7HZ7mzOPulUgI9p6klmzZrWco+bx+Pzzz93LTJw40esyeXl5qqqqamlpqTpu3Dg1MjJSjYiIUE866SR1w4YNgXlBHeSP162qqvrKK6+oo0ePViMjI9Xk5GT1zDPPVH/99dfuf0Ed5K/X7XQ61b59+6p33nln978IH/jrde/fv189++yz1aioKDU1NVWdPXu2WlZW1v0vqB2sa9Y167oZ65p13YJ1zbpmXfccrGvWdSjXdU9RVVWlAlAnG89Wp5jO13xMNp6tAlCrqqq6vF35+fkev/+VK1eqBoNBLSwsdC/z6quvqlartVvaI1FUtRvvhkZERERERERE1A2qq6sRGxuLPyqnwwSz5rIO2LFe/RBVVVUdOsOoo77//nt8//33+OMf/4j4+Hjs3r0bd999N4qKivDzzz/DarXC6XRi1KhRSE1NxcMPP4zy8nLMnj0bZ511FpYuXeq3tujFS9KIiIiIiIiIKORYLBakpaVhffGH7S8MIC0tzeOyR38IDw/H22+/jfnz56Ourg7p6emYPn06Xn31Vff9kYxGIz766CNcc801OO644xAeHo6LLroIixcv9mtb9OIZRkREREREREQUkhobG2Gz2Tq0rMViQVhYWBe3KHhwwIiIiIiIiIiIiDwYAt0AIiIiIiIiIiLqWThgREREREREREREHjhgREREREREREREHjhgREREREREREREHjhgREREREREREREHjhgRLpNmjQJN954Y8hsc/bs2TjrrLO6ZN1EwYA1TRR6WNdEoYd1TUTdzRToBhB1xNtvvw2z2ez+OTs7GzfeeGO3d5pE5B+saaLQw7omCj2sa6LejQNGFBQSEhIC3QQi8iPWNFHoYV0ThR7WNVHvxkvSqFMqKipw2WWXIT4+HhERETjllFPw22+/uee/8MILiIuLw+rVqzF06FBERUVh+vTpKCoqci/jcDhw/fXXIy4uDomJibj99tsxa9Ysj1NUDz8ddtKkSdi7dy/mzZsHRVGgKAoAYMGCBRg1apRH+x577DFkZ2e7f3Y6nbjpppvc27rtttugqqrHc1RVxUMPPYQBAwYgPDwcI0eOxJtvvumfN4yoh2NNE4Ue1jVR6GFdE1F34IARdcrs2bPxww8/4P3338e3334LVVVx6qmnwm63u5epr6/H4sWL8Z///Adffvkl8vPzccstt7jnP/jgg1ixYgWWL1+Or7/+GtXV1Xj33XfFbb799tvo27cvFi1ahKKiIo+Orz2PPPII/v3vf+P555/H+vXrUV5ejnfeecdjmb///e9Yvnw5nnrqKfz888+YN28eLrnkEnzxxRcdf2OIghRrmij0sK6JQg/rmoi6hUqk08SJE9UbbrhB3blzpwpA/frrr93zDh48qIaHh6uvv/66qqqqunz5chWAumvXLvcyTzzxhJqamur+OTU1VX344YfdPzscDrVfv37qjBkz2myzRVZWlrpkyRKPds2fP18dOXKkx7QlS5aoWVlZ7p/T09PVBx54wP2z3W5X+/bt695WbW2tGhYWpn7zzTce67n88svVCy+8UPN9IQpWrGmi0MO6Jgo9rGsi6m68hxH57Ndff4XJZMKxxx7rnpaYmIghQ4bg119/dU+LiIjAwIED3T+np6ejpKQEAFBVVYUDBw7gmGOOcc83Go0YM2YMXC6XX9tbVVWFoqIijB8/3j3NZDJh7Nix7lNif/nlFzQ2NmLKlCkez7XZbBg9erRf20PU07CmiUIP65oo9LCuiai7cMCIfKa2uu748Okt1zQD8EhWAABFUdo89/DltdatxWAwtHne4afldkRLB/nRRx+hT58+HvOsVqvuNhEFE9Y0UehhXROFHtY1EXUX3sOIfDZs2DA4HA5899137mllZWXYuXMnhg4d2qF1xMbGIjU1Fd9//717mtPpxObNmzWfZ7FY4HQ6PaYlJyejuLjYo8PasmWLx7bS09OxYcMG9zSHw4FNmzZ5vCar1Yr8/Hzk5OR4PDIzMzv0moiCFWuaKPSwrolCD+uaiLoLzzAinw0aNAgzZszA3Llz8cwzzyA6Ohp/+9vf0KdPH8yYMaPD67nuuutw//33IycnB0cccQSWLl2KioqKNt94HC47OxtffvklLrjgAlitViQlJWHSpEkoLS3FQw89hHPOOQerVq3Cxx9/jJiYGPfzbrjhBjzwwAMYNGgQhg4dikcffRSVlZXu+dHR0bjlllswb948uFwu/PGPf0R1dTW++eYbREVFYdasWT69V0TBgDVNFHpY10Shh3VNRN2FZxhRpyxfvhxjxozB6aefjvHjx0NVVaxcubLNKbBabr/9dlx44YW47LLLMH78eERFRWHatGkICwsTn7No0SLs2bMHAwcORHJyMgBg6NChePLJJ/HEE09g5MiR+P777z2SIADg5ptvxmWXXYbZs2dj/PjxiI6OxsyZMz2Wueeee3D33Xfj/vvvx9ChQzFt2jR88MEH6N+/v453hig4saaJQg/rmij0sK6JqDsoqi8XqhJ1IZfLhaFDh+K8887DPffcE+jmEFEnsaaJQg/rmij0sK6JqDVekkYBt3fvXqxZswYTJ05EU1MTli1bhry8PFx00UWBbhoR+YA1TRR6WNdEoYd1TUTt4SVpFHAGgwEvvPAC/vCHP+C4447D1q1b8cknn3T4pn1E1LOwpolCD+uaKPSwromoPbwkjYiIiIiIiIiIPPAMIyIiIiIiIiIi8sABIyIiIiIiIiIi8sABIyIiIiIiIiIi8sABIyIiIiIiIiIi8sABIyIiIiIiIiIi8sABIyIiIiIiIiIi8sABIyIiIiIiIiIi8sABIyIiIiIiIiIi8vD/wEKAknMPDlgAAAAASUVORK5CYII=\n",
       "text/plain": [
        "<Figure size 1300x300 with 5 Axes>"
       ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-02-07T02:10:15.516207Z",
-     "start_time": "2023-02-07T02:10:14.392886Z"
-    },
-    "scrolled": true
-   }
+   "source": [
+    "import geopandas as gpd\n",
+    "df_world = gpd.read_file(gpd.datasets.get_path('naturalearth_lowres'))\n",
+    "xmin, ymin, xmax, ymax = set_ds_ref.rio.bounds()\n",
+    "\n",
+    "s = set_ds_ref['solidEarthTide'].plot.imshow(col='height', \n",
+    "                                             col_wrap=4, \n",
+    "                                             extent=[xmin, ymin, xmax, ymax])\n",
+    "[df_world.boundary.plot(ax=ax, color='black') for ax in s.axes[0]]\n",
+    "[ax.set_ylim(ymin, ymax) for ax in s.axes[0]]\n",
+    "[ax.set_xlim(xmin, xmax) for ax in s.axes[0]]"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
+   "id": "2d77a966",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-02-28T20:36:40.882532Z",
+     "start_time": "2023-02-28T20:36:40.864494Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "import rasterio\n",
     "from rasterio.crs import CRS\n",
     "from affine import Affine\n",
     "\n",
-    "with rasterio.open(f'netcdf:{gunw_path}:/science/grids/corrections/external/tides/solidEarthTide') as ds:\n",
+    "with rasterio.open(f'netcdf:{gunw_path}:/science/grids/corrections/external/tides/reference/solidEarthTide') as ds:\n",
     "    p = ds.profile"
-   ],
-   "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-02-07T02:10:15.533079Z",
-     "start_time": "2023-02-07T02:10:15.518231Z"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "03fd38ac",
+   "metadata": {},
    "source": [
     "Make sure lat/lon"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "source": [
-    "assert p['crs'] == CRS.from_epsg(4326)"
-   ],
-   "outputs": [],
+   "execution_count": 8,
+   "id": "31588ed9",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-02-07T02:10:15.537628Z",
-     "start_time": "2023-02-07T02:10:15.534889Z"
+     "end_time": "2023-02-28T20:36:40.887324Z",
+     "start_time": "2023-02-28T20:36:40.884500Z"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "assert p['crs'] == CRS.from_epsg(4326)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
+   "id": "e4688ebe",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-02-28T20:36:40.892100Z",
+     "start_time": "2023-02-28T20:36:40.889563Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "\n",
     "assert p['nodata'] == 0"
-   ],
-   "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2023-02-07T02:10:15.541418Z",
-     "start_time": "2023-02-07T02:10:15.539268Z"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "id": "4e1a8b62",
+   "metadata": {},
    "source": [
     "Make sure transform is not identity and not None"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 10,
-   "source": [
-    "assert p['transform']"
-   ],
-   "outputs": [],
+   "id": "eb0dab16",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-02-07T02:10:15.547207Z",
-     "start_time": "2023-02-07T02:10:15.544776Z"
+     "end_time": "2023-02-28T20:36:40.899177Z",
+     "start_time": "2023-02-28T20:36:40.896620Z"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "assert p['transform']"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 11,
-   "source": [
-    "assert p['transform'] != Affine(1, 0, 0, 0, 1, 0)"
-   ],
-   "outputs": [],
+   "id": "4218131d",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-02-07T02:10:15.551306Z",
-     "start_time": "2023-02-07T02:10:15.548818Z"
+     "end_time": "2023-02-28T20:36:40.903678Z",
+     "start_time": "2023-02-28T20:36:40.901091Z"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "assert p['transform'] != Affine(1, 0, 0, 0, 1, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "16c2d462",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-02-28T20:36:51.521204Z",
+     "start_time": "2023-02-28T20:36:51.517726Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Affine(0.09999999999999984, 0.0, -119.25,\n",
+       "       0.0, -0.1, 35.75)"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "p['transform']"
+   ]
   }
  ],
  "metadata": {
+  "interpreter": {
+   "hash": "83c8da8660bbe18150fdc09aeaa55e9731d119a6641346a233b76fde249768bb"
+  },
   "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3.9.15 64-bit ('topsapp_env': conda)"
+   "display_name": "topsapp_env",
+   "language": "python",
+   "name": "topsapp_env"
   },
   "language_info": {
-   "name": "python",
-   "version": "3.9.16",
-   "mimetype": "text/x-python",
    "codemirror_mode": {
     "name": "ipython",
     "version": 3
    },
-   "pygments_lexer": "ipython3",
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
    "nbconvert_exporter": "python",
-   "file_extension": ".py"
-  },
-  "interpreter": {
-   "hash": "83c8da8660bbe18150fdc09aeaa55e9731d119a6641346a233b76fde249768bb"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/tests/solid_earth_tides.ipynb
+++ b/tests/solid_earth_tides.ipynb
@@ -6,8 +6,8 @@
    "id": "8b166ef0",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-02-28T20:36:25.474559Z",
-     "start_time": "2023-02-28T20:36:23.082810Z"
+     "end_time": "2023-02-28T20:47:22.564598Z",
+     "start_time": "2023-02-28T20:47:19.873627Z"
     }
    },
    "outputs": [],
@@ -23,8 +23,8 @@
    "id": "784aa63a",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-02-28T20:36:38.736306Z",
-     "start_time": "2023-02-28T20:36:25.477267Z"
+     "end_time": "2023-02-28T20:47:35.212834Z",
+     "start_time": "2023-02-28T20:47:22.567290Z"
     }
    },
    "outputs": [],
@@ -43,8 +43,8 @@
    "id": "613a1787",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-02-28T20:36:39.040480Z",
-     "start_time": "2023-02-28T20:36:38.738321Z"
+     "end_time": "2023-02-28T20:47:35.534034Z",
+     "start_time": "2023-02-28T20:47:35.214862Z"
     }
    },
    "outputs": [
@@ -431,13 +431,13 @@
        "  * height          (height) float64 -1.5e+03 0.0 3e+03 9e+03\n",
        "    spatial_ref     int64 0\n",
        "Data variables:\n",
-       "    solidEarthTide  (height, latitude, longitude) float32 -28.14 ... -23.08</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-c70cac63-815b-4e83-8417-5c4870b3958d' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-c70cac63-815b-4e83-8417-5c4870b3958d' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>height</span>: 4</li><li><span class='xr-has-index'>latitude</span>: 26</li><li><span class='xr-has-index'>longitude</span>: 37</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-6ba5c5d7-99aa-421a-866e-a967fb250706' class='xr-section-summary-in' type='checkbox'  checked><label for='section-6ba5c5d7-99aa-421a-866e-a967fb250706' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>longitude</span></div><div class='xr-var-dims'>(longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-119.2 -119.1 ... -115.7 -115.6</div><input id='attrs-2b5f7524-a8b7-4b03-b51e-e7fa43ea8431' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2b5f7524-a8b7-4b03-b51e-e7fa43ea8431' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-21886218-da8a-4796-8c59-370f9173b04e' class='xr-var-data-in' type='checkbox'><label for='data-21886218-da8a-4796-8c59-370f9173b04e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Lon</dd><dt><span>units :</span></dt><dd>degrees_east</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([-119.2, -119.1, -119. , -118.9, -118.8, -118.7, -118.6, -118.5, -118.4,\n",
+       "    solidEarthTide  (height, latitude, longitude) float32 -28.14 ... -23.08</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-f1aeff85-d5d8-48d2-b9dc-4323abfcbd66' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-f1aeff85-d5d8-48d2-b9dc-4323abfcbd66' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>height</span>: 4</li><li><span class='xr-has-index'>latitude</span>: 26</li><li><span class='xr-has-index'>longitude</span>: 37</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-a0db56a8-60fa-4244-b86d-93e2ae3eccc2' class='xr-section-summary-in' type='checkbox'  checked><label for='section-a0db56a8-60fa-4244-b86d-93e2ae3eccc2' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>longitude</span></div><div class='xr-var-dims'>(longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-119.2 -119.1 ... -115.7 -115.6</div><input id='attrs-c6b87465-9811-48e3-ba44-24d7bae19756' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-c6b87465-9811-48e3-ba44-24d7bae19756' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d8f58143-0b13-4d64-bc82-fcd12e861dfd' class='xr-var-data-in' type='checkbox'><label for='data-d8f58143-0b13-4d64-bc82-fcd12e861dfd' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Lon</dd><dt><span>units :</span></dt><dd>degrees_east</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([-119.2, -119.1, -119. , -118.9, -118.8, -118.7, -118.6, -118.5, -118.4,\n",
        "       -118.3, -118.2, -118.1, -118. , -117.9, -117.8, -117.7, -117.6, -117.5,\n",
        "       -117.4, -117.3, -117.2, -117.1, -117. , -116.9, -116.8, -116.7, -116.6,\n",
        "       -116.5, -116.4, -116.3, -116.2, -116.1, -116. , -115.9, -115.8, -115.7,\n",
-       "       -115.6])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>latitude</span></div><div class='xr-var-dims'>(latitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>35.7 35.6 35.5 ... 33.4 33.3 33.2</div><input id='attrs-88d67f5b-2445-4bc8-89f8-74ac5e5b9bfb' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-88d67f5b-2445-4bc8-89f8-74ac5e5b9bfb' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a76410b7-cf6a-4f9a-b55f-7137f0eb1bc8' class='xr-var-data-in' type='checkbox'><label for='data-a76410b7-cf6a-4f9a-b55f-7137f0eb1bc8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Lat</dd><dt><span>units :</span></dt><dd>degrees_north</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([35.7, 35.6, 35.5, 35.4, 35.3, 35.2, 35.1, 35. , 34.9, 34.8, 34.7, 34.6,\n",
+       "       -115.6])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>latitude</span></div><div class='xr-var-dims'>(latitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>35.7 35.6 35.5 ... 33.4 33.3 33.2</div><input id='attrs-d02d4210-ef03-4eb3-aa7f-bc6694f55412' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d02d4210-ef03-4eb3-aa7f-bc6694f55412' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c1cd2c5d-de47-4864-85f0-dfc60de142f7' class='xr-var-data-in' type='checkbox'><label for='data-c1cd2c5d-de47-4864-85f0-dfc60de142f7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Lat</dd><dt><span>units :</span></dt><dd>degrees_north</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([35.7, 35.6, 35.5, 35.4, 35.3, 35.2, 35.1, 35. , 34.9, 34.8, 34.7, 34.6,\n",
        "       34.5, 34.4, 34.3, 34.2, 34.1, 34. , 33.9, 33.8, 33.7, 33.6, 33.5, 33.4,\n",
-       "       33.3, 33.2])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>height</span></div><div class='xr-var-dims'>(height)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-1.5e+03 0.0 3e+03 9e+03</div><input id='attrs-76795f05-c402-44ab-90e7-2bacb1f0431d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-76795f05-c402-44ab-90e7-2bacb1f0431d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-dc41ab96-6da4-4395-8c5c-8add378205cc' class='xr-var-data-in' type='checkbox'><label for='data-dc41ab96-6da4-4395-8c5c-8add378205cc' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Lev</dd><dt><span>units :</span></dt><dd>meter</dd><dt><span>long_name :</span></dt><dd>height</dd><dt><span>standard_name :</span></dt><dd>height</dd><dt><span>positive :</span></dt><dd>up</dd></dl></div><div class='xr-var-data'><pre>array([-1500.,     0.,  3000.,  9000.])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>spatial_ref</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0</div><input id='attrs-77f3bf29-5121-469c-9a34-0f3b36aa73e8' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-77f3bf29-5121-469c-9a34-0f3b36aa73e8' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8117f3b2-fc82-4e82-a831-00f1c143afe7' class='xr-var-data-in' type='checkbox'><label for='data-8117f3b2-fc82-4e82-a831-00f1c143afe7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>crs_wkt :</span></dt><dd>GEOGCS[&quot;WGS 84&quot;,DATUM[&quot;WGS_1984&quot;,SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],PRIMEM[&quot;Greenwich&quot;,0,AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],UNIT[&quot;degree&quot;,0.0174532925199433,AUTHORITY[&quot;EPSG&quot;,&quot;9122&quot;]],AXIS[&quot;Latitude&quot;,NORTH],AXIS[&quot;Longitude&quot;,EAST],AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</dd><dt><span>semi_major_axis :</span></dt><dd>6378137.0</dd><dt><span>semi_minor_axis :</span></dt><dd>6356752.314245179</dd><dt><span>inverse_flattening :</span></dt><dd>298.257223563</dd><dt><span>reference_ellipsoid_name :</span></dt><dd>WGS 84</dd><dt><span>longitude_of_prime_meridian :</span></dt><dd>0.0</dd><dt><span>prime_meridian_name :</span></dt><dd>Greenwich</dd><dt><span>geographic_crs_name :</span></dt><dd>WGS 84</dd><dt><span>grid_mapping_name :</span></dt><dd>latitude_longitude</dd><dt><span>spatial_ref :</span></dt><dd>GEOGCS[&quot;WGS 84&quot;,DATUM[&quot;WGS_1984&quot;,SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],PRIMEM[&quot;Greenwich&quot;,0,AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],UNIT[&quot;degree&quot;,0.0174532925199433,AUTHORITY[&quot;EPSG&quot;,&quot;9122&quot;]],AXIS[&quot;Latitude&quot;,NORTH],AXIS[&quot;Longitude&quot;,EAST],AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-b96302c5-dc14-4d5c-8302-b54ec9ef9edb' class='xr-section-summary-in' type='checkbox'  checked><label for='section-b96302c5-dc14-4d5c-8302-b54ec9ef9edb' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>solidEarthTide</span></div><div class='xr-var-dims'>(height, latitude, longitude)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-28.14 -27.96 ... -23.27 -23.08</div><input id='attrs-95e4641c-99f3-4f22-a273-501f4a8f3a1d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-95e4641c-99f3-4f22-a273-501f4a8f3a1d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-78950c7f-67f2-4fb2-9123-a9251ac5c549' class='xr-var-data-in' type='checkbox'><label for='data-78950c7f-67f2-4fb2-9123-a9251ac5c549' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>description :</span></dt><dd>Solid Earth tide</dd><dt><span>units :</span></dt><dd>radians</dd><dt><span>long_name :</span></dt><dd>solidEarthTide</dd><dt><span>standard_name :</span></dt><dd>solidEarthTide</dd><dt><span>_FillValue :</span></dt><dd>0.0</dd></dl></div><div class='xr-var-data'><pre>array([[[-28.14476 , -27.961794, -27.777964, ..., -21.9595  ,\n",
+       "       33.3, 33.2])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>height</span></div><div class='xr-var-dims'>(height)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-1.5e+03 0.0 3e+03 9e+03</div><input id='attrs-04bebb91-1091-44b8-b8b7-e3a7a2d9a445' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-04bebb91-1091-44b8-b8b7-e3a7a2d9a445' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7a1b82fc-f29a-4e2c-9e40-28e5bee2cbeb' class='xr-var-data-in' type='checkbox'><label for='data-7a1b82fc-f29a-4e2c-9e40-28e5bee2cbeb' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Lev</dd><dt><span>units :</span></dt><dd>meter</dd><dt><span>long_name :</span></dt><dd>height</dd><dt><span>standard_name :</span></dt><dd>height</dd><dt><span>positive :</span></dt><dd>up</dd></dl></div><div class='xr-var-data'><pre>array([-1500.,     0.,  3000.,  9000.])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>spatial_ref</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0</div><input id='attrs-a1d06d14-7e55-4c20-82f0-0dc484e7a3eb' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a1d06d14-7e55-4c20-82f0-0dc484e7a3eb' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c5fccb88-d853-44ec-bed8-f4bd9a3d819b' class='xr-var-data-in' type='checkbox'><label for='data-c5fccb88-d853-44ec-bed8-f4bd9a3d819b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>crs_wkt :</span></dt><dd>GEOGCS[&quot;WGS 84&quot;,DATUM[&quot;WGS_1984&quot;,SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],PRIMEM[&quot;Greenwich&quot;,0,AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],UNIT[&quot;degree&quot;,0.0174532925199433,AUTHORITY[&quot;EPSG&quot;,&quot;9122&quot;]],AXIS[&quot;Latitude&quot;,NORTH],AXIS[&quot;Longitude&quot;,EAST],AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</dd><dt><span>semi_major_axis :</span></dt><dd>6378137.0</dd><dt><span>semi_minor_axis :</span></dt><dd>6356752.314245179</dd><dt><span>inverse_flattening :</span></dt><dd>298.257223563</dd><dt><span>reference_ellipsoid_name :</span></dt><dd>WGS 84</dd><dt><span>longitude_of_prime_meridian :</span></dt><dd>0.0</dd><dt><span>prime_meridian_name :</span></dt><dd>Greenwich</dd><dt><span>geographic_crs_name :</span></dt><dd>WGS 84</dd><dt><span>grid_mapping_name :</span></dt><dd>latitude_longitude</dd><dt><span>spatial_ref :</span></dt><dd>GEOGCS[&quot;WGS 84&quot;,DATUM[&quot;WGS_1984&quot;,SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],PRIMEM[&quot;Greenwich&quot;,0,AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],UNIT[&quot;degree&quot;,0.0174532925199433,AUTHORITY[&quot;EPSG&quot;,&quot;9122&quot;]],AXIS[&quot;Latitude&quot;,NORTH],AXIS[&quot;Longitude&quot;,EAST],AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-57043f75-a295-4083-875a-d9bb8d42adf7' class='xr-section-summary-in' type='checkbox'  checked><label for='section-57043f75-a295-4083-875a-d9bb8d42adf7' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>solidEarthTide</span></div><div class='xr-var-dims'>(height, latitude, longitude)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-28.14 -27.96 ... -23.27 -23.08</div><input id='attrs-bf3e4ba6-556c-4e9e-9925-61c672e275dd' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-bf3e4ba6-556c-4e9e-9925-61c672e275dd' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9c2093b5-d83d-4855-bfbb-0bbbad405069' class='xr-var-data-in' type='checkbox'><label for='data-9c2093b5-d83d-4855-bfbb-0bbbad405069' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>description :</span></dt><dd>Solid Earth tide</dd><dt><span>units :</span></dt><dd>radians</dd><dt><span>long_name :</span></dt><dd>solidEarthTide</dd><dt><span>standard_name :</span></dt><dd>solidEarthTide</dd><dt><span>_FillValue :</span></dt><dd>0.0</dd></dl></div><div class='xr-var-data'><pre>array([[[-28.14476 , -27.961794, -27.777964, ..., -21.9595  ,\n",
        "         -21.790537, -21.622738],\n",
        "        [-28.230165, -28.047003, -27.862946, ..., -22.027756,\n",
        "         -21.858156, -21.689722],\n",
@@ -477,7 +477,7 @@
        "        [-30.041592, -29.852608, -29.66191 , ..., -23.386162,\n",
        "         -23.200565, -23.0162  ],\n",
        "        [-30.125172, -29.936249, -29.745562, ..., -23.455952,\n",
-       "         -23.269718, -23.084713]]], dtype=float32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-2d4c6a69-76b5-408a-b4b4-bb5f51853db9' class='xr-section-summary-in' type='checkbox'  ><label for='section-2d4c6a69-76b5-408a-b4b4-bb5f51853db9' class='xr-section-summary' >Indexes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>longitude</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-6da2e22e-5129-47f7-9f9f-2a6ff0821b13' class='xr-index-data-in' type='checkbox'/><label for='index-6da2e22e-5129-47f7-9f9f-2a6ff0821b13' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Float64Index([             -119.2, -119.10000000000001,              -119.0,\n",
+       "         -23.269718, -23.084713]]], dtype=float32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-9b104edd-d866-46f3-a130-0edf3e9192e7' class='xr-section-summary-in' type='checkbox'  ><label for='section-9b104edd-d866-46f3-a130-0edf3e9192e7' class='xr-section-summary' >Indexes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>longitude</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-a385593a-d01d-4b3f-9624-1c4cf0bf0425' class='xr-index-data-in' type='checkbox'/><label for='index-a385593a-d01d-4b3f-9624-1c4cf0bf0425' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Float64Index([             -119.2, -119.10000000000001,              -119.0,\n",
        "                           -118.9,              -118.8,              -118.7,\n",
        "              -118.60000000000001,              -118.5,              -118.4,\n",
        "                           -118.3,              -118.2, -118.10000000000001,\n",
@@ -490,7 +490,7 @@
        "                           -116.2, -116.10000000000001,              -116.0,\n",
        "                           -115.9,              -115.8,              -115.7,\n",
        "              -115.60000000000001],\n",
-       "             dtype=&#x27;float64&#x27;, name=&#x27;longitude&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>latitude</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-71a87f2f-859c-482b-93b4-dd50d890832f' class='xr-index-data-in' type='checkbox'/><label for='index-71a87f2f-859c-482b-93b4-dd50d890832f' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Float64Index([              35.7,               35.6,               35.5,\n",
+       "             dtype=&#x27;float64&#x27;, name=&#x27;longitude&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>latitude</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-6067cd4c-54f1-4ad0-afca-ce1c8bf4786b' class='xr-index-data-in' type='checkbox'/><label for='index-6067cd4c-54f1-4ad0-afca-ce1c8bf4786b' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Float64Index([              35.7,               35.6,               35.5,\n",
        "              35.400000000000006, 35.300000000000004,               35.2,\n",
        "                            35.1,               35.0, 34.900000000000006,\n",
        "              34.800000000000004,               34.7,               34.6,\n",
@@ -499,7 +499,7 @@
        "              33.900000000000006, 33.800000000000004,               33.7,\n",
        "                            33.6,               33.5, 33.400000000000006,\n",
        "              33.300000000000004,               33.2],\n",
-       "             dtype=&#x27;float64&#x27;, name=&#x27;latitude&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>height</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-d75795c9-e5e9-4a1d-bfa0-e1708d393199' class='xr-index-data-in' type='checkbox'/><label for='index-d75795c9-e5e9-4a1d-bfa0-e1708d393199' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Float64Index([-1500.0, 0.0, 3000.0, 9000.0], dtype=&#x27;float64&#x27;, name=&#x27;height&#x27;))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-f6348ef4-c2ca-441b-9ef2-74e2a0adec23' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-f6348ef4-c2ca-441b-9ef2-74e2a0adec23' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
+       "             dtype=&#x27;float64&#x27;, name=&#x27;latitude&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>height</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-36fdc982-56af-4bb0-8be0-904a22a1a44c' class='xr-index-data-in' type='checkbox'/><label for='index-36fdc982-56af-4bb0-8be0-904a22a1a44c' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Float64Index([-1500.0, 0.0, 3000.0, 9000.0], dtype=&#x27;float64&#x27;, name=&#x27;height&#x27;))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-50c0dcf0-56d6-4202-9e47-60baa632bc4a' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-50c0dcf0-56d6-4202-9e47-60baa632bc4a' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -526,11 +526,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "b074fcb5",
+   "id": "7d0e585e",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-02-28T20:36:39.237039Z",
-     "start_time": "2023-02-28T20:36:39.043198Z"
+     "end_time": "2023-02-28T20:47:35.734524Z",
+     "start_time": "2023-02-28T20:47:35.536799Z"
     }
    },
    "outputs": [
@@ -917,13 +917,13 @@
        "  * height          (height) float64 -1.5e+03 0.0 3e+03 9e+03\n",
        "    spatial_ref     int64 0\n",
        "Data variables:\n",
-       "    solidEarthTide  (height, latitude, longitude) float32 -10.35 ... -8.61</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-2f1a2bd2-7904-4fa5-8435-1ab92453e10d' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-2f1a2bd2-7904-4fa5-8435-1ab92453e10d' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>height</span>: 4</li><li><span class='xr-has-index'>latitude</span>: 26</li><li><span class='xr-has-index'>longitude</span>: 37</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-510a925f-8461-4c71-aeb4-23e23ae340dc' class='xr-section-summary-in' type='checkbox'  checked><label for='section-510a925f-8461-4c71-aeb4-23e23ae340dc' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>longitude</span></div><div class='xr-var-dims'>(longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-119.2 -119.1 ... -115.7 -115.6</div><input id='attrs-8de3b4a0-c955-44d0-af2a-e43f2c0543cd' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8de3b4a0-c955-44d0-af2a-e43f2c0543cd' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8422c04b-18cd-4c13-b051-7bacdd728f99' class='xr-var-data-in' type='checkbox'><label for='data-8422c04b-18cd-4c13-b051-7bacdd728f99' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Lon</dd><dt><span>units :</span></dt><dd>degrees_east</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([-119.2, -119.1, -119. , -118.9, -118.8, -118.7, -118.6, -118.5, -118.4,\n",
+       "    solidEarthTide  (height, latitude, longitude) float32 -10.35 ... -8.61</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-2ef5bd11-adf5-426c-b0db-fe3c0a1e5d5c' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-2ef5bd11-adf5-426c-b0db-fe3c0a1e5d5c' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>height</span>: 4</li><li><span class='xr-has-index'>latitude</span>: 26</li><li><span class='xr-has-index'>longitude</span>: 37</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-72e6a3db-5082-45a7-bad6-7ea06a1e6bc9' class='xr-section-summary-in' type='checkbox'  checked><label for='section-72e6a3db-5082-45a7-bad6-7ea06a1e6bc9' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>longitude</span></div><div class='xr-var-dims'>(longitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-119.2 -119.1 ... -115.7 -115.6</div><input id='attrs-7b9711df-ef3b-4d79-8dd6-b68162b15d34' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-7b9711df-ef3b-4d79-8dd6-b68162b15d34' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5eac85b1-3455-4e4e-b1c7-a95af165eee6' class='xr-var-data-in' type='checkbox'><label for='data-5eac85b1-3455-4e4e-b1c7-a95af165eee6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Lon</dd><dt><span>units :</span></dt><dd>degrees_east</dd><dt><span>long_name :</span></dt><dd>longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd></dl></div><div class='xr-var-data'><pre>array([-119.2, -119.1, -119. , -118.9, -118.8, -118.7, -118.6, -118.5, -118.4,\n",
        "       -118.3, -118.2, -118.1, -118. , -117.9, -117.8, -117.7, -117.6, -117.5,\n",
        "       -117.4, -117.3, -117.2, -117.1, -117. , -116.9, -116.8, -116.7, -116.6,\n",
        "       -116.5, -116.4, -116.3, -116.2, -116.1, -116. , -115.9, -115.8, -115.7,\n",
-       "       -115.6])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>latitude</span></div><div class='xr-var-dims'>(latitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>35.7 35.6 35.5 ... 33.4 33.3 33.2</div><input id='attrs-8a49bf97-ccfd-4792-bc7f-05a38c993e27' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8a49bf97-ccfd-4792-bc7f-05a38c993e27' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-87a849ee-75da-4d59-8db4-8effacf7eb0a' class='xr-var-data-in' type='checkbox'><label for='data-87a849ee-75da-4d59-8db4-8effacf7eb0a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Lat</dd><dt><span>units :</span></dt><dd>degrees_north</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([35.7, 35.6, 35.5, 35.4, 35.3, 35.2, 35.1, 35. , 34.9, 34.8, 34.7, 34.6,\n",
+       "       -115.6])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>latitude</span></div><div class='xr-var-dims'>(latitude)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>35.7 35.6 35.5 ... 33.4 33.3 33.2</div><input id='attrs-0d1ed4c1-82c1-4129-b142-10b8a144e6db' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0d1ed4c1-82c1-4129-b142-10b8a144e6db' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-dc7501ec-9020-44a8-902a-5cebdacde80e' class='xr-var-data-in' type='checkbox'><label for='data-dc7501ec-9020-44a8-902a-5cebdacde80e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Lat</dd><dt><span>units :</span></dt><dd>degrees_north</dd><dt><span>long_name :</span></dt><dd>latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd></dl></div><div class='xr-var-data'><pre>array([35.7, 35.6, 35.5, 35.4, 35.3, 35.2, 35.1, 35. , 34.9, 34.8, 34.7, 34.6,\n",
        "       34.5, 34.4, 34.3, 34.2, 34.1, 34. , 33.9, 33.8, 33.7, 33.6, 33.5, 33.4,\n",
-       "       33.3, 33.2])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>height</span></div><div class='xr-var-dims'>(height)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-1.5e+03 0.0 3e+03 9e+03</div><input id='attrs-d536f230-9a0f-4256-9df1-85241744dd95' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d536f230-9a0f-4256-9df1-85241744dd95' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-cdbb61b4-2a30-41c7-99f6-64b0a69ba2ec' class='xr-var-data-in' type='checkbox'><label for='data-cdbb61b4-2a30-41c7-99f6-64b0a69ba2ec' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Lev</dd><dt><span>units :</span></dt><dd>meter</dd><dt><span>long_name :</span></dt><dd>height</dd><dt><span>standard_name :</span></dt><dd>height</dd><dt><span>positive :</span></dt><dd>up</dd></dl></div><div class='xr-var-data'><pre>array([-1500.,     0.,  3000.,  9000.])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>spatial_ref</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0</div><input id='attrs-6f456eec-f4c2-4dc1-92de-258409dbb234' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6f456eec-f4c2-4dc1-92de-258409dbb234' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3f8d3e34-e3e7-4274-80f6-9d570bf2dc08' class='xr-var-data-in' type='checkbox'><label for='data-3f8d3e34-e3e7-4274-80f6-9d570bf2dc08' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>crs_wkt :</span></dt><dd>GEOGCS[&quot;WGS 84&quot;,DATUM[&quot;WGS_1984&quot;,SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],PRIMEM[&quot;Greenwich&quot;,0,AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],UNIT[&quot;degree&quot;,0.0174532925199433,AUTHORITY[&quot;EPSG&quot;,&quot;9122&quot;]],AXIS[&quot;Latitude&quot;,NORTH],AXIS[&quot;Longitude&quot;,EAST],AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</dd><dt><span>semi_major_axis :</span></dt><dd>6378137.0</dd><dt><span>semi_minor_axis :</span></dt><dd>6356752.314245179</dd><dt><span>inverse_flattening :</span></dt><dd>298.257223563</dd><dt><span>reference_ellipsoid_name :</span></dt><dd>WGS 84</dd><dt><span>longitude_of_prime_meridian :</span></dt><dd>0.0</dd><dt><span>prime_meridian_name :</span></dt><dd>Greenwich</dd><dt><span>geographic_crs_name :</span></dt><dd>WGS 84</dd><dt><span>grid_mapping_name :</span></dt><dd>latitude_longitude</dd><dt><span>spatial_ref :</span></dt><dd>GEOGCS[&quot;WGS 84&quot;,DATUM[&quot;WGS_1984&quot;,SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],PRIMEM[&quot;Greenwich&quot;,0,AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],UNIT[&quot;degree&quot;,0.0174532925199433,AUTHORITY[&quot;EPSG&quot;,&quot;9122&quot;]],AXIS[&quot;Latitude&quot;,NORTH],AXIS[&quot;Longitude&quot;,EAST],AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-331146bd-2384-444c-a84f-4ef02258bf70' class='xr-section-summary-in' type='checkbox'  checked><label for='section-331146bd-2384-444c-a84f-4ef02258bf70' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>solidEarthTide</span></div><div class='xr-var-dims'>(height, latitude, longitude)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-10.35 -10.26 ... -8.698 -8.61</div><input id='attrs-f89c2694-23d6-416d-8cf3-140df49193a3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f89c2694-23d6-416d-8cf3-140df49193a3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-67eb2f24-3d57-4904-8bf3-9def41d8c06e' class='xr-var-data-in' type='checkbox'><label for='data-67eb2f24-3d57-4904-8bf3-9def41d8c06e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>description :</span></dt><dd>Solid Earth tide</dd><dt><span>units :</span></dt><dd>radians</dd><dt><span>long_name :</span></dt><dd>solidEarthTide</dd><dt><span>standard_name :</span></dt><dd>solidEarthTide</dd><dt><span>_FillValue :</span></dt><dd>0.0</dd></dl></div><div class='xr-var-data'><pre>array([[[-10.34811  , -10.257366 , -10.166645 , ...,  -7.4522157,\n",
+       "       33.3, 33.2])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>height</span></div><div class='xr-var-dims'>(height)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-1.5e+03 0.0 3e+03 9e+03</div><input id='attrs-41026e06-28f5-43e7-89fe-c55ef3475e87' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-41026e06-28f5-43e7-89fe-c55ef3475e87' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-fa31db5f-951c-44e4-9305-6cadb0477a65' class='xr-var-data-in' type='checkbox'><label for='data-fa31db5f-951c-44e4-9305-6cadb0477a65' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>_CoordinateAxisType :</span></dt><dd>Lev</dd><dt><span>units :</span></dt><dd>meter</dd><dt><span>long_name :</span></dt><dd>height</dd><dt><span>standard_name :</span></dt><dd>height</dd><dt><span>positive :</span></dt><dd>up</dd></dl></div><div class='xr-var-data'><pre>array([-1500.,     0.,  3000.,  9000.])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>spatial_ref</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0</div><input id='attrs-495fb123-6405-4190-8a48-8d9ac2683b95' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-495fb123-6405-4190-8a48-8d9ac2683b95' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ee0c374c-5808-4471-89ec-2af53e8a168f' class='xr-var-data-in' type='checkbox'><label for='data-ee0c374c-5808-4471-89ec-2af53e8a168f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>crs_wkt :</span></dt><dd>GEOGCS[&quot;WGS 84&quot;,DATUM[&quot;WGS_1984&quot;,SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],PRIMEM[&quot;Greenwich&quot;,0,AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],UNIT[&quot;degree&quot;,0.0174532925199433,AUTHORITY[&quot;EPSG&quot;,&quot;9122&quot;]],AXIS[&quot;Latitude&quot;,NORTH],AXIS[&quot;Longitude&quot;,EAST],AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</dd><dt><span>semi_major_axis :</span></dt><dd>6378137.0</dd><dt><span>semi_minor_axis :</span></dt><dd>6356752.314245179</dd><dt><span>inverse_flattening :</span></dt><dd>298.257223563</dd><dt><span>reference_ellipsoid_name :</span></dt><dd>WGS 84</dd><dt><span>longitude_of_prime_meridian :</span></dt><dd>0.0</dd><dt><span>prime_meridian_name :</span></dt><dd>Greenwich</dd><dt><span>geographic_crs_name :</span></dt><dd>WGS 84</dd><dt><span>grid_mapping_name :</span></dt><dd>latitude_longitude</dd><dt><span>spatial_ref :</span></dt><dd>GEOGCS[&quot;WGS 84&quot;,DATUM[&quot;WGS_1984&quot;,SPHEROID[&quot;WGS 84&quot;,6378137,298.257223563,AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]],AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]],PRIMEM[&quot;Greenwich&quot;,0,AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]],UNIT[&quot;degree&quot;,0.0174532925199433,AUTHORITY[&quot;EPSG&quot;,&quot;9122&quot;]],AXIS[&quot;Latitude&quot;,NORTH],AXIS[&quot;Longitude&quot;,EAST],AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-33009456-b078-409e-983a-88976c56b612' class='xr-section-summary-in' type='checkbox'  checked><label for='section-33009456-b078-409e-983a-88976c56b612' class='xr-section-summary' >Data variables: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>solidEarthTide</span></div><div class='xr-var-dims'>(height, latitude, longitude)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>-10.35 -10.26 ... -8.698 -8.61</div><input id='attrs-ab2df6d7-ef9a-41c6-a480-1c90bee4415c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ab2df6d7-ef9a-41c6-a480-1c90bee4415c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4a4a583e-c1c0-418f-8ac7-4a6ed0c266de' class='xr-var-data-in' type='checkbox'><label for='data-4a4a583e-c1c0-418f-8ac7-4a6ed0c266de' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>description :</span></dt><dd>Solid Earth tide</dd><dt><span>units :</span></dt><dd>radians</dd><dt><span>long_name :</span></dt><dd>solidEarthTide</dd><dt><span>standard_name :</span></dt><dd>solidEarthTide</dd><dt><span>_FillValue :</span></dt><dd>0.0</dd></dl></div><div class='xr-var-data'><pre>array([[[-10.34811  , -10.257366 , -10.166645 , ...,  -7.4522157,\n",
        "          -7.3765492,  -7.3015294],\n",
        "        [-10.421266 , -10.330172 , -10.23909  , ...,  -7.5099363,\n",
        "          -7.4337974,  -7.358306 ],\n",
@@ -963,7 +963,7 @@
        "        [-12.049238 , -11.948448 , -11.847338 , ...,  -8.72448  ,\n",
        "          -8.636063 ,  -8.548382 ],\n",
        "        [-12.127005 , -12.025955 , -11.924563 , ...,  -8.786858 ,\n",
-       "          -8.69792  ,  -8.609719 ]]], dtype=float32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-97bbc948-1004-436f-9b94-ee1bc5404d1c' class='xr-section-summary-in' type='checkbox'  ><label for='section-97bbc948-1004-436f-9b94-ee1bc5404d1c' class='xr-section-summary' >Indexes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>longitude</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-1361d979-321f-4700-828a-5f626640ef98' class='xr-index-data-in' type='checkbox'/><label for='index-1361d979-321f-4700-828a-5f626640ef98' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Float64Index([             -119.2, -119.10000000000001,              -119.0,\n",
+       "          -8.69792  ,  -8.609719 ]]], dtype=float32)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-4195747a-7ea8-4d5c-bb46-7d0fb3ac702e' class='xr-section-summary-in' type='checkbox'  ><label for='section-4195747a-7ea8-4d5c-bb46-7d0fb3ac702e' class='xr-section-summary' >Indexes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>longitude</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-73b75942-db69-4879-9e71-f352af26c657' class='xr-index-data-in' type='checkbox'/><label for='index-73b75942-db69-4879-9e71-f352af26c657' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Float64Index([             -119.2, -119.10000000000001,              -119.0,\n",
        "                           -118.9,              -118.8,              -118.7,\n",
        "              -118.60000000000001,              -118.5,              -118.4,\n",
        "                           -118.3,              -118.2, -118.10000000000001,\n",
@@ -976,7 +976,7 @@
        "                           -116.2, -116.10000000000001,              -116.0,\n",
        "                           -115.9,              -115.8,              -115.7,\n",
        "              -115.60000000000001],\n",
-       "             dtype=&#x27;float64&#x27;, name=&#x27;longitude&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>latitude</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-ce37abc4-f091-466a-ade2-720c9f77aabd' class='xr-index-data-in' type='checkbox'/><label for='index-ce37abc4-f091-466a-ade2-720c9f77aabd' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Float64Index([              35.7,               35.6,               35.5,\n",
+       "             dtype=&#x27;float64&#x27;, name=&#x27;longitude&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>latitude</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-1c5076c0-12dc-4f30-9517-32f9d8b375ad' class='xr-index-data-in' type='checkbox'/><label for='index-1c5076c0-12dc-4f30-9517-32f9d8b375ad' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Float64Index([              35.7,               35.6,               35.5,\n",
        "              35.400000000000006, 35.300000000000004,               35.2,\n",
        "                            35.1,               35.0, 34.900000000000006,\n",
        "              34.800000000000004,               34.7,               34.6,\n",
@@ -985,7 +985,7 @@
        "              33.900000000000006, 33.800000000000004,               33.7,\n",
        "                            33.6,               33.5, 33.400000000000006,\n",
        "              33.300000000000004,               33.2],\n",
-       "             dtype=&#x27;float64&#x27;, name=&#x27;latitude&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>height</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-054324d9-c41d-4ba5-bc34-6d1620de11ba' class='xr-index-data-in' type='checkbox'/><label for='index-054324d9-c41d-4ba5-bc34-6d1620de11ba' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Float64Index([-1500.0, 0.0, 3000.0, 9000.0], dtype=&#x27;float64&#x27;, name=&#x27;height&#x27;))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-43571e71-8729-474e-a97f-1d613f7caf2d' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-43571e71-8729-474e-a97f-1d613f7caf2d' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
+       "             dtype=&#x27;float64&#x27;, name=&#x27;latitude&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>height</div></div><div class='xr-index-preview'>PandasIndex</div><div></div><input id='index-a508fd46-d370-466d-9381-eaaf7acd96ac' class='xr-index-data-in' type='checkbox'/><label for='index-a508fd46-d370-466d-9381-eaaf7acd96ac' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Float64Index([-1500.0, 0.0, 3000.0, 9000.0], dtype=&#x27;float64&#x27;, name=&#x27;height&#x27;))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-720f68f6-1678-43df-bfa0-9e86a55a5eb3' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-720f68f6-1678-43df-bfa0-9e86a55a5eb3' class='xr-section-summary'  title='Expand/collapse section'>Attributes: <span>(0)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset>\n",
@@ -1015,8 +1015,8 @@
    "id": "8ba88428",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-02-28T20:36:39.668748Z",
-     "start_time": "2023-02-28T20:36:39.238837Z"
+     "end_time": "2023-02-28T20:47:36.176401Z",
+     "start_time": "2023-02-28T20:47:35.736812Z"
     }
    },
    "outputs": [
@@ -1054,8 +1054,8 @@
    "id": "894408de",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-02-28T20:36:40.862334Z",
-     "start_time": "2023-02-28T20:36:39.670917Z"
+     "end_time": "2023-02-28T20:47:37.422265Z",
+     "start_time": "2023-02-28T20:47:36.178563Z"
     },
     "scrolled": true
    },
@@ -1064,11 +1064,11 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/var/folders/s6/fbsc26cd0ddffbp3_knts_9c0wcxj1/T/ipykernel_39361/89806542.py:8: DeprecationWarning: self.axes is deprecated since 2022.11 in order to align with matplotlibs plt.subplots, use self.axs instead.\n",
+      "/var/folders/s6/fbsc26cd0ddffbp3_knts_9c0wcxj1/T/ipykernel_41432/89806542.py:8: DeprecationWarning: self.axes is deprecated since 2022.11 in order to align with matplotlibs plt.subplots, use self.axs instead.\n",
       "  [df_world.boundary.plot(ax=ax, color='black') for ax in s.axes[0]]\n",
-      "/var/folders/s6/fbsc26cd0ddffbp3_knts_9c0wcxj1/T/ipykernel_39361/89806542.py:9: DeprecationWarning: self.axes is deprecated since 2022.11 in order to align with matplotlibs plt.subplots, use self.axs instead.\n",
+      "/var/folders/s6/fbsc26cd0ddffbp3_knts_9c0wcxj1/T/ipykernel_41432/89806542.py:9: DeprecationWarning: self.axes is deprecated since 2022.11 in order to align with matplotlibs plt.subplots, use self.axs instead.\n",
       "  [ax.set_ylim(ymin, ymax) for ax in s.axes[0]]\n",
-      "/var/folders/s6/fbsc26cd0ddffbp3_knts_9c0wcxj1/T/ipykernel_39361/89806542.py:10: DeprecationWarning: self.axes is deprecated since 2022.11 in order to align with matplotlibs plt.subplots, use self.axs instead.\n",
+      "/var/folders/s6/fbsc26cd0ddffbp3_knts_9c0wcxj1/T/ipykernel_41432/89806542.py:10: DeprecationWarning: self.axes is deprecated since 2022.11 in order to align with matplotlibs plt.subplots, use self.axs instead.\n",
       "  [ax.set_xlim(xmin, xmax) for ax in s.axes[0]]\n"
      ]
     },
@@ -1111,12 +1111,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "2d77a966",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-02-28T20:36:40.882532Z",
-     "start_time": "2023-02-28T20:36:40.864494Z"
+     "end_time": "2023-02-28T20:47:58.866672Z",
+     "start_time": "2023-02-28T20:47:58.848277Z"
     }
    },
    "outputs": [],
@@ -1125,7 +1125,7 @@
     "from rasterio.crs import CRS\n",
     "from affine import Affine\n",
     "\n",
-    "with rasterio.open(f'netcdf:{gunw_path}:/science/grids/corrections/external/tides/reference/solidEarthTide') as ds:\n",
+    "with rasterio.open(f'netcdf:{gunw_path}:/science/grids/corrections/external/tides/solidEarth/reference/solidEarthTide') as ds:\n",
     "    p = ds.profile"
    ]
   },
@@ -1139,12 +1139,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "31588ed9",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-02-28T20:36:40.887324Z",
-     "start_time": "2023-02-28T20:36:40.884500Z"
+     "end_time": "2023-02-28T20:47:59.834026Z",
+     "start_time": "2023-02-28T20:47:59.831461Z"
     }
    },
    "outputs": [],
@@ -1154,12 +1154,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "e4688ebe",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-02-28T20:36:40.892100Z",
-     "start_time": "2023-02-28T20:36:40.889563Z"
+     "end_time": "2023-02-28T20:48:00.106024Z",
+     "start_time": "2023-02-28T20:48:00.103550Z"
     }
    },
    "outputs": [],
@@ -1179,12 +1179,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "eb0dab16",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-02-28T20:36:40.899177Z",
-     "start_time": "2023-02-28T20:36:40.896620Z"
+     "end_time": "2023-02-28T20:48:00.785815Z",
+     "start_time": "2023-02-28T20:48:00.783222Z"
     }
    },
    "outputs": [],
@@ -1194,12 +1194,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "4218131d",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-02-28T20:36:40.903678Z",
-     "start_time": "2023-02-28T20:36:40.901091Z"
+     "end_time": "2023-02-28T20:48:01.346012Z",
+     "start_time": "2023-02-28T20:48:01.343351Z"
     }
    },
    "outputs": [],
@@ -1209,12 +1209,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "16c2d462",
+   "execution_count": 13,
+   "id": "54e24cdb",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2023-02-28T20:36:51.521204Z",
-     "start_time": "2023-02-28T20:36:51.517726Z"
+     "end_time": "2023-02-28T20:48:01.835236Z",
+     "start_time": "2023-02-28T20:48:01.831459Z"
     }
    },
    "outputs": [
@@ -1225,7 +1225,7 @@
        "       0.0, -0.1, 35.75)"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
Splits reference and secondary solid earth tide corrections into separate groups:

specifically

```
/science/grids/corrections/external/tides/solidEarth/reference
/science/grids/corrections/external/tides/solidEarth/secondary
```