### PR TITLE
Iono workflow with masking

### DIFF
--- a/.trufflehog.txt
+++ b/.trufflehog.txt
@@ -5,3 +5,4 @@ Dockerfile
 tests/test_data/sec_manifest.xml
 tests/test_data/ref_manifest.xml
 tests/test_data/
+isce2_topsapp/iono_proc.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Updated
 * Explode footprints polygons
+* Added support for using water mask in ionospheric correction computation
 
 ### Removed
 * Python 3.8 Support

--- a/isce2_topsapp/__init__.py
+++ b/isce2_topsapp/__init__.py
@@ -5,12 +5,11 @@ from isce2_topsapp.delivery_prep import prepare_for_delivery
 from isce2_topsapp.localize_aux_cal import download_aux_cal
 from isce2_topsapp.localize_burst import BurstParams, download_bursts, get_region_of_interest
 from isce2_topsapp.localize_dem import download_dem_for_isce2
-from isce2_topsapp.localize_orbits import download_orbits
 from isce2_topsapp.localize_mask import download_water_mask
+from isce2_topsapp.localize_orbits import download_orbits
 from isce2_topsapp.localize_slc import download_slcs, get_asf_slc_objects
 from isce2_topsapp.packaging import package_gunw_product
 from isce2_topsapp.topsapp_proc import topsapp_processing
-
 
 try:
     __version__ = version(__name__)

--- a/isce2_topsapp/__init__.py
+++ b/isce2_topsapp/__init__.py
@@ -6,6 +6,7 @@ from isce2_topsapp.localize_aux_cal import download_aux_cal
 from isce2_topsapp.localize_burst import BurstParams, download_bursts, get_region_of_interest
 from isce2_topsapp.localize_dem import download_dem_for_isce2
 from isce2_topsapp.localize_orbits import download_orbits
+from isce2_topsapp.localize_mask import download_water_mask
 from isce2_topsapp.localize_slc import download_slcs, get_asf_slc_objects
 from isce2_topsapp.packaging import package_gunw_product
 from isce2_topsapp.topsapp_proc import topsapp_processing
