### PR TITLE
Makes sure that the date and time in the GUNW ID are derived from center acquisition datetime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,8 @@ tests/out/*.ipynb
 
 # Jsons in Test Directory
 tests/**/*.json
+!tests/sample_loc_metadata.json
+!tests/midnight_crossing_metadata.json
 
 # Use geojson zip file for ARIA s1 frame data
 !isce2_topsapp/data/s1_gunw_frame_footprints.geojson.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Uses dem-stitcher 2.4.0 to resolve #89 - ensures only polygonal intersection of tiles
 * Fix variable name error in localize_slc.py
 * Removes dummy Solid Earth Tide variable from GUNW
+* Ensures dates and time in GUNW name are derived from center of secondary and reference pass.
 
 ## Changed
 * Metadata `intersection_geo` is changed to `gunw_geo`.

--- a/isce2_topsapp/packaging.py
+++ b/isce2_topsapp/packaging.py
@@ -1,3 +1,4 @@
+import datetime
 import hashlib
 import json
 import os
@@ -6,7 +7,6 @@ from pathlib import Path
 from typing import Union
 
 import h5py
-import numpy as np
 from dateparser import parse
 
 import isce2_topsapp
@@ -64,18 +64,16 @@ def get_geo_str(extent: list) -> str:
     return f'{lon_str}_{lat_str}'
 
 
-def get_center_time(properties: list) -> str:
+def get_center_time(properties: list) -> datetime.datetime:
 
-    ref_start_times = [parse(props['startTime']) for props in properties]
-    ref_stop_times = [parse(props['stopTime']) for props in properties]
+    start_times = sorted([parse(props['startTime']) for props in properties])
+    stop_times = sorted([parse(props['stopTime']) for props in properties])
 
-    all_times = (ref_start_times + ref_stop_times)
-    N = len(all_times)
-    all_time_deltas = [all_times[k] - all_times[0] for k in range(N)]
+    start_time = start_times[0]
+    stop_time = stop_times[-1]
 
