### PR TITLE
Python 3.10 + ISCE2 2.6.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   call-version-info-workflow:
     uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.7.0
+    with:
+      python_version: '3.10'
 
   call-docker-ghcr-workflow:
     needs: call-version-info-workflow

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.9"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+## [0.2.3]
+
+## Changed
+* Updated python support to 3.10 (removed 3.8 and 3.9)
+
+
 ## [0.2.2]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-## [0.2.3]
+## [0.2.4]
 
 ## Changed
 * Updated python support to 3.10 (removed 3.8 and 3.9)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+## [0.2.3]
+
+## Removed
+* Python 3.8 Support
+
 ## [0.2.2]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.2.3]
 
-## Removed
+### Updated
+* Explode footprints polygons
+
+### Removed
 * Python 3.8 Support
 
 ## [0.2.2]

--- a/README.md
+++ b/README.md
@@ -144,6 +144,16 @@ docker run -ti -v $PWD:/home/ops/topsapp_data topsapp_img \
 ```
 where the `username`/`password` are the Earthdata credentials for accessing NASA data. We note the command line magic of the above is taken care of the `isce2_topsapp/etc/entrypoint.sh` (written by Joe Kennedy) which automatically runs certain bash commands on startup of the container, i.e. the run commands also calls the `isce2_topsapp` command line function as can be seen [here](isce2_topsapp/etc/entrypoint.sh).
 
+# Build Issues
+
+ISCE2, gdal, and xarray are hard to balance. Ideally, we would have a dependabot to increment packages and integration tests to make sure datasets are generated correctly with each update. Unfortunately, this is not currently the case. So, we are including some snippets (credit to Joseph Kennedy) for determining where packages might fail. We have some caps in our environment.yml file. This is how we find them. Sometimes even with our rather minimal integration tests and builds, in 24 hours, a new package can entirely throw something awry with respect to builds.
+
+The easiest way to see what was the *last* working build, check out the docker [images](https://github.com/ACCESS-Cloud-Based-InSAR/DockerizedTopsApp/pkgs/container/dockerizedtopsapp) for the last build. `latest` refers to the latest production build on `main`. `test` refers to the last build on `dev`. But each merge to `dev` gets an image that is recorded.
+
+1. Click one of the images and it will tell you how to download an image into docker e.g. `docker pull ghcr.io/access-cloud-based-insar/dockerizedtopsapp:0.2.2.dev148_gab75888`.
+2. Load the image and get into interactive mode e.g. `docker run --entrypoint /usr/bin/bash  -it --rm ghcr.io/access-cloud-based-insar/dockerizedtopsapp:0.2.2.dev136_ga2d5389 -l`
+3. Check the packages `conda list | grep xarray`
+
 ## FAQ
 
 1. The docker build is taking a long time.

--- a/environment.yml
+++ b/environment.yml
@@ -1,10 +1,8 @@
 name: topsapp_env
 channels:
  - conda-forge
- - anaconda
- - defaults
 dependencies:
- - python==3.9
+ - python=>3.9,<3.10
  - pip
  - affine
  - asf_search>=5.0.0
@@ -27,7 +25,7 @@ dependencies:
  - matplotlib
  - netcdf4
  - notebook
- - numpy<1.24
+ - numpy
  - pandas
  - pysolid
  - papermill
@@ -35,12 +33,11 @@ dependencies:
  - pytest-cov
  - pytest-mock
  - rasterio
- - rioxarray<=0.14.0
+ - rioxarray
  - xarray
- - scipy<1.10
+ - scipy
  - setuptools
  - setuptools_scm
- - scipy<1.10
  - shapely
  - tqdm
  - dem_stitcher>=2.4.0

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: topsapp_env
 channels:
  - conda-forge
 dependencies:
- - python=>3.9,<3.10
+ - python>=3.9,<3.10
  - pip
  - affine
  - asf_search>=5.0.0

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
  - anaconda
  - defaults
 dependencies:
- - python>=3.8,<3.10
+ - python==3.9
  - pip
  - affine
  - asf_search>=5.0.0

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
  - anaconda
  - defaults
 dependencies:
- - python>=3.8,<3.10
+ - python==3.10
  - pip
  - affine
  - asf_search>=5.0.0
@@ -18,7 +18,7 @@ dependencies:
  - geopandas
  - hyp3lib>=1.7
  - ipykernel
- - isce2==2.6.1
+ - isce2==2.6.2
  - jinja2
  - joblib
  - jsonschema==3.2.0

--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,6 @@
 name: topsapp_env
 channels:
  - conda-forge
- - anaconda
- - defaults
 dependencies:
  - python==3.10
  - pip
@@ -27,7 +25,7 @@ dependencies:
  - matplotlib
  - netcdf4
  - notebook
- - numpy<1.24
+ - numpy
  - pandas
  - pysolid
  - papermill
@@ -37,10 +35,9 @@ dependencies:
  - rasterio
  - rioxarray
  - xarray
- - scipy<1.10
  - setuptools
  - setuptools_scm
- - scipy<1.10
+ - scipy
  - shapely
  - tqdm
  - dem_stitcher>=2.4.0

--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,7 @@ dependencies:
  - matplotlib
  - netcdf4
  - notebook
- - numpy
+ - numpy<1.24
  - pandas
  - pysolid
  - papermill
@@ -33,9 +33,9 @@ dependencies:
  - pytest-cov
  - pytest-mock
  - rasterio
- - rioxarray
+ - rioxarray<0.14.0
  - xarray
- - scipy
+ - scipy<1.10
  - setuptools
  - setuptools_scm
  - shapely

--- a/environment.yml
+++ b/environment.yml
@@ -35,7 +35,7 @@ dependencies:
  - pytest-cov
  - pytest-mock
  - rasterio
- - rioxarray
+ - rioxarray<=0.14.0
  - xarray
  - scipy<1.10
  - setuptools

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: topsapp_env
 channels:
  - conda-forge
 dependencies:
- - python==3.10
+ - python>=3.10,<3.11
  - pip
  - affine
  - asf_search>=5.0.0
@@ -33,11 +33,11 @@ dependencies:
  - pytest-cov
  - pytest-mock
  - rasterio
- - rioxarray
+ - rioxarray<0.14.0
  - xarray
  - setuptools
  - setuptools_scm
- - scipy
+ - scipy>=1.10.1
  - shapely
  - tqdm
  - dem_stitcher>=2.4.0


### PR DESCRIPTION
This is an outline of how to get 3.10 and the ISCE2 2.6.2 into the plugin - currently fails at topo step.