@@ -25,6 +26,7 @@ __all__ = [
     'get_asf_slc_objects',
     'get_region_of_interest',
     'download_dem_for_isce2',
+    'download_water_mask',
     'download_aux_cal',
     'download_bursts',
     'BurstParams',

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -10,12 +10,12 @@ from typing import Optional
 
 from isce2_topsapp import (BurstParams, aws, download_aux_cal, download_bursts,
                            download_dem_for_isce2, download_orbits,
-                           download_slcs, download_water_mask, get_asf_slc_objects, 
+                           download_slcs, download_water_mask, get_asf_slc_objects,
                            get_region_of_interest, package_gunw_product,
                            prepare_for_delivery, topsapp_processing)
 from isce2_topsapp.json_encoder import MetadataEncoder
-from isce2_topsapp.packaging import update_gunw_internal_version_attribute
 from isce2_topsapp.iono_proc import iono_processing
+from isce2_topsapp.packaging import update_gunw_internal_version_attribute
 from isce2_topsapp.solid_earth_tides import update_gunw_with_solid_earth_tide
 
 

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -8,21 +8,33 @@ from importlib.metadata import entry_points
 from pathlib import Path
 from typing import Optional
 
-from isce2_topsapp import (BurstParams, aws, download_aux_cal, download_bursts,
-                           download_dem_for_isce2, download_orbits,
-                           download_slcs, download_water_mask, get_asf_slc_objects,
-                           get_region_of_interest, package_gunw_product,
-                           prepare_for_delivery, topsapp_processing)
-from isce2_topsapp.json_encoder import MetadataEncoder
+from isce2_topsapp import (
+    BurstParams,
+    aws,
+    download_aux_cal,
+    download_bursts,
+    download_dem_for_isce2,
+    download_orbits,
+    download_slcs,
+    download_water_mask,
+    get_asf_slc_objects,
+    get_region_of_interest,
+    package_gunw_product,
+    prepare_for_delivery,
+    topsapp_processing,
+)
 from isce2_topsapp.iono_proc import iono_processing
+from isce2_topsapp.json_encoder import MetadataEncoder
 from isce2_topsapp.packaging import update_gunw_internal_version_attribute
 from isce2_topsapp.solid_earth_tides import update_gunw_with_solid_earth_tide
 
 
-def localize_data(reference_scenes: list,
-                  secondary_scenes: list,
-                  frame_id: int = -1,
-                  dry_run: bool = False) -> dict:
+def localize_data(
+    reference_scenes: list,
+    secondary_scenes: list,
+    frame_id: int = -1,
+    dry_run: bool = False,
+) -> dict:
     """The dry-run prevents gets necessary metadata from SLCs and orbits.
 
     Can be used to run workflow without redownloading data (except DEM).
@@ -30,51 +42,55 @@ def localize_data(reference_scenes: list,
     Fixed frames are found here: s3://s1-gunw-frames/s1_frames.geojson
     And discussed in the readme.
     """
-    out_slc = download_slcs(reference_scenes,
-                            secondary_scenes,
-                            frame_id=frame_id,
-                            dry_run=dry_run)
+    out_slc = download_slcs(
+        reference_scenes, secondary_scenes, frame_id=frame_id, dry_run=dry_run
+    )
 
-    out_orbits = download_orbits(reference_scenes,
-                                 secondary_scenes,
-                                 dry_run=dry_run)
+    out_orbits = download_orbits(
+        reference_scenes, secondary_scenes, dry_run=dry_run)
 
     out_dem = {}
     out_aux_cal = {}
     if not dry_run:
-        out_dem = download_dem_for_isce2(out_slc['extent'])
-        out_water_mask = download_water_mask(out_slc['extent'])
+        out_dem = download_dem_for_isce2(out_slc["extent"])
+        out_water_mask = download_water_mask(out_slc["extent"])
         out_aux_cal = download_aux_cal()
 
-    out = {'reference_scenes': reference_scenes,
-           'secondary_scenes': secondary_scenes,
-           **out_slc,
-           **out_dem,
-           **out_water_mask,
-           **out_aux_cal,
-           **out_orbits}
+    out = {
+        "reference_scenes": reference_scenes,
+        "secondary_scenes": secondary_scenes,
+        **out_slc,
+        **out_dem,
+        **out_water_mask,
+        **out_aux_cal,
+        **out_orbits,
+    }
     return out
 
 
-def ensure_earthdata_credentials(username: Optional[str] = None, password: Optional[str] = None,
-                                 host: str = 'urs.earthdata.nasa.gov'):
+def ensure_earthdata_credentials(
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+    host: str = "urs.earthdata.nasa.gov",
+):
     """Ensures Earthdata credentials are provided in ~/.netrc
 
-     Earthdata username and password may be provided by, in order of preference, one of:
-        * `netrc_file`
-        * `username` and `password`
-        * `EARTHDATA_USERNAME` and `EARTHDATA_PASSWORD` environment variables
-     and will be written to the ~/.netrc file if it doesn't already exist.
-     """
+    Earthdata username and password may be provided by, in order of preference, one of:
+       * `netrc_file`
+       * `username` and `password`
+       * `EARTHDATA_USERNAME` and `EARTHDATA_PASSWORD` environment variables
+    and will be written to the ~/.netrc file if it doesn't already exist.
+    """
     if username is None:
-        username = os.getenv('EARTHDATA_USERNAME')
+        username = os.getenv("EARTHDATA_USERNAME")
 
     if password is None:
-        password = os.getenv('EARTHDATA_PASSWORD')
+        password = os.getenv("EARTHDATA_PASSWORD")
 
-    netrc_file = Path.home() / '.netrc'
+    netrc_file = Path.home() / ".netrc"
     if not netrc_file.exists() and username and password:
-        netrc_file.write_text(f'machine {host} login {username} password {password}')
+        netrc_file.write_text(
+            f"machine {host} login {username} password {password}")
         netrc_file.chmod(0o000600)
 
     try:
@@ -82,148 +98,167 @@ def ensure_earthdata_credentials(username: Optional[str] = None, password: Optio
         username, _, password = dot_netrc.authenticators(host)
     except (FileNotFoundError, netrc.NetrcParseError, TypeError):
         raise ValueError(
-            f'Please provide valid Earthdata login credentials via {netrc_file}, '
-            f'username and password options, or '
-            f'the EARTHDATA_USERNAME and EARTHDATA_PASSWORD environment variables.'
+            f"Please provide valid Earthdata login credentials via {netrc_file}, "
+            f"username and password options, or "
+            f"the EARTHDATA_USERNAME and EARTHDATA_PASSWORD environment variables."
         )
 
 
 def true_false_string_argument(s: str) -> bool:
     s = s.lower()
-    if s not in ('true', 'false'):
-        raise ValueError('Only the strings `true` or `false` (any capitalization) may be provided.')
-    return s == 'true'
+    if s not in ("true", "false"):
+        raise ValueError(
+            "Only the strings `true` or `false` (any capitalization) may be provided."
+        )
+    return s == "true"
 
 
 def esd_threshold_argument(threshold: str) -> float:
     threshold = float(threshold)
 
-    if math.isclose(threshold, -1.):
+    if math.isclose(threshold, -1.0):
         return threshold
 
-    if (0. > threshold) or (threshold > 1.):
-        raise ValueError('ESD coherence threshold should be a value between 0 and 1,'
-                         ' or -1 for no ESD correction')
+    if (0.0 > threshold) or (threshold > 1.0):
+        raise ValueError(
+            "ESD coherence threshold should be a value between 0 and 1,"
+            " or -1 for no ESD correction"
+        )
     return threshold
 
 
 def gunw_slc():
     parser = ArgumentParser()
-    parser.add_argument('--username')
-    parser.add_argument('--password')
-    parser.add_argument('--bucket')
-    parser.add_argument('--bucket-prefix', default='')
-    parser.add_argument('--dry-run', action='store_true')
-    parser.add_argument('--reference-scenes', type=str.split, nargs='+', required=True)
-    parser.add_argument('--secondary-scenes', type=str.split, nargs='+', required=True)
-    parser.add_argument('--estimate-ionosphere-delay', type=true_false_string_argument, default=False)
-    parser.add_argument('--frame-id', type=int, default=-1)
-    parser.add_argument('--compute-solid-earth-tide', type=true_false_string_argument, default=False)
-    parser.add_argument('--esd-coherence-threshold', type=float, default=-1.)
+    parser.add_argument("--username")
+    parser.add_argument("--password")
+    parser.add_argument("--bucket")
+    parser.add_argument("--bucket-prefix", default="")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--reference-scenes",
+                        type=str.split, nargs="+", required=True)
+    parser.add_argument("--secondary-scenes",
+                        type=str.split, nargs="+", required=True)
+    parser.add_argument(
+        "--estimate-ionosphere-delay", type=true_false_string_argument, default=False
+    )
+    parser.add_argument("--frame-id", type=int, default=-1)
+    parser.add_argument(
+        "--compute-solid-earth-tide", type=true_false_string_argument, default=False
+    )
+    parser.add_argument("--esd-coherence-threshold", type=float, default=-1.0)
     args = parser.parse_args()
 
     ensure_earthdata_credentials(args.username, args.password)
 
-    args.reference_scenes = [item for sublist in args.reference_scenes for item in sublist]
-    args.secondary_scenes = [item for sublist in args.secondary_scenes for item in sublist]
+    args.reference_scenes = [
+        item for sublist in args.reference_scenes for item in sublist
+    ]
+    args.secondary_scenes = [
+        item for sublist in args.secondary_scenes for item in sublist
+    ]
 
     # Region of interest becomes 'extent' in loc_data
-    loc_data = localize_data(args.reference_scenes,
-                             args.secondary_scenes,
-                             dry_run=args.dry_run,
-                             frame_id=args.frame_id)
-    loc_data['frame_id'] = args.frame_id
+    loc_data = localize_data(
+        args.reference_scenes,
+        args.secondary_scenes,
+        dry_run=args.dry_run,
+        frame_id=args.frame_id,
+    )
+    loc_data["frame_id"] = args.frame_id
 
     # Allows for easier re-inspection of processing, packaging, and delivery
     # after job completes
-    json.dump(loc_data,
-              open('loc_data.json', 'w'),
-              indent=2,
-              cls=MetadataEncoder)
+    json.dump(loc_data, open("loc_data.json", "w"),
+              indent=2, cls=MetadataEncoder)
 
-    topsapp_processing(reference_slc_zips=loc_data['ref_paths'],
-                       secondary_slc_zips=loc_data['sec_paths'],
-                       orbit_directory=loc_data['orbit_directory'],
-                       # Region of interest is passed to topsapp via 'extent' key in loc_data
-                       extent=loc_data['processing_extent'],
-                       estimate_ionosphere_delay=False,
-                       do_esd=args.esd_coherence_threshold >= 0.,
-                       esd_coherence_threshold=args.esd_coherence_threshold,
-                       dem_for_proc=loc_data['full_res_dem_path'],
-                       dem_for_geoc=loc_data['low_res_dem_path'],
-                       dry_run=args.dry_run,
-                       )
+    topsapp_processing(
+        reference_slc_zips=loc_data["ref_paths"],
+        secondary_slc_zips=loc_data["sec_paths"],
+        orbit_directory=loc_data["orbit_directory"],
+        # Region of interest is passed to topsapp via 'extent' key in loc_data
+        extent=loc_data["processing_extent"],
+        estimate_ionosphere_delay=False,
+        do_esd=args.esd_coherence_threshold >= 0.0,
+        esd_coherence_threshold=args.esd_coherence_threshold,
+        dem_for_proc=loc_data["full_res_dem_path"],
+        dem_for_geoc=loc_data["low_res_dem_path"],
+        dry_run=args.dry_run,
+    )
 
     # Run ionospheric correction
     if args.estimate_ionosphere_delay:
         iono_processing(
-            reference_slc_zips=loc_data['ref_paths'],
-            secondary_slc_zips=loc_data['sec_paths'],
-            orbit_directory=loc_data['orbit_directory'],
-            extent=loc_data['processing_extent'],
-            dem_for_proc=loc_data['full_res_dem_path'],
-            dem_for_geoc=loc_data['low_res_dem_path'],
-            mask_filename=loc_data['water_mask'],
+            reference_slc_zips=loc_data["ref_paths"],
+            secondary_slc_zips=loc_data["sec_paths"],
+            orbit_directory=loc_data["orbit_directory"],
+            extent=loc_data["processing_extent"],
+            dem_for_proc=loc_data["full_res_dem_path"],
+            dem_for_geoc=loc_data["low_res_dem_path"],
+            mask_filename=loc_data["water_mask"],
         )
 
-    ref_properties = loc_data['reference_properties']
-    sec_properties = loc_data['secondary_properties']
-    extent = loc_data['extent']
+    ref_properties = loc_data["reference_properties"]
+    sec_properties = loc_data["secondary_properties"]
+    extent = loc_data["extent"]
 
     additional_2d_layers = []
     if args.estimate_ionosphere_delay:
-        additional_2d_layers.append('ionosphere')
+        additional_2d_layers.append("ionosphere")
 
     additional_2d_layers = additional_2d_layers or None
-    nc_path = package_gunw_product(isce_data_directory=Path.cwd(),
-                                   reference_properties=ref_properties,
-                                   secondary_properties=sec_properties,
-                                   extent=extent,
-                                   additional_2d_layers=additional_2d_layers,
-                                   )
+    nc_path = package_gunw_product(
+        isce_data_directory=Path.cwd(),
+        reference_properties=ref_properties,
+        secondary_properties=sec_properties,
+        extent=extent,
+        additional_2d_layers=additional_2d_layers,
+    )
 
     if args.compute_solid_earth_tide:
-        nc_path = update_gunw_with_solid_earth_tide(nc_path, 'reference')
-        nc_path = update_gunw_with_solid_earth_tide(nc_path, 'secondary')
+        nc_path = update_gunw_with_solid_earth_tide(nc_path, "reference")
+        nc_path = update_gunw_with_solid_earth_tide(nc_path, "secondary")
 
     if args.compute_solid_earth_tide or args.estimate_ionosphere_delay:
-        update_gunw_internal_version_attribute(nc_path, new_version='1c')
+        update_gunw_internal_version_attribute(nc_path, new_version="1c")
 
     # Move final product to current working directory
     final_directory = prepare_for_delivery(nc_path, loc_data)
 
     if args.bucket:
-        for file in final_directory.glob('S1-GUNW*'):
+        for file in final_directory.glob("S1-GUNW*"):
             aws.upload_file_to_s3(file, args.bucket, args.bucket_prefix)
 
 
 def gunw_burst():
     parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
-    parser.add_argument('--username')
-    parser.add_argument('--password')
-    parser.add_argument('--bucket')
-    parser.add_argument('--bucket-prefix', default='')
-    parser.add_argument('--dry-run', action='store_true')
-    parser.add_argument('--reference-scene', type=str, required=True)
-    parser.add_argument('--secondary-scene', type=str, required=True)
-    parser.add_argument('--image-number', type=int, required=True)
-    parser.add_argument('--burst-number', type=int, required=True)
-    parser.add_argument('--azimuth-looks', type=int, default=2)
-    parser.add_argument('--range-looks', type=int, default=10)
-    parser.add_argument('--estimate-ionosphere-delay', type=true_false_string_argument, default=False)
+    parser.add_argument("--username")
+    parser.add_argument("--password")
+    parser.add_argument("--bucket")
+    parser.add_argument("--bucket-prefix", default="")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--reference-scene", type=str, required=True)
+    parser.add_argument("--secondary-scene", type=str, required=True)
+    parser.add_argument("--image-number", type=int, required=True)
+    parser.add_argument("--burst-number", type=int, required=True)
+    parser.add_argument("--azimuth-looks", type=int, default=2)
+    parser.add_argument("--range-looks", type=int, default=10)
+    parser.add_argument(
+        "--estimate-ionosphere-delay", type=true_false_string_argument, default=False
+    )
     args = parser.parse_args()
 
     ensure_earthdata_credentials(args.username, args.password)
 
-    ref_obj, sec_obj = get_asf_slc_objects([args.reference_scene, args.secondary_scene])
+    ref_obj, sec_obj = get_asf_slc_objects(
+        [args.reference_scene, args.secondary_scene])
 
     ref_params = BurstParams(
-        safe_url=ref_obj.properties['url'],
+        safe_url=ref_obj.properties["url"],
         image_number=args.image_number,
         burst_number=args.burst_number,
     )
     sec_params = BurstParams(
-        safe_url=sec_obj.properties['url'],
+        safe_url=sec_obj.properties["url"],
         image_number=args.image_number,
         burst_number=args.burst_number,
     )
@@ -231,10 +266,14 @@ def gunw_burst():
     ref_burst, sec_burst = download_bursts([ref_params, sec_params])
 
     intersection = ref_burst.footprint.intersection(sec_burst.footprint).bounds
-    is_ascending = ref_burst.orbit_direction == 'ascending'
-    roi = get_region_of_interest(ref_burst.footprint, sec_burst.footprint, is_ascending=is_ascending)
+    is_ascending = ref_burst.orbit_direction == "ascending"
+    roi = get_region_of_interest(
+        ref_burst.footprint, sec_burst.footprint, is_ascending=is_ascending
+    )
 
-    orbits = download_orbits([ref_burst.safe_name[:-5]], [sec_burst.safe_name[:-5]], dry_run=args.dry_run)
+    orbits = download_orbits(
+        [ref_burst.safe_name[:-5]], [sec_burst.safe_name[:-5]], dry_run=args.dry_run
+    )
 
     if not args.dry_run:
         # TODO this is likely not the optimal geometry to pass to this function
@@ -245,10 +284,10 @@ def gunw_burst():
     topsapp_processing(
         reference_slc_zips=ref_burst.safe_name,
         secondary_slc_zips=sec_burst.safe_name,
-        orbit_directory=orbits['orbit_directory'],
+        orbit_directory=orbits["orbit_directory"],
         extent=roi,
-        dem_for_proc=dem['full_res_dem_path'],
-        dem_for_geoc=dem['low_res_dem_path'],
+        dem_for_proc=dem["full_res_dem_path"],
+        dem_for_geoc=dem["low_res_dem_path"],
         estimate_ionosphere_delay=False,
         azimuth_looks=args.azimuth_looks,
         range_looks=args.range_looks,
@@ -261,10 +300,10 @@ def gunw_burst():
         iono_processing(
             reference_slc_zips=ref_burst.safe_name,
             secondary_slc_zips=sec_burst.safe_name,
-            orbit_directory=orbits['orbit_directory'],
+            orbit_directory=orbits["orbit_directory"],
             extent=roi,
-            dem_for_proc=dem['full_res_dem_path'],
-            dem_for_geoc=dem['low_res_dem_path'],
+            dem_for_proc=dem["full_res_dem_path"],
+            dem_for_geoc=dem["low_res_dem_path"],
             azimuth_looks=args.azimuth_looks,
             range_looks=args.range_looks,
             swaths=[ref_burst.swath],
@@ -272,26 +311,30 @@ def gunw_burst():
         )
 
     if args.bucket:
-        for file in Path('merged').glob('*geo*'):
+        for file in Path("merged").glob("*geo*"):
             aws.upload_file_to_s3(file, args.bucket, args.bucket_prefix)
 
 
 def main():
-    parser = ArgumentParser(prefix_chars='+', formatter_class=ArgumentDefaultsHelpFormatter)
+    parser = ArgumentParser(
+        prefix_chars="+", formatter_class=ArgumentDefaultsHelpFormatter
+    )
     parser.add_argument(
-        '++process', choices=['gunw_slc', 'gunw_burst'], default='gunw_slc',
-        help='Select the HyP3 entrypoint to use'
+        "++process",
+        choices=["gunw_slc", "gunw_burst"],
+        default="gunw_slc",
+        help="Select the HyP3 entrypoint to use",
     )
     args, unknowns = parser.parse_known_args()
 
     sys.argv = [args.process, *unknowns]
     # FIXME: this gets better in python 3.10
     # (process_entry_point,) = entry_points(group='console_scripts', name=args.process)
-    process_entry_point = [ep for ep in entry_points()['console_scripts'] if ep.name == args.process][0]
-    sys.exit(
-        process_entry_point.load()()
-    )
+    process_entry_point = [
+        ep for ep in entry_points()["console_scripts"] if ep.name == args.process
+    ][0]
+    sys.exit(process_entry_point.load()())
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -10,13 +10,14 @@ from typing import Optional
 
 from isce2_topsapp import (BurstParams, aws, download_aux_cal, download_bursts,
                            download_dem_for_isce2, download_orbits,
-                           download_slcs, get_asf_slc_objects, download_water_mask,
+                           download_slcs, download_water_mask, get_asf_slc_objects, 
                            get_region_of_interest, package_gunw_product,
                            prepare_for_delivery, topsapp_processing)
 from isce2_topsapp.json_encoder import MetadataEncoder
 from isce2_topsapp.packaging import update_gunw_internal_version_attribute
-from isce2_topsapp.solid_earth_tides import update_gunw_with_solid_earth_tide
 from isce2_topsapp.iono_proc import iono_processing
+from isce2_topsapp.solid_earth_tides import update_gunw_with_solid_earth_tide
+
 
 def localize_data(reference_scenes: list,
                   secondary_scenes: list,
@@ -152,8 +153,8 @@ def gunw_slc():
                        dem_for_geoc=loc_data['low_res_dem_path'],
                        dry_run=args.dry_run,
                        )
-    
-    #Run ionospheric correction
+
+    # Run ionospheric correction
     if args.estimate_ionosphere_delay:
         iono_processing(
             reference_slc_zips=loc_data['ref_paths'],
@@ -255,7 +256,7 @@ def gunw_burst():
         dry_run=args.dry_run,
     )
 
-    #Run ionospheric correction
+    # Run ionospheric correction
     if args.estimate_ionosphere_delay:
         iono_processing(
             reference_slc_zips=ref_burst.safe_name,

--- a/isce2_topsapp/iono_proc.py
+++ b/isce2_topsapp/iono_proc.py
@@ -9,315 +9,280 @@ import numpy as np
 from jinja2 import Template
 from tqdm import tqdm
 
-from isce.components import isceobj
 from numpy.typing import NDArray
+from isce.components import isceobj
+from isce.components.isceobj.TopsProc.runMergeBursts import (
+    interpolateDifferentNumberOfLooks,
+)
 
-try:
-    from osgeo import gdal
-except ModuleNotFoundError as exc:
-    raise ModuleNotFoundError('Python module gdal missing!') from exc
+from osgeo import gdal
 
-'''
-List of parameters for ionospheric correction:
-______________________________________________________________________
-property name="do ionosphere correction">False</property>
-<property name="apply ionosphere correction">False</property>
-<property name="consider burst properties in ionosphere computation">False</property>
-#choose from: ['subband', 'rawion', 'grd2ion', 'filt_gaussian', 'ionosphere_shift', 'ion2grd', 'esd']
-<property name="start ionosphere step">subband</property>
-<property name="end ionosphere step">esd</property>
+# List of parameters for ionospheric correction:
+# https://github.com/isce-framework/isce2/blob/8af43d2b9f291e2370e9112a3ead1449d0f2a386/examples/input_files/topsApp.xml#L182
 
-<property name="height of ionosphere layer in km">200.0</property>
-<property name="apply polynomial fit before filtering ionosphere phase">True</property>
-<property name="maximum window size for filtering ionosphere phase">200</property>
-<property name="minimum window size for filtering ionosphere phase">100</property>
-<property name="maximum window size for filtering ionosphere azimuth shift">150</property>
-<property name="minimum window size for filtering ionosphere azimuth shift">75</property>
-#0: no correction
-#1: use mean value of a burst
-#2: use full burst
-<property name="correct phase error caused by ionosphere azimuth shift">1</property>
+IONO_STEPS = ["subband", "rawion", "grd2ion", "filt_gaussian"]
 
-seperated islands or areas usually affect ionosphere estimation and it's better to mask them
-#out. check ion/ion_cal/raw_no_projection.ion for areas to be masked out.
-#The parameter is a 2-D list. Each element in the 2-D list is a four-element list: [firstLine,
-#lastLine, firstColumn, lastColumn], with line/column numbers starting with 1. If one of the
-#four elements is specified as -1, the program will use firstLine/lastLine/firstColumn/
-#lastColumn instead. For exmple, if you want to mask the following two areas out, you can
-#specify a 2-D list like:
-#[[100, 200, 100, 200],[1000, 1200, 500, 600]]
-<property name="areas masked out in ionospheric phase estimation">None</property>
+TEMPLATE_DIR = Path(__file__).parent / "templates"
 
-#better NOT try changing the following two parameters, since they are related
-#to the filtering parameters above
-<property name="total number of azimuth looks in the ionosphere processing">50</property>
-<property name="total number of range looks in the ionosphere processing">200</property>
-#the above numbers should be integer multiples of the below numbers
-<property name="number of azimuth looks at first stage for ionosphere phase unwrapping">10</property>
-<property name="number of range looks at first stage for ionosphere phase unwrapping">40</property>
-'''
-
-IONO_STEPS = ['subband',
-              'rawion',
-              'grd2ion',
-              'filt_gaussian',
-               # only do the following steps 
-               # when considering burst properties
-              'ionosphere_shift',
-              'ion2grd',
-              'esd']
-
-TEMPLATE_DIR = Path(__file__).parent/'templates'
-
-GEOCODE_LIST_BASE = ['merged/topophase.ion']
+GEOCODE_LIST_BASE = ["merged/topophase.ion"]
 
 
-def iono_processing(*,
-                    reference_slc_zips: list,
-                    secondary_slc_zips: list,
-                    orbit_directory: str,
-                    extent: list,
-                    dem_for_proc: str,
-                    dem_for_geoc: str,
-                    azimuth_looks: int = 7,
-                    range_looks: int = 19,
-                    swaths: list = None,
-                    do_esd: bool = False,
-                    esd_coherence_threshold: float = .7,
-                    mask_filename: str = None):
+def iono_processing(
+    *,
+    reference_slc_zips: list,
+    secondary_slc_zips: list,
+    orbit_directory: str,
+    extent: list,
+    dem_for_proc: str,
+    dem_for_geoc: str,
+    azimuth_looks: int = 7,
+    range_looks: int = 19,
+    swaths: list = None,
+    do_esd: bool = False,
+    esd_coherence_threshold: float = 0.7,
+    mask_filename: str = None,
+):
     swaths = swaths or [1, 2, 3]
     # for [ymin, ymax, xmin, xmax]
     extent_isce = [extent[k] for k in [1, 3, 0, 2]]
 
     # Update PATH with ISCE2 applications
-    isce_application_path = Path(f'{site.getsitepackages()[0]}'
-                                    '/isce/applications/')
-    os.environ['PATH'] += (':' + str(isce_application_path))
+    isce_app_path = Path(f"{site.getsitepackages()[0]}" "/isce/applications/")
+    os.environ["PATH"] += ":" + str(isce_app_path)
 
     # Define topsApp input xml parameters
-    iono_kwargs = {'orbit_directory': orbit_directory,
-                   'output_reference_directory': 'reference',
-                   'output_secondary_directory': 'secondary',
-                   'ref_zip_file': reference_slc_zips,
-                   'sec_zip_file': secondary_slc_zips,
-                   'region_of_interest': extent_isce,
-                   'demFilename': dem_for_proc,
-                   'geocodeDemFilename': dem_for_geoc,
-                   'filter_strength': .5,
-                    'do_unwrap': True,
-                    'use_virtual_files': True,
-                    'do_esd': do_esd,
-                    'esd_coherence_threshold': esd_coherence_threshold,
-                    # IONO PARAMETERS
-                    'estimate_ionosphere_delay': True,
-                    'iono_burstProperties': False,
-                    'iono_polyFit': True,
-                    'iono_correctAzimuthshift': 1,
-                    'azimuth_looks': azimuth_looks,
-                    'range_looks': range_looks,
-                    'swaths': swaths,
-                    'geocode_list': GEOCODE_LIST_BASE
-                     }
+    ion_kwargs = {
+        "orbit_directory": orbit_directory,
+        "output_reference_directory": "reference",
+        "output_secondary_directory": "secondary",
+        "ref_zip_file": reference_slc_zips,
+        "sec_zip_file": secondary_slc_zips,
+        "region_of_interest": extent_isce,
+        "demFilename": dem_for_proc,
+        "geocodeDemFilename": dem_for_geoc,
+        "filter_strength": 0.5,
+        "do_unwrap": True,
+        "use_virtual_files": True,
+        "do_esd": do_esd,
+        "esd_coherence_threshold": esd_coherence_threshold,
+        # IONO PARAMETERS
+        "estimate_ionosphere_delay": True,
+        "ion_burstProperties": False,
+        "ion_polyFit": True,
+        "ion_correctAzimuthshift": 1,
+        "azimuth_looks": azimuth_looks,
+        "range_looks": range_looks,
+        "swaths": swaths,
+        "geocode_list": GEOCODE_LIST_BASE,
+    }
 
-    with open(TEMPLATE_DIR/'topsapp_iono_template.xml', 'r') as file:
+    with open(TEMPLATE_DIR / "topsapp_iono_template.xml", "r") as file:
         template = Template(file.read())
 
     # Step-1 Run ionospheric correction step subband
-    iono_xml = template.render(**iono_kwargs,
-                               iono_startStep=IONO_STEPS[0],
-                               iono_stopStep=IONO_STEPS[0])
+    iono_xml = template.render(
+        **ion_kwargs, ion_startStep=IONO_STEPS[0], ion_stopStep=IONO_STEPS[0]
+    )
 
-    with open('ionoApp.xml', "w") as file:
+    with open("ionoApp.xml", "w") as file:
         file.write(iono_xml)
 
-    tops_app_cmd = f'{isce_application_path}/topsApp.py'
+    tops_app_cmd = f"{isce_app_path}/topsApp.py"
 
-    step_cmd = f'{tops_app_cmd} ionoApp.xml --dostep=ion'
-    result = subprocess.run(step_cmd,
-                            shell=True)
+    step_cmd = f"{tops_app_cmd} ionoApp.xml --dostep=ion"
+    result = subprocess.run(step_cmd, shell=True)
     if result.returncode != 0:
-        raise ValueError('TopsApp failed at step: ion-subband')
+        raise ValueError("TopsApp failed at step: ion-subband")
 
     # Step-2 Mask upper and lower band burst wrapped interferograms
-    # path to burst ifgs: ion/lower|upper/fine_interferogram/IW{1,2,3}/burst_{##}.int
+    # path to burst ifgs:
+    # ion/lower|upper/fine_interferogram/IW{1,2,3}/burst_{##}.int
     # path to burst geometry: geom_reference/IW{1,2,3}/lat|lon_{##}.rdr
 
     if mask_filename:
         # Project mask to burst image coordinate space
-        workdir = Path('.').absolute()
+        workdir = Path(".").absolute()
 
-        get_swath = lambda x: x.split('/')[-2]
-        get_burst = lambda x: x.split('/')[-1].split('_')[-1].split('.')[0]
+        def get_swath(x):
+            return x.split("/")[-2]
+
+        def get_burst(x):
+            return x.split("/")[-1].split("_")[-1].split(".")[0]
 
         # Get all geometry files
-        geom_files = list(workdir.glob('geom_reference/IW*/lat*.rdr'))
+        geom_files = list(workdir.glob("geom_reference/IW*/lat*.rdr"))
 
         # NOTE: THis can be easily parallized, skipped for now
         with tqdm(total=len(geom_files)) as pbar:
             for lat in geom_files:
-                pbar.set_description(f'Geo2radar mask {get_swath(str(lat))}\
-                                        /{get_burst(str(lat))}')
+                pbar.set_description(
+                    f"Geo2radar mask {get_swath(str(lat))}\
+                                        /{get_burst(str(lat))}"
+                )
 
-                lon = str(lat).replace('lat', 'lon')
+                lon = str(lat).replace("lat", "lon")
                 # Get the swath and burst number
                 swath = get_swath(str(lat))
                 burst = get_burst(str(lat))
                 # Get output dir and file
-                output_dir = workdir / f'mask/{swath}'
+                output_dir = workdir / f"mask/{swath}"
                 output_dir.mkdir(parents=True, exist_ok=True)
-                output_filename = output_dir / f'msk_{burst}.rdr'
+                output_file = output_dir / f"msk_{burst}.rdr"
                 # Projct mask to radar coordinate space
-                mask = mask_geo2radar(mask_filename,
-                                      str(lat), lon,
-                                      str(output_filename), saveFlag=True)
-                mask = None  # del mask array
+                mask_geo2radar(mask_filename, str(lat), lon, str(output_file))
                 pbar.update()
 
         # Get lower and upper band full-resolution interferograms
-        lower_band_ifgs = workdir.glob('ion/lower/fine_interferogram/IW*/burst*.int')
-        upper_band_ifgs = workdir.glob('ion/upper/fine_interferogram/IW*/burst*.int')
+        iono_location = "ion/{band}/fine_interferogram/IW*/burst*.int"
+        lower_band_ifgs = workdir.glob(iono_location.format(band="lower"))
+        upper_band_ifgs = workdir.glob(iono_location.format(band="upper"))
 
         # Lower band interferograms
         with tqdm(total=len(lower_band_ifgs + upper_band_ifgs)) as pbar:
             for ifg in lower_band_ifgs + upper_band_ifgs:
-                band = str(ifg).split('/')[-4]
-                pbar.set_description(f'Masking {band}-iono interferograms {get_swath(str(ifg))}/\
-                                    {get_burst(str(ifg))}')
+                band = str(ifg).split("/")[-4]
+                pbar.set_description(
+                    f"Masking {band}-iono interferograms \
+                                     {get_swath(str(ifg))}\
+                                     /{get_burst(str(ifg))}"
+                )
+
                 # Get the swath and burst number
                 swath = get_swath(str(ifg))
                 burst = get_burst(str(ifg))
                 # Get mask
-                mask_file = workdir / f'mask/{swath}/msk_{burst}.rdr.vrt'
+                mask_file = workdir / f"mask/{swath}/msk_{burst}.rdr.vrt"
                 mask_ds = gdal.Open(str(mask_file), gdal.GA_ReadOnly)
                 # Mask
                 mask_interferogram(str(ifg), mask_ds.ReadAsArray())
-                mask_ds = None  #close
+                mask_ds = None  # close
                 pbar.update()
 
     # Step-3 Compute ionospheric correction
-    iono_xml = template.render(**iono_kwargs,
-                               iono_startStep=IONO_STEPS[1],
-                               iono_stopStep=IONO_STEPS[-1])
+    iono_xml = template.render(
+        **ion_kwargs, ion_startStep=IONO_STEPS[1], ion_stopStep=IONO_STEPS[-1]
+    )
 
-    with open('ionoApp.xml', "w") as file:
+    with open("ionoApp.xml", "w") as file:
         file.write(iono_xml)
 
-    tops_app_cmd = f'{isce_application_path}/topsApp.py'
-
-    step_cmd = f'{tops_app_cmd} ionoApp.xml --dostep=ion'
-    result = subprocess.run(step_cmd,
-                            shell=True)
+    step_cmd = f"{tops_app_cmd} ionoApp.xml --dostep=ion"
+    result = subprocess.run(step_cmd, shell=True)
     if result.returncode != 0:
-        raise ValueError('TopsApp failed at step: ion-rawion2esd')
+        raise ValueError("TopsApp failed at step: ion-rawion2esd")
 
     # Step-4 mergeBursts
     # Create merged/topophase.ion file
     merge_bursts(range_looks=range_looks, azimuth_looks=azimuth_looks)
 
     # Step-5 Geocode ionospheric correction outputs
-    step_cmd = f'{tops_app_cmd} ionoApp.xml --dostep=geocode'
-    result = subprocess.run(step_cmd,
-                            shell=True)
+    step_cmd = f"{tops_app_cmd} ionoApp.xml --dostep=geocode"
+    result = subprocess.run(step_cmd, shell=True)
     if result.returncode != 0:
-        raise ValueError('TopsApp failed at step: geocode (ion)')
+        raise ValueError("TopsApp failed at step: geocode (ion)")
 
 
-def merge_bursts(range_looks: int = 19,
-                 azimuth_looks: int = 7,
-                 ion_rangeLooks: int = 200,
-                 ion_azimuthLooks: int = 50,
-                 considerBursts: bool = False,
-                 mergedir: Union[str, Path] = './merged') -> None:
-    from isce.components.isceobj.TopsProc.runMergeBursts import interpolateDifferentNumberOfLooks
+def merge_bursts(
+    range_looks: int = 19,
+    azimuth_looks: int = 7,
+    ion_rangeLooks: int = 200,
+    ion_azimuthLooks: int = 50,
+    mergedir: Union[str, Path] = "./merged",
+) -> None:
+    """
+    Reference:
+      https://github.com/isce-framework/isce2/blob/8af43d2b9f291e2370e9112a3ead1449d0f2a386/components/isceobj/TopsProc/runMergeBursts.py#L851
 
-    mergedIfgname = 'topophase.flat'
-    mergedIonname = 'topophase.ion'
+    """
+    mergedIfgname = "topophase.flat"
+    mergedIonname = "topophase.ion"
     #########################################
 
-    if considerBursts:
-        print('TODO, Skip as it is not a DEFAULT')
-        '''
-        ionDirname = 'ion/ion_burst'
-        topsProc : runMergeBursts.py 776
-        mergeBursts2(frames, os.path.join(ionDirname, 'IW%d',  'burst_%02d.ion'),\
-              burstIndex, box, os.path.join(mergedir, mergedIonname+suffix), virtual=virtual, validOnly=True)
-        multilook(os.path.join(mergedir, mergedIonname+suffix),
-                      outname = os.path.join(mergedir, mergedIonname),
-                      alks = self.numberAzimuthLooks, rlks=self.numberRangeLooks)
-        '''
-    else:
-        ionFilt = 'ion/ion_cal/filt.ion'
-        img = isceobj.createImage()
-        img.load(ionFilt+'.xml')
-        ionFiltImage = (np.fromfile(ionFilt, dtype=np.float32).reshape(img.length*2, img.width))[1:img.length*2:2, :]
-        img = isceobj.createImage()
-        img.load(os.path.join(mergedir, mergedIfgname+'.xml'))
+    ionFilt = "ion/ion_cal/filt.ion"
+    img = isceobj.createImage()
+    img.load(ionFilt + ".xml")
+    ionFiltImage = (
+        np.fromfile(ionFilt, dtype=np.float32).reshape(img.length * 2, img.width)
+    )[1 : img.length * 2 : 2, :]
+    img = isceobj.createImage()
+    img.load(os.path.join(mergedir, mergedIfgname + ".xml"))
 
-        # interpolate original
-        ionFiltImageOut = interpolateDifferentNumberOfLooks(ionFiltImage,
-                                                            img.length, img.width,
-                                                            range_looks, azimuth_looks,
-                                                            ion_rangeLooks, ion_azimuthLooks)
-        ionFiltOut = os.path.join(mergedir, mergedIonname)
-        ionFiltImageOut.astype(np.float32).tofile(ionFiltOut)
+    # interpolate original
+    ionFiltImageOut = interpolateDifferentNumberOfLooks(
+        ionFiltImage,
+        img.length,
+        img.width,
+        range_looks,
+        azimuth_looks,
+        ion_rangeLooks,
+        ion_azimuthLooks,
+    )
+    ionFiltOut = os.path.join(mergedir, mergedIonname)
+    ionFiltImageOut.astype(np.float32).tofile(ionFiltOut)
 
-        image = isceobj.createImage()
-        image.setDataType('FLOAT')
-        image.setFilename(ionFiltOut)
-        image.extraFilename = ionFiltOut + '.vrt'
-        image.setWidth(img.width)
-        image.setLength(img.length)
-        # image.setAccessMode('read')
-        # image.createImage()
-        image.renderHdr()
-        # image.finalizeImage()
+    image = isceobj.createImage()
+    image.setDataType("FLOAT")
+    image.setFilename(ionFiltOut)
+    image.extraFilename = ionFiltOut + ".vrt"
+    image.setWidth(img.width)
+    image.setLength(img.length)
+    image.renderHdr()
 
 
-####################### UTILITIES FOR MASKING ###############################
-
-def mask_geo2radar(maskFilename: Union[str, Path],
-                   latFilename: Union[str, Path],
-                   lonFilename: Union[str, Path],
-                   outputFilename: Union[str, Path],
-                   saveFlag: bool = False) -> NDArray:
-    '''
-    This routine translates mask raster from geographical to radar(image) coordinate space
+# UTILITIES FOR MASKING
+def mask_geo2radar(
+    maskFilename: Union[str, Path],
+    latFilename: Union[str, Path],
+    lonFilename: Union[str, Path],
+    outputFilename: Union[str, Path],
+    saveFlag: bool = True,
+) -> NDArray:
+    """
+    This routine translates mask raster
+    from geographical to radar(image) coordinate space
 
     maskFilename : str
             path to georeferenced mask raster (must have vrt extension)
     latFilename : str
-            path to radar lat.rdr file (bursts: geom_reference/IW{1,2,3}/lat_burst.rdr
-                                        merged: merged/lat.rdr.full.vrt)
+            path to radar lat.rdr file
+            (bursts: geom_reference/IW{1,2,3}/lat_burst.rdr
+                     merged: merged/lat.rdr.full.vrt)
     lonFilename : str
-            path to radar lon.rdr file (bursts: geom_reference/IW{1,2,3}/lon_burst.rdr
-                                        merged: merged/lon.rdr.full.vrt)
+            path to radar lon.rdr file
+            (bursts: geom_reference/IW{1,2,3}/lon_burst.rdr
+                     merged: merged/lon.rdr.full.vrt)
     outputFilename : str
             path to save mask output file
     saveFlag : bool
             flag to locally save mask in radar coordinates
-    '''
+    """
 
     # Open mask file
-    mask_ds = gdal.Open(maskFilename + '.vrt')
+    mask_ds = gdal.Open(maskFilename + ".vrt")
     # Open lon and lat file
-    lon_ds = gdal.Open(lonFilename + '.vrt')
-    lat_ds = gdal.Open(latFilename + '.vrt')
+    lon_ds = gdal.Open(lonFilename + ".vrt")
+    lat_ds = gdal.Open(latFilename + ".vrt")
 
     # Get lon and lat arrays
     lons = lon_ds.ReadAsArray()
     lats = lat_ds.ReadAsArray()
 
     # Translate mask geo corrdinate to radar
-    lineIndex = np.int32((lats - mask_ds.GetGeoTransform()[3]) / mask_ds.GetGeoTransform()[5] + 0.5)
-    sampleIndex = np.int32((lons - mask_ds.GetGeoTransform()[0]) / mask_ds.GetGeoTransform()[1] + 0.5)
+    lineIdx = np.int32(
+        (lats - mask_ds.GetGeoTransform()[3]) / mask_ds.GetGeoTransform()[5] + 0.5
+    )
+    sampleIdx = np.int32(
+        (lons - mask_ds.GetGeoTransform()[0]) / mask_ds.GetGeoTransform()[1] + 0.5
+    )
     inboundIndex = np.logical_and(
-                np.logical_and(lineIndex >= 0, lineIndex <= mask_ds.RasterYSize-1),
-                np.logical_and(sampleIndex >= 0, sampleIndex <= mask_ds.RasterXSize-1)
-                )
+        np.logical_and(lineIdx >= 0, lineIdx <= mask_ds.RasterYSize - 1),
+        np.logical_and(sampleIdx >= 0, sampleIdx <= mask_ds.RasterXSize - 1),
+    )
     # Convert
     mask_radarcoord = np.empty(lats.shape)
-    mask_radarcoord[inboundIndex] = mask_ds.ReadAsArray()[lineIndex[inboundIndex],
-                                                            sampleIndex[inboundIndex]]
+    mask_radarcoord[inboundIndex] = mask_ds.ReadAsArray()[
+        lineIdx[inboundIndex], sampleIdx[inboundIndex]
+    ]
     # close gdal instances
     mask_ds = None
     lon_ds = None
@@ -327,9 +292,9 @@ def mask_geo2radar(maskFilename: Union[str, Path],
     if saveFlag:
         mask_radarcoord.astype(np.int8).tofile(outputFilename)
         image = isceobj.createImage()
-        image.setDataType('BYTE')
+        image.setDataType("BYTE")
         image.setFilename(outputFilename)
-        image.extraFilename = outputFilename + '.vrt'
+        image.extraFilename = outputFilename + ".vrt"
         image.setWidth(mask_radarcoord.shape[1])
         image.setLength(mask_radarcoord.shape[0])
         image.renderHdr()
@@ -337,22 +302,25 @@ def mask_geo2radar(maskFilename: Union[str, Path],
     return mask_radarcoord
 
 
-def mask_interferogram(ifgFilename: Union[str, Path],
-                       maskArray: NDArray,
-                       outFilename: Union[str, Path] = None) -> None:
-    
-    '''
+def mask_interferogram(
+    ifgFilename: Union[str, Path],
+    maskArray: NDArray,
+    outFilename: Union[str, Path] = None,
+) -> None:
+    """
     This routine uses mask np.array to mask wrapped interferogram
     ifgFilename : str
             path to georeferenced mask raster (must have vrt extension)
     maskArray : np.array
-            mask 2d array (1: mask values, 0; no-mask values))
+            mask 2d array  in rdr coordinates
+            (1: mask values, 0; no-mask values))
     outFilename : str
-            path where to save masked interferogram (default: None = overwrite existing)
-    '''
+            path where to save masked interferogram
+            (default: None = overwrite existing)
+    """
 
     # Read interferogram
-    int_ds = gdal.Open(ifgFilename + '.vrt')
+    int_ds = gdal.Open(ifgFilename + ".vrt")
     int_array = int_ds.ReadAsArray()
 
     # Mask interferogram
@@ -361,20 +329,20 @@ def mask_interferogram(ifgFilename: Union[str, Path],
 
     # Write masked interferogram
     if outFilename:
-        driver = gdal.GetDriverByName('ISCE')
-        outdata = driver.CreateCopy(ifgFilename + '_msk', int_ds)
+        driver = gdal.GetDriverByName("ISCE")
+        outdata = driver.CreateCopy(ifgFilename + "_msk", int_ds)
         outdata.GetRasterBand(1).WriteArray(int_array)
         outdata.FlushCache()  # saves to disk!!
         outdata = None
 
         # create isce aux files
         image = isceobj.createIntImage()
-        image.setDataType('cfloat')
-        image.setFilename(outFilename + '_msk')
-        image.extraFilename = outFilename + '_msk' + '.vrt'
+        image.setDataType("cfloat")
+        image.setFilename(outFilename + "_msk")
+        image.extraFilename = outFilename + "_msk" + ".vrt"
         image.setWidth(int_ds.RasterXSize)
         image.setLength(int_ds.RasterYSize)
-        image.setAccessMode('READ')
+        image.setAccessMode("READ")
         image.renderHdr()
         int_ds = None
     else:

--- a/isce2_topsapp/iono_proc.py
+++ b/isce2_topsapp/iono_proc.py
@@ -2,13 +2,14 @@ import os
 import site
 import subprocess
 
-import isce
-import isceobj 
-import numpy as np
-
 from pathlib import Path
 from typing import Union
+
 from numpy.typing import NDArray
+
+import isce
+import isceobj
+import numpy as np
 
 from jinja2 import Template
 from tqdm import tqdm
@@ -62,7 +63,7 @@ IONO_STEPS = ['subband',
               'rawion',
               'grd2ion',
               'filt_gaussian',
-              #only do the following steps when considering burst properties
+               # only do the following steps when considering burst properties
               'ionosphere_shift', 
               'ion2grd',
               'esd']
@@ -70,6 +71,7 @@ IONO_STEPS = ['subband',
 TEMPLATE_DIR = Path(__file__).parent/'templates'
 
 GEOCODE_LIST_BASE = ['merged/topophase.ion']
+
 
 def iono_processing(*,
                     reference_slc_zips: list,
@@ -83,7 +85,7 @@ def iono_processing(*,
                     swaths: list = None,
                     do_esd: bool = False,
                     esd_coherence_threshold: float = .7,
-                    mask_filename : str = None):
+                    mask_filename: str = None):
         
         swaths = swaths or [1, 2, 3]
         # for [ymin, ymax, xmin, xmax]

--- a/isce2_topsapp/iono_proc.py
+++ b/isce2_topsapp/iono_proc.py
@@ -4,14 +4,14 @@ import subprocess
 from pathlib import Path
 from typing import Union
 
+import numpy as np
 from isce.components import isceobj
 from isce.components.isceobj.TopsProc.runMergeBursts import (
     interpolateDifferentNumberOfLooks,
 )
-import numpy as np
 from jinja2 import Template
-from tqdm import tqdm
 from numpy.typing import NDArray
+from tqdm import tqdm
 from osgeo import gdal
 
 # List of parameters for ionospheric correction:

--- a/isce2_topsapp/iono_proc.py
+++ b/isce2_topsapp/iono_proc.py
@@ -187,8 +187,8 @@ def mask_iono_ifg_bursts(tops_dir: Path,
     with tqdm(total=len(geom_files)) as pbar:
         for lat in geom_files:
             pbar.set_description(
-                f'Geo2radar mask {get_swath(str(lat))}'
-                f'/ {get_burst(str(lat))}'
+                f"Geo2radar mask {get_swath(str(lat))}"
+                f" /{get_burst(str(lat))}"
             )
 
             lon = str(lat).replace("lat", "lon")
@@ -325,6 +325,10 @@ def mask_interferogram(
     # Read interferogram
     int_ds = gdal.Open(ifgFilename + ".vrt")
     int_array = int_ds.ReadAsArray()
+
+    if not np.array_equal(int_array.shape, maskArray.shape):
+        raise ValueError('Mask array dimensions do not match'
+                         ' the interferogram dimensions!')
 
     # Mask interferogram
     int_array.imag[np.bool_(maskArray)] = 0

--- a/isce2_topsapp/iono_proc.py
+++ b/isce2_topsapp/iono_proc.py
@@ -146,13 +146,13 @@ def iono_processing(*,
 
         if mask_filename:
             # Project mask to burst image coordinate space
-            dir = Path('.').absolute()
+            workdir = Path('.').absolute()
 
             get_swath = lambda x: x.split('/')[-2]
             get_burst = lambda x: x.split('/')[-1].split('_')[-1].split('.')[0]
 
             # Get all geometry files
-            geom_files = list(dir.glob('geom_reference/IW*/lat*.rdr'))
+            geom_files = list(workdir.glob('geom_reference/IW*/lat*.rdr'))
 
             # NOTE: THis can be easily parallized, skipped for now
             with tqdm(total=len(geom_files)) as pbar:
@@ -165,7 +165,7 @@ def iono_processing(*,
                     swath = get_swath(str(lat))
                     burst = get_burst(str(lat))
                     # Get output dir and file
-                    output_dir = dir / f'mask/{swath}'
+                    output_dir = workdir / f'mask/{swath}'
                     output_dir.mkdir(parents=True, exist_ok=True)
                     output_filename = output_dir / f'msk_{burst}.rdr'
                     # Projct mask to radar coordinate space
@@ -176,8 +176,8 @@ def iono_processing(*,
                     pbar.update()
 
             # Get lower and upper band full-resolution interferograms 
-            lower_band_ifgs = dir.glob('ion/lower/fine_interferogram/IW*/burst*.int')
-            upper_band_ifgs = dir.glob('ion/upper/fine_interferogram/IW*/burst*.int')
+            lower_band_ifgs = workdir.glob('ion/lower/fine_interferogram/IW*/burst*.int')
+            upper_band_ifgs = workdir.glob('ion/upper/fine_interferogram/IW*/burst*.int')
 
             # Lower band interferograms
             with tqdm(total=len(lower_band_ifgs + upper_band_ifgs)) as pbar:
@@ -189,7 +189,7 @@ def iono_processing(*,
                     swath = get_swath(str(ifg))
                     burst = get_burst(str(ifg))
                     # Get mask
-                    mask_file = dir / f'mask/{swath}/msk_{burst}.rdr.vrt'
+                    mask_file = workdir / f'mask/{swath}/msk_{burst}.rdr.vrt'
                     mask_ds = gdal.Open(str(mask_file), gdal.GA_ReadOnly)
                     # Mask
                     mask_interferogram(str(ifg), mask_ds.ReadAsArray())

--- a/isce2_topsapp/iono_proc.py
+++ b/isce2_topsapp/iono_proc.py
@@ -48,6 +48,8 @@ def iono_processing(
     isce_app_path = Path(f"{site.getsitepackages()[0]}" "/isce/applications/")
     os.environ["PATH"] += ":" + str(isce_app_path)
 
+    tops_app_cmd = f"{isce_app_path}/topsApp.py"
+
     # Define topsApp input xml parameters
     ion_kwargs = {
         "orbit_directory": orbit_directory,
@@ -84,8 +86,6 @@ def iono_processing(
 
     with open("ionoApp.xml", "w") as file:
         file.write(iono_xml)
-
-    tops_app_cmd = f"{isce_app_path}/topsApp.py"
 
     step_cmd = f"{tops_app_cmd} ionoApp.xml --dostep=ion"
     result = subprocess.run(step_cmd, shell=True)
@@ -187,8 +187,8 @@ def mask_iono_ifg_bursts(tops_dir: Path,
     with tqdm(total=len(geom_files)) as pbar:
         for lat in geom_files:
             pbar.set_description(
-                f"Geo2radar mask {get_swath(str(lat))}\
-                                        /{get_burst(str(lat))}"
+                f'Geo2radar mask {get_swath(str(lat))}'
+                f'/ {get_burst(str(lat))}'
             )
 
             lon = str(lat).replace("lat", "lon")
@@ -205,17 +205,16 @@ def mask_iono_ifg_bursts(tops_dir: Path,
 
     # Get lower and upper band full-resolution interferograms
     iono_location = "ion/{band}/fine_interferogram/IW*/burst*.int"
-    lower_band_ifgs = tops_dir.glob(iono_location.format(band="lower"))
-    upper_band_ifgs = tops_dir.glob(iono_location.format(band="upper"))
+    lower_band_ifgs = list(tops_dir.glob(iono_location.format(band="lower")))
+    upper_band_ifgs = list(tops_dir.glob(iono_location.format(band="upper")))
 
     # Lower band interferograms
     with tqdm(total=len(lower_band_ifgs + upper_band_ifgs)) as pbar:
         for ifg in lower_band_ifgs + upper_band_ifgs:
             band = str(ifg).split("/")[-4]
             pbar.set_description(
-                f"Masking {band}-iono interferograms \
-                                     {get_swath(str(ifg))}\
-                                     /{get_burst(str(ifg))}"
+                f"Masking {band}-iono interferograms"
+                f" {get_swath(str(ifg))}/{get_burst(str(ifg))}"
             )
 
             # Get the swath and burst number
@@ -246,12 +245,12 @@ def raster_geo2radar(
             path to georeferenced raster (must have vrt extension)
     latFilename : str
             path to radar lat.rdr file
-            (bursts: geom_reference/IW{1,2,3}/lat_burst.rdr
-                     merged: merged/lat.rdr.full.vrt)
+            bursts: geom_reference/IW{1,2,3}/lat_burst.rdr
+                    merged: merged/lat.rdr.full.vrt
     lonFilename : str
             path to radar lon.rdr file
-            (bursts: geom_reference/IW{1,2,3}/lon_burst.rdr
-                     merged: merged/lon.rdr.full.vrt)
+            bursts: geom_reference/IW{1,2,3}/lon_burst.rdr
+                    merged: merged/lon.rdr.full.vrt
     outputFilename : str
             path to save output file
     saveFlag : bool
@@ -317,10 +316,10 @@ def mask_interferogram(
             path to georeferenced mask raster (must have vrt extension)
     maskArray : np.array
             mask 2d array  in rdr coordinates
-            (1: mask values, 0; no-mask values))
+            1: mask values, 0; no-mask values
     outFilename : str
             path where to save masked interferogram
-            (default: None = overwrite existing)
+            default: None = overwrite existing
     """
 
     # Read interferogram

--- a/isce2_topsapp/iono_proc.py
+++ b/isce2_topsapp/iono_proc.py
@@ -11,8 +11,9 @@ from isce.components.isceobj.TopsProc.runMergeBursts import (
 )
 from jinja2 import Template
 from numpy.typing import NDArray
-from tqdm import tqdm
 from osgeo import gdal
+from tqdm import tqdm
+
 
 # List of parameters for ionospheric correction:
 # https://github.com/isce-framework/isce2/blob/8af43d2b9f291e2370e9112a3ead1449d0f2a386/examples/input_files/topsApp.xml#L182

--- a/isce2_topsapp/iono_proc.py
+++ b/isce2_topsapp/iono_proc.py
@@ -1,18 +1,15 @@
 import os
-
 import site
 import subprocess
-
 from pathlib import Path
 from typing import Union
-
-import numpy as np
-from jinja2 import Template
 
 from isce.components import isceobj
 from isce.components.isceobj.TopsProc.runMergeBursts import (
     interpolateDifferentNumberOfLooks,
 )
+import numpy as np
+from jinja2 import Template
 from tqdm import tqdm
 from numpy.typing import NDArray
 from osgeo import gdal

--- a/isce2_topsapp/iono_proc.py
+++ b/isce2_topsapp/iono_proc.py
@@ -1,17 +1,16 @@
 import os
 import site
-import subprocess
 
+import subprocess
 from pathlib import Path
 from typing import Union
 
-from numpy.typing import NDArray
-
-from isce.components import isceobj
 import numpy as np
-
 from jinja2 import Template
 from tqdm import tqdm
+
+from isce.components import isceobj
+from numpy.typing import NDArray
 
 try:
     from osgeo import gdal
@@ -62,8 +61,9 @@ IONO_STEPS = ['subband',
               'rawion',
               'grd2ion',
               'filt_gaussian',
-               # only do the following steps when considering burst properties
-              'ionosphere_shift', 
+               # only do the following steps 
+               # when considering burst properties
+              'ionosphere_shift',
               'ion2grd',
               'esd']
 
@@ -95,29 +95,29 @@ def iono_processing(*,
     os.environ['PATH'] += (':' + str(isce_application_path))
 
     # Define topsApp input xml parameters
-    iono_kwargs = {'orbit_directory':orbit_directory,
-            'output_reference_directory':'reference',
-            'output_secondary_directory':'secondary',
-            'ref_zip_file':reference_slc_zips,
-            'sec_zip_file':secondary_slc_zips,
-            'region_of_interest':extent_isce,
-            'demFilename':dem_for_proc,
-            'geocodeDemFilename':dem_for_geoc,
-            'filter_strength':.5,
-            'do_unwrap':True,
-            'use_virtual_files':True,
-            'do_esd':do_esd,
-            'esd_coherence_threshold':esd_coherence_threshold,
-            # IONO PARAMETERS
-            'estimate_ionosphere_delay':True,
-            'iono_burstProperties':False,
-            'iono_polyFit':True,
-            'iono_correctAzimuthshift':1,
-            'azimuth_looks':azimuth_looks,
-            'range_looks':range_looks,
-            'swaths':swaths,
-            'geocode_list':GEOCODE_LIST_BASE
-    }
+    iono_kwargs = {'orbit_directory': orbit_directory,
+                   'output_reference_directory': 'reference',
+                   'output_secondary_directory': 'secondary',
+                   'ref_zip_file': reference_slc_zips,
+                   'sec_zip_file': secondary_slc_zips,
+                   'region_of_interest': extent_isce,
+                   'demFilename': dem_for_proc,
+                   'geocodeDemFilename': dem_for_geoc,
+                   'filter_strength': .5,
+                    'do_unwrap': True,
+                    'use_virtual_files': True,
+                    'do_esd': do_esd,
+                    'esd_coherence_threshold': esd_coherence_threshold,
+                    # IONO PARAMETERS
+                    'estimate_ionosphere_delay': True,
+                    'iono_burstProperties': False,
+                    'iono_polyFit': True,
+                    'iono_correctAzimuthshift': 1,
+                    'azimuth_looks': azimuth_looks,
+                    'range_looks': range_looks,
+                    'swaths': swaths,
+                    'geocode_list': GEOCODE_LIST_BASE
+                     }
 
     with open(TEMPLATE_DIR/'topsapp_iono_template.xml', 'r') as file:
         template = Template(file.read())
@@ -170,7 +170,7 @@ def iono_processing(*,
                 mask = mask_geo2radar(mask_filename,
                                       str(lat), lon,
                                       str(output_filename), saveFlag=True)
-                mask = None # del mask array
+                mask = None  # del mask array
                 pbar.update()
 
         # Get lower and upper band full-resolution interferograms
@@ -191,7 +191,7 @@ def iono_processing(*,
                 mask_ds = gdal.Open(str(mask_file), gdal.GA_ReadOnly)
                 # Mask
                 mask_interferogram(str(ifg), mask_ds.ReadAsArray())
-                mask_ds = None #close
+                mask_ds = None  #close
                 pbar.update()
 
     # Step-3 Compute ionospheric correction
@@ -227,10 +227,10 @@ def merge_bursts(range_looks: int = 19,
                  ion_rangeLooks: int = 200,
                  ion_azimuthLooks: int = 50,
                  considerBursts: bool = False,
-                 mergedir : Union[str, Path] = './merged') -> None:
+                 mergedir: Union[str, Path] = './merged') -> None:
     from isce.components.isceobj.TopsProc.runMergeBursts import interpolateDifferentNumberOfLooks
 
-    mergedIfgname='topophase.flat'
+    mergedIfgname = 'topophase.flat'
     mergedIonname = 'topophase.ion'
     #########################################
 
@@ -244,7 +244,6 @@ def merge_bursts(range_looks: int = 19,
         multilook(os.path.join(mergedir, mergedIonname+suffix),
                       outname = os.path.join(mergedir, mergedIonname),
                       alks = self.numberAzimuthLooks, rlks=self.numberRangeLooks)
-        
         '''
     else:
         ionFilt = 'ion/ion_cal/filt.ion'
@@ -268,19 +267,19 @@ def merge_bursts(range_looks: int = 19,
         image.extraFilename = ionFiltOut + '.vrt'
         image.setWidth(img.width)
         image.setLength(img.length)
-        #image.setAccessMode('read')
-        #image.createImage()
+        # image.setAccessMode('read')
+        # image.createImage()
         image.renderHdr()
-        #image.finalizeImage()
+        # image.finalizeImage()
 
 
 ####################### UTILITIES FOR MASKING ###############################
 
-def mask_geo2radar(maskFilename : Union[str, Path],
-                   latFilename : Union[str, Path],
-                   lonFilename : Union[str, Path],
-                   outputFilename : Union[str, Path],
-                   saveFlag: bool=False)-> NDArray:
+def mask_geo2radar(maskFilename: Union[str, Path],
+                   latFilename: Union[str, Path],
+                   lonFilename: Union[str, Path],
+                   outputFilename: Union[str, Path],
+                   saveFlag: bool = False) -> NDArray:
     '''
     This routine translates mask raster from geographical to radar(image) coordinate space
 
@@ -309,17 +308,16 @@ def mask_geo2radar(maskFilename : Union[str, Path],
     lats = lat_ds.ReadAsArray()
 
     # Translate mask geo corrdinate to radar
-    lineIndex = np.int32((lats  - mask_ds.GetGeoTransform()[3]) /  mask_ds.GetGeoTransform()[5] + 0.5)
-    sampleIndex = np.int32((lons  - mask_ds.GetGeoTransform()[0]) /  mask_ds.GetGeoTransform()[1] + 0.5)
+    lineIndex = np.int32((lats - mask_ds.GetGeoTransform()[3]) / mask_ds.GetGeoTransform()[5] + 0.5)
+    sampleIndex = np.int32((lons - mask_ds.GetGeoTransform()[0]) / mask_ds.GetGeoTransform()[1] + 0.5)
     inboundIndex = np.logical_and(
-                np.logical_and(lineIndex>=0, lineIndex<=mask_ds.RasterYSize-1),
-                np.logical_and(sampleIndex>=0, sampleIndex<=mask_ds.RasterXSize-1)
+                np.logical_and(lineIndex >= 0, lineIndex <= mask_ds.RasterYSize-1),
+                np.logical_and(sampleIndex >= 0, sampleIndex <= mask_ds.RasterXSize-1)
                 )
     # Convert
     mask_radarcoord = np.empty(lats.shape)
     mask_radarcoord[inboundIndex] = mask_ds.ReadAsArray()[lineIndex[inboundIndex],
                                                             sampleIndex[inboundIndex]]
-
     # close gdal instances
     mask_ds = None
     lon_ds = None
@@ -338,9 +336,11 @@ def mask_geo2radar(maskFilename : Union[str, Path],
 
     return mask_radarcoord
 
-def mask_interferogram(ifgFilename : Union[str, Path],
-                       maskArray : NDArray,
-                       outFilename: Union[str, Path]=None)-> None:
+
+def mask_interferogram(ifgFilename: Union[str, Path],
+                       maskArray: NDArray,
+                       outFilename: Union[str, Path] = None) -> None:
+    
     '''
     This routine uses mask np.array to mask wrapped interferogram
     ifgFilename : str
@@ -361,10 +361,10 @@ def mask_interferogram(ifgFilename : Union[str, Path],
 
     # Write masked interferogram
     if outFilename:
-        driver= gdal.GetDriverByName('ISCE')
+        driver = gdal.GetDriverByName('ISCE')
         outdata = driver.CreateCopy(ifgFilename + '_msk', int_ds)
         outdata.GetRasterBand(1).WriteArray(int_array)
-        outdata.FlushCache() ##saves to disk!!
+        outdata.FlushCache()  # saves to disk!!
         outdata = None
 
         # create isce aux files
@@ -376,7 +376,7 @@ def mask_interferogram(ifgFilename : Union[str, Path],
         image.setLength(int_ds.RasterYSize)
         image.setAccessMode('READ')
         image.renderHdr()
-        int_ds=None
+        int_ds = None
     else:
         # Overwrite existing interferogram
         int_ds = None

--- a/isce2_topsapp/iono_proc.py
+++ b/isce2_topsapp/iono_proc.py
@@ -1,0 +1,327 @@
+import os
+import site
+import subprocess
+
+import isce
+import isceobj 
+import numpy as np
+
+from pathlib import Path
+from typing import Union
+from numpy.typing import NDArray
+
+from jinja2 import Template
+from tqdm import tqdm
+
+try:
+    from osgeo import gdal
+except:
+    raise ModuleNotFoundError('Python module gdal missing!')
+
+'''
+List of parameters for ionospheric correction:
+______________________________________________________________________
+property name="do ionosphere correction">False</property>
+<property name="apply ionosphere correction">False</property>
+<property name="consider burst properties in ionosphere computation">False</property>
+#choose from: ['subband', 'rawion', 'grd2ion', 'filt_gaussian', 'ionosphere_shift', 'ion2grd', 'esd']
+<property name="start ionosphere step">subband</property>
+<property name="end ionosphere step">esd</property>
+
+<property name="height of ionosphere layer in km">200.0</property>
+<property name="apply polynomial fit before filtering ionosphere phase">True</property>
+<property name="maximum window size for filtering ionosphere phase">200</property>
+<property name="minimum window size for filtering ionosphere phase">100</property>
+<property name="maximum window size for filtering ionosphere azimuth shift">150</property>
+<property name="minimum window size for filtering ionosphere azimuth shift">75</property>
+#0: no correction
+#1: use mean value of a burst
+#2: use full burst
+<property name="correct phase error caused by ionosphere azimuth shift">1</property>
+
+seperated islands or areas usually affect ionosphere estimation and it's better to mask them
+#out. check ion/ion_cal/raw_no_projection.ion for areas to be masked out.
+#The parameter is a 2-D list. Each element in the 2-D list is a four-element list: [firstLine,
+#lastLine, firstColumn, lastColumn], with line/column numbers starting with 1. If one of the
+#four elements is specified as -1, the program will use firstLine/lastLine/firstColumn/
+#lastColumn instead. For exmple, if you want to mask the following two areas out, you can
+#specify a 2-D list like:
+#[[100, 200, 100, 200],[1000, 1200, 500, 600]]
+<property name="areas masked out in ionospheric phase estimation">None</property>
+
+#better NOT try changing the following two parameters, since they are related
+#to the filtering parameters above
+<property name="total number of azimuth looks in the ionosphere processing">50</property>
+<property name="total number of range looks in the ionosphere processing">200</property>
+#the above numbers should be integer multiples of the below numbers
+<property name="number of azimuth looks at first stage for ionosphere phase unwrapping">10</property>
+<property name="number of range looks at first stage for ionosphere phase unwrapping">40</property>
+'''
+
+IONO_STEPS = ['subband',
+              'rawion',
+              'grd2ion',
+              'filt_gaussian',
+              #only do the following steps when considering burst properties
+              'ionosphere_shift', 
+              'ion2grd',
+              'esd']
+
+TEMPLATE_DIR = Path(__file__).parent/'templates'
+
+GEOCODE_LIST_BASE = ['merged/topophase.ion']
+
+def iono_processing(*,
+                    reference_slc_zips: list,
+                    secondary_slc_zips: list,
+                    orbit_directory: str,
+                    extent: list,
+                    dem_for_proc: str,
+                    dem_for_geoc: str,
+                    azimuth_looks: int = 7,
+                    range_looks: int = 19,
+                    swaths: list = None,
+                    do_esd: bool = False,
+                    esd_coherence_threshold: float = .7,
+                    mask_filename : str = None):
+        
+        swaths = swaths or [1, 2, 3]
+        # for [ymin, ymax, xmin, xmax]
+        extent_isce = [extent[k] for k in [1, 3, 0, 2]]
+
+        # Update PATH with ISCE2 applications
+        isce_application_path = Path(f'{site.getsitepackages()[0]}'
+                                     '/isce/applications/')
+        os.environ['PATH'] += (':' + str(isce_application_path))
+
+        # Define topsApp input xml parameters
+        iono_kwargs = {'orbit_directory':orbit_directory,
+               'output_reference_directory':'reference',
+               'output_secondary_directory':'secondary',
+               'ref_zip_file':reference_slc_zips,
+               'sec_zip_file':secondary_slc_zips,
+               'region_of_interest':extent_isce,
+               'demFilename':dem_for_proc,
+               'geocodeDemFilename':dem_for_geoc,
+               'filter_strength':.5,
+               'do_unwrap':True,
+               'use_virtual_files':True,
+               'do_esd':do_esd,
+               'esd_coherence_threshold':esd_coherence_threshold,
+               # IONO PARAMETERS
+               'estimate_ionosphere_delay':True,
+               'iono_burstProperties':False,
+               'iono_polyFit':True,
+               'iono_correctAzimuthshift':1,
+               'azimuth_looks':azimuth_looks,
+               'range_looks':range_looks,
+               'swaths':swaths,
+               'geocode_list':GEOCODE_LIST_BASE
+        }
+
+        with open(TEMPLATE_DIR/'topsapp_iono_template.xml', 'r') as file:
+            template = Template(file.read())
+
+        # Step-1 Run ionospheric correction step subband
+        ionoApp_xml = template.render(**iono_kwargs,
+                                      iono_startStep=IONO_STEPS[0],
+                                      iono_stopStep=IONO_STEPS[0])
+        
+        with open('ionoApp.xml', "w") as file:
+            file.write(ionoApp_xml)
+        
+        tops_app_cmd = f'{isce_application_path}/topsApp.py'
+
+        step_cmd = f'{tops_app_cmd} ionoApp.xml --dostep=ion'
+        result = subprocess.run(step_cmd,
+                                shell=True)
+        if result.returncode != 0:
+            raise ValueError(f'TopsApp failed at step: ion-subband')
+        
+        # Step-2 Mask upper and lower band burst wrapped interferograms
+        # path to burst ifgs: ion/lower|upper/fine_interferogram/IW{1,2,3}/burst_{##}.int
+        # path to burst geometry: geom_reference/IW{1,2,3}/lat|lon_{##}.rdr
+
+        if mask_filename:
+            # Project mask to burst image coordinate space
+            dir = Path('.').absolute()
+
+            get_swath = lambda x: x.split('/')[-2]
+            get_burst = lambda x: x.split('/')[-1].split('_')[-1].split('.')[0]
+
+            # Get all geometry files
+            geom_files = list(dir.glob('geom_reference/IW*/lat*.rdr'))
+
+            # NOTE: THis can be easily parallized, skipped for now
+            with tqdm(total=len(geom_files)) as pbar:
+                for lat in geom_files:
+                    pbar.set_description(f'Geo2radar mask {get_swath(str(lat))}\
+                                         /{get_burst(str(lat))}')
+
+                    lon = str(lat).replace('lat', 'lon')
+                    # Get the swath and burst number 
+                    swath = get_swath(str(lat))
+                    burst = get_burst(str(lat))
+                    # Get output dir and file
+                    output_dir = dir / f'mask/{swath}'
+                    output_dir.mkdir(parents=True, exist_ok=True)
+                    output_filename = output_dir / f'msk_{burst}.rdr'
+                    # Projct mask to radar coordinate space
+                    mask = mask_geo2radar(mask_filename, 
+                                          str(lat), lon,  
+                                          str(output_filename), saveFlag=True)
+                    mask = None # del mask array
+                    pbar.update()
+
+            # Get lower and upper band full-resolution interferograms 
+            lower_band_ifgs = dir.glob('ion/lower/fine_interferogram/IW*/burst*.int')
+            upper_band_ifgs = dir.glob('ion/upper/fine_interferogram/IW*/burst*.int')
+
+            # Lower band interferograms
+            with tqdm(total=len(lower_band_ifgs + upper_band_ifgs)) as pbar:
+                for ifg in lower_band_ifgs + upper_band_ifgs:
+                    band = str(ifg).split('/')[-4]
+                    pbar.set_description(f'Masking {band}-iono interferograms {get_swath(str(ifg))}/\
+                                        {get_burst(str(ifg))}')
+                    # Get the swath and burst number 
+                    swath = get_swath(str(ifg))
+                    burst = get_burst(str(ifg))
+                    # Get mask
+                    mask_file = dir / f'mask/{swath}/msk_{burst}.rdr.vrt'
+                    mask_ds = gdal.Open(str(mask_file), gdal.GA_ReadOnly)
+                    # Mask
+                    mask_interferogram(str(ifg), mask_ds.ReadAsArray())
+                    mask_ds = None #close
+                    pbar.update()
+
+        # Step-3 Compute ionospheric correction
+        ionoApp_xml = template.render(**iono_kwargs,
+                                      iono_startStep=IONO_STEPS[1],
+                                      iono_stopStep=IONO_STEPS[-1])
+        
+        with open('ionoApp.xml', "w") as file:
+            file.write(ionoApp_xml)
+        
+        tops_app_cmd = f'{isce_application_path}/topsApp.py'
+
+        step_cmd = f'{tops_app_cmd} ionoApp.xml --dostep=ion'
+        result = subprocess.run(step_cmd,
+                                shell=True)
+        if result.returncode != 0:
+            raise ValueError(f'TopsApp failed at step: ion-rawion2esd')
+        
+        # Step-4 Geocode ionospheric correction outputs
+        step_cmd = f'{tops_app_cmd} ionoApp.xml --dostep=geocode'
+        result = subprocess.run(step_cmd,
+                                shell=True)
+        if result.returncode != 0:
+            raise ValueError(f'TopsApp failed at step: geocode (ion)')
+
+
+####################### UTILITIES FOR MASKING ###############################
+
+def mask_geo2radar(maskFilename : Union[str, Path], 
+                   latFilename : Union[str, Path], 
+                   lonFilename : Union[str, Path], 
+                   outputFilename : Union[str, Path], 
+                   saveFlag: bool=False)-> NDArray:
+    '''
+    This routine translates mask raster from geographical to radar(image) coordinate space
+
+    maskFilename : str
+            path to georeferenced mask raster (must have vrt extension)
+    latFilename : str
+            path to radar lat.rdr file (bursts: geom_reference/IW{1,2,3}/lat_burst.rdr
+                                        merged: merged/lat.rdr.full.vrt)
+    lonFilename : str
+            path to radar lon.rdr file (bursts: geom_reference/IW{1,2,3}/lon_burst.rdr
+                                        merged: merged/lon.rdr.full.vrt)
+    outputFilename : str
+            path to save mask output file
+    saveFlag : bool
+            flag to locally save mask in radar coordinates
+    '''
+
+    # Open mask file
+    mask_ds = gdal.Open(maskFilename + '.vrt')
+    # Open lon and lat file
+    lon_ds = gdal.Open(lonFilename + '.vrt')
+    lat_ds = gdal.Open(latFilename + '.vrt')  
+
+    # Get lon and lat arrays
+    lons = lon_ds.ReadAsArray()
+    lats = lat_ds.ReadAsArray()
+
+    # Translate mask geo corrdinate to radar
+    lineIndex = np.int32((lats  - mask_ds.GetGeoTransform()[3]) /  mask_ds.GetGeoTransform()[5] + 0.5)
+    sampleIndex = np.int32((lons  - mask_ds.GetGeoTransform()[0]) /  mask_ds.GetGeoTransform()[1] + 0.5)
+    inboundIndex = np.logical_and(
+                np.logical_and(lineIndex>=0, lineIndex<=mask_ds.RasterYSize-1),
+                np.logical_and(sampleIndex>=0, sampleIndex<=mask_ds.RasterXSize-1)
+                )
+    # Convert 
+    mask_radarcoord = np.empty(lats.shape)
+    mask_radarcoord[inboundIndex] = mask_ds.ReadAsArray()[lineIndex[inboundIndex], 
+                                                            sampleIndex[inboundIndex]]
+
+    # close gdal instances
+    mask_ds = None
+    lon_ds = None
+    lat_ds = None
+
+    # Save
+    if saveFlag:
+        mask_radarcoord.astype(np.int8).tofile(outputFilename)
+        image = isceobj.createImage()
+        image.setDataType('BYTE')
+        image.setFilename(outputFilename)
+        image.extraFilename = outputFilename + '.vrt'
+        image.setWidth(mask_radarcoord.shape[1])
+        image.setLength(mask_radarcoord.shape[0])
+        image.renderHdr()
+
+    return mask_radarcoord
+
+def mask_interferogram(ifgFilename : Union[str, Path], 
+                       maskArray : NDArray, 
+                       outFilename: Union[str, Path]=None)-> None:
+    '''
+    This routine uses mask np.array to mask wrapped interferogram
+    ifgFilename : str
+            path to georeferenced mask raster (must have vrt extension)
+    maskArray : np.array
+            mask 2d array (1: mask values, 0; no-mask values))
+    outFilename : str
+            path where to save masked interferogram (default: None = overwrite existing)
+    '''
+
+    # Read interferogram
+    int_ds = gdal.Open(ifgFilename + '.vrt')
+    int_array = int_ds.ReadAsArray()
+
+    # Mask interferogram
+    int_array.imag[np.bool_(maskArray)] = 0
+    int_array.real[np.bool_(maskArray)] = 0
+
+    # Write masked interferogram
+    if outFilename:
+        driver= gdal.GetDriverByName('ISCE')
+        outdata = driver.CreateCopy(ifgFilename + '_msk', int_ds)
+        outdata.GetRasterBand(1).WriteArray(int_array)
+        outdata.FlushCache() ##saves to disk!!
+        outdata = None
+
+        # create isce aux files
+        image = isceobj.createIntImage()
+        image.setDataType('cfloat')
+        image.setFilename(outFilename + '_msk')
+        image.extraFilename = outFilename + '_msk' + '.vrt'
+        image.setWidth(int_ds.RasterXSize)
+        image.setLength(int_ds.RasterYSize)
+        image.setAccessMode('READ')
+        image.renderHdr()
+        int_ds=None
+    else:
+        # Overwrite existing interferogram
+        int_ds = None
+        int_array.astype(np.complex64).tofile(ifgFilename)

--- a/isce2_topsapp/iono_proc.py
+++ b/isce2_topsapp/iono_proc.py
@@ -257,7 +257,10 @@ def merge_bursts(range_looks: int = 19,
         img.load(os.path.join(mergedir, mergedIfgname+'.xml'))
 
         #interpolate original
-        ionFiltImageOut = interpolateDifferentNumberOfLooks(ionFiltImage, img.length, img.width, range_looks, azimuth_looks, ion_rangeLooks, ion_azimuthLooks)
+        ionFiltImageOut = interpolateDifferentNumberOfLooks(ionFiltImage, 
+                                                            img.length, img.width, 
+                                                            range_looks, azimuth_looks, 
+                                                            ion_rangeLooks, ion_azimuthLooks)
         ionFiltOut = os.path.join(mergedir, mergedIonname)
         ionFiltImageOut.astype(np.float32).tofile(ionFiltOut)
 

--- a/isce2_topsapp/iono_proc.py
+++ b/isce2_topsapp/iono_proc.py
@@ -239,11 +239,11 @@ def raster_geo2radar(
     saveFlag: bool = True,
 ) -> NDArray:
     """
-    This routine translates mask raster
+    This routine translates raster
     from geographical to radar(image) coordinate space
 
-    maskFilename : str
-            path to georeferenced mask raster (must have vrt extension)
+    rasterFilename : str
+            path to georeferenced raster (must have vrt extension)
     latFilename : str
             path to radar lat.rdr file
             (bursts: geom_reference/IW{1,2,3}/lat_burst.rdr
@@ -253,10 +253,10 @@ def raster_geo2radar(
             (bursts: geom_reference/IW{1,2,3}/lon_burst.rdr
                      merged: merged/lon.rdr.full.vrt)
     outputFilename : str
-            path to save mask output file
+            path to save output file
     saveFlag : bool
-            flag to locally save mask in radar coordinates
-            if False, function returns rdr mask array
+            flag to locally save output in radar coordinates
+            if False, function returns rdr numpy array
     """
 
     # Open mask file
@@ -312,7 +312,7 @@ def mask_interferogram(
     outFilename: Union[str, Path] = None,
 ) -> None:
     """
-    This routine uses mask np.array to mask wrapped interferogram
+    This routine uses mask np.array in rdr to mask wrapped interferogram
     ifgFilename : str
             path to georeferenced mask raster (must have vrt extension)
     maskArray : np.array

--- a/isce2_topsapp/localize_mask.py
+++ b/isce2_topsapp/localize_mask.py
@@ -2,31 +2,34 @@ from pathlib import Path
 
 import numpy as np
 from shapely.geometry import box
+from isce.components.isceobj.Alos2Proc.runDownloadDem import download_wbd
 
 
-def download_water_mask(extent: list,
-                        water_name: str = 'SWDB',
-                        buffer: float = .1) -> dict:
-    
-    output_dir = Path('.').absolute()
+def download_water_mask(
+    extent: list, water_name: str = "SWDB", buffer: float = 0.1
+) -> dict:
+    output_dir = Path(".").absolute()
 
     extent_geo = box(*extent)
     extent_buffered = list(extent_geo.buffer(buffer).bounds)
-    extent_buffered = [np.floor(extent_buffered[0]), np.floor(extent_buffered[1]),
-                       np.ceil(extent_buffered[2]), np.ceil(extent_buffered[3])]
-    
-    if water_name == 'SWDB':
-        import isce
-        from isceobj.Alos2Proc.runDownloadDem import download_wbd
-        #Download SRTM-SWDB water mask
-        mask_filename = download_wbd(extent_buffered[1],
-                                     extent_buffered[3], 
-                                     extent_buffered[0], 
-                                     extent_buffered[2])
-        
-    elif water_name == 'GSHHS':
-        #from water_mask import get_water_mask_raster
-        # TO BE ADDED
-        print('TODO as another option')
+    extent_buffered = [
+        np.floor(extent_buffered[0]),
+        np.floor(extent_buffered[1]),
+        np.ceil(extent_buffered[2]),
+        np.ceil(extent_buffered[3]),
+    ]
 
-    return {'water_mask': str(output_dir / mask_filename)}
+    if water_name == "SWDB":
+        # Download SRTM-SWDB water mask
+        mask_filename = download_wbd(
+            extent_buffered[1],
+            extent_buffered[3],
+            extent_buffered[0],
+            extent_buffered[2],
+        )
+
+    elif water_name == "GSHHS":
+        # from water_mask import get_water_mask_raster
+        raise NotImplementedError("Your Message")
+
+    return {"water_mask": str(output_dir / mask_filename)}

--- a/isce2_topsapp/localize_mask.py
+++ b/isce2_topsapp/localize_mask.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import numpy as np
+from shapely.geometry import box
+
+def download_water_mask(extent: list,
+                        water_name: str = 'SWDB',
+                        buffer: float = .1) -> dict:
+    
+    output_dir = Path('.').absolute()
+
+    extent_geo = box(*extent)
+    extent_buffered = list(extent_geo.buffer(buffer).bounds)
+    extent_buffered = [np.floor(extent_buffered[0]), np.floor(extent_buffered[1]),
+                       np.ceil(extent_buffered[2]), np.ceil(extent_buffered[3])]
+    
+    if water_name == 'SWDB':
+        import isce
+        from isceobj.Alos2Proc.runDownloadDem import download_wbd
+
+        #Download SRTM-SWDB water mask
+        mask_filename = download_wbd(extent_buffered[1], 
+                                     extent_buffered[3], 
+                                     extent_buffered[0], 
+                                     extent_buffered[2])
+        
+    elif water_name == 'GSHHS':
+        from water_mask import get_water_mask_raster
+
+        # TO BE ADDED
+
+    return {'water_mask': str(output_dir / mask_filename)}

--- a/isce2_topsapp/localize_mask.py
+++ b/isce2_topsapp/localize_mask.py
@@ -30,6 +30,6 @@ def download_water_mask(
 
     elif water_name == "GSHHS":
         # from water_mask import get_water_mask_raster
-        raise NotImplementedError("Your Message")
+        raise NotImplementedError("TODO, GSHHS not yet available")
 
     return {"water_mask": str(output_dir / mask_filename)}

--- a/isce2_topsapp/localize_mask.py
+++ b/isce2_topsapp/localize_mask.py
@@ -1,6 +1,8 @@
 from pathlib import Path
+
 import numpy as np
 from shapely.geometry import box
+
 
 def download_water_mask(extent: list,
                         water_name: str = 'SWDB',
@@ -16,9 +18,8 @@ def download_water_mask(extent: list,
     if water_name == 'SWDB':
         import isce
         from isceobj.Alos2Proc.runDownloadDem import download_wbd
-
         #Download SRTM-SWDB water mask
-        mask_filename = download_wbd(extent_buffered[1], 
+        mask_filename = download_wbd(extent_buffered[1],
                                      extent_buffered[3], 
                                      extent_buffered[0], 
                                      extent_buffered[2])

--- a/isce2_topsapp/localize_mask.py
+++ b/isce2_topsapp/localize_mask.py
@@ -24,8 +24,8 @@ def download_water_mask(extent: list,
                                      extent_buffered[2])
         
     elif water_name == 'GSHHS':
-        from water_mask import get_water_mask_raster
-
+        #from water_mask import get_water_mask_raster
         # TO BE ADDED
+        print('TODO as another option')
 
     return {'water_mask': str(output_dir / mask_filename)}

--- a/isce2_topsapp/localize_mask.py
+++ b/isce2_topsapp/localize_mask.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
 import numpy as np
-from shapely.geometry import box
 from isce.components.isceobj.Alos2Proc.runDownloadDem import download_wbd
+from shapely.geometry import box
 
 
 def download_water_mask(


### PR DESCRIPTION
Resolves #85.

Adding option to use water mask for ionospheric correction:
       --      Ionospheric computation is done after topsApp run using ionoApp.xml
       --      Iono_processiong runs in 5 steps: 

             1. run ion step 'subband' (creation of lower and upper fine_interferograms for each burst)
             2. transform (water) mask from geo to radar coordinate space, and us it to mask burst interferograms
             3. run ion steps 'rawion' to 'esd' (computation and filtering of ionospheric correction)
             4. create merged/topophase.ion (extracted from runMergeBursts.py)
             5. run geocode for merged/topophase.ion