-    center_time = all_times[0] + np.mean(all_time_deltas)
-
-    return center_time.strftime('%H%M%S')
+    center_datetime = start_time + (stop_time - start_time) / 2
+    return center_datetime
 
 
 def get_gunw_id(reference_properties: list,
@@ -92,20 +90,21 @@ def get_gunw_id(reference_properties: list,
     track_num = int(reference_properties[0]['pathNumber'])
     track = f'{track_num:03}'
 
-    # dates; remove dashes
-    reference_date = reference_properties[0]['startTime'].split('T')[0]
-    reference_date = reference_date.replace('-', '')
-    secondary_date = secondary_properties[0]['startTime'].split('T')[0]
-    secondary_date = secondary_date.replace('-', '')
+    # Center Datetimes
+    ref_center_datetime = get_center_time(reference_properties)
+    sec_center_datetime = get_center_time(secondary_properties)
+
+    # Center Time sring
+    ref_center_time_str = ref_center_datetime.strftime('%H%M%S')
+
+    reference_date_str = ref_center_datetime.strftime('%Y%m%d')
+    secondary_date_str = sec_center_datetime.strftime('%Y%m%d')
 
     # date pair
-    date_pair = f'{reference_date}_{secondary_date}'
+    date_pair = f'{reference_date_str}_{secondary_date_str}'
 
     # Geo string
     geo_str = get_geo_str(extent)
-
-    # Center Time (with Respect to Reference)
-    ref_center_time = get_center_time(reference_properties)
 
     # hash_id
     reference_ids = [p['sceneName'] for p in reference_properties]
@@ -125,7 +124,7 @@ def get_gunw_id(reference_properties: list,
            # legacy constant
            'tops',
            date_pair,
-           ref_center_time,
+           ref_center_time_str,
            geo_str,
            # legacy constant
            'PP',

--- a/isce2_topsapp/packaging.py
+++ b/isce2_topsapp/packaging.py
@@ -94,7 +94,7 @@ def get_gunw_id(reference_properties: list,
     ref_center_datetime = get_center_time(reference_properties)
     sec_center_datetime = get_center_time(secondary_properties)
 
-    # Center Time sring
+    # Center Time string
     ref_center_time_str = ref_center_datetime.strftime('%H%M%S')
 
     reference_date_str = ref_center_datetime.strftime('%Y%m%d')

--- a/tests/midnight_crossing_metadata.json
+++ b/tests/midnight_crossing_metadata.json
@@ -1,0 +1,40 @@
+{
+    "extent": [
+        89.7244830435,
+        39.721350911500004,
+        93.3319816005,
+        41.97551667650001
+    ],
+    "reference_properties": [
+        {
+            "sceneName": "S1A_IW_SLC__1SDV_20230106T235934_20230107T000001_046670_059804_D8E3",
+            "startTime": "2023-01-06T23:59:34.00000Z",
+            "stopTime": "2023-01-07T00:00:00.00000Z",
+            "flightDirection": "DESCENDING",
+            "pathNumber": 48
+        },
+        {
+            "sceneName": "S1A_IW_SLC__1SDV_20230106T235959_20230107T000026_046670_059804_74DB",
+            "startTime": "2023-01-06T23:59:59.00000Z",
+            "stopTime": "2023-01-07T00:00:25.00000Z",
+            "flightDirection": "DESCENDING",
+            "pathNumber": 48
+        }
+    ],
+    "secondary_properties": [
+        {
+            "sceneName": "S1A_IW_SLC__1SDV_20221213T235935_20221214T000002_046320_058C2F_7DFC",
+            "startTime": "2022-12-13T23:59:35.00000Z",
+            "stopTime": "2022-12-14T00:00:00.00000Z",
+            "flightDirection": "DESCENDING",
+            "pathNumber": 48
+        },
+        {
+            "sceneName": "S1A_IW_SLC__1SDV_20221214T000000_20221214T000027_046320_058C2F_9AD4",
+            "startTime": "2022-12-14T00:00:00.00000Z",
+            "stopTime": "2022-12-14T00:00:25.00000Z",
+            "flightDirection": "DESCENDING",
+            "pathNumber": 48
+        }
+    ]
+}

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,15 @@
+import json
+from pathlib import Path
+
+from isce2_topsapp.packaging import get_gunw_id
+
+test_dir = Path(__file__).parent
+
+
+def test_gunw_id_generation_crossing_dateline():
+    sample_json_path = test_dir / 'midnight_crossing_metadata.json'
+    metadata = json.load(open(sample_json_path))
+    gunw_id = get_gunw_id(metadata['reference_properties'],
+                          metadata['secondary_properties'],
+                          metadata['extent'])
+    assert gunw_id == 'S1-GUNW-D-R-048-tops-20230106_20221214-235959-00090E_00040N-PP-c254-v2_0_6'


### PR DESCRIPTION
A GUNW ID looks like this:

```
S1-GUNW-D-R-048-tops-20230106_20221214-235959-00090E_00040N-PP-c254-v2_0_6
```
The `20230106` is the reference date and `20221214` is the secondary date. The `235959` is the center time i.e. `23:59:59`.

Previously the dates in the GUNW id were derived from start time. The center time was indeed the center time of a pass. In other words, these two date and time tokens were derived from _different_ datetimes and could be problematic if assuming not - i.e. using the GUNW ID to extract the metadata. This brought up in Raider [here](https://github.com/dbekaert/RAiDER/issues/488). You can see the current GUNW ID would be `[S1-GUNW-D-R-048-tops-20230106_20221214-000000-00090E_00040N-PP-c254-v2_0_6.nc](https://hyp3-a19-jpl-contentbucket-1wfnatpznlg8b.s3.us-west-2.amazonaws.com/5225cd05-0869-4031-a697-15778a29635f/S1-GUNW-D-R-048-tops-20230106_20221214-000000-00090E_00040N-PP-c254-v2_0_6.nc)` which is confusing (and wrong) if you think the center time and the start time correspond to the same datetime, which would lead you to believe the GUNW was acquired 24 hours before it did! For more details, see the linked issue ticket.

Also cleaned up the code to make it more readable. Added a test which was hardest part because had to copy metadata (I did make up the `stopTimes` - just added 25 seconds).