### PR TITLE
Solid Earth Tides: Pass coordinates from Geo Transforms to Pysolid, not lat/lon metadata arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### Added
-
-## [0.2.3]
+## [0.2.4]
 
 ## Fixed
 * For Solid Earth Tide computation, derive coordinates and spacing from geotrans as opposed to latitude/longitude metadata arrays
+
+## [0.2.3]
 
 ### Updated
 * Explode footprints polygons

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.2.3]
 
+## Fixed
+* For Solid Earth Tide computation, derive coordinates and spacing from geotrans as opposed to latitude/longitude metadata arrays
+
 ### Updated
 * Explode footprints polygons
 

--- a/isce2_topsapp/solid_earth_tides.py
+++ b/isce2_topsapp/solid_earth_tides.py
@@ -66,9 +66,7 @@ def get_gunw_attrs(gunw_path: str) -> Tuple[float, np.array, np.array,
     group = 'science/grids/imagingGeometry'
     with xr.open_dataset(gunw_path, group=group, engine='rasterio') as ds:
         z_meta = ds.heightsMeta.data
-        lat_meta = ds.y.data
-        lon_meta = ds.x.data
-        gt  = ds.rio.transform()
+        gt = ds.rio.transform()
         # convert angles to rad
         inc_angle = np.deg2rad(ds.incidenceAngle.data)
         az_angle = np.deg2rad(ds.azimuthAngle.data-90)

--- a/isce2_topsapp/solid_earth_tides.py
+++ b/isce2_topsapp/solid_earth_tides.py
@@ -41,7 +41,7 @@ def compute_solid_earth_tide_from_gunw(gunw_path: str, acq_type: str) -> xr.Data
                                                  set_attrs)
 
     # compute SET LOS estimate for each height level
-    tide_los = np.zeros(inc_angle.shape, dtype=float)
+    tide_los = np.zeros(inc_angle.shape, dtype=np.float32)
     for i in range(len(z_meta)):
         tide_los[i] = compute_los_solid_earth_tide(tide_e,
                                                    tide_n,
@@ -146,7 +146,7 @@ def export_se_tides_to_dataset(gunw_path: str,
     solidtide_corr_ds[lyr_name] = (dim_order, tide_los)
     solidtide_corr_ds[lyr_name].attrs.update(attrs)
     solidtide_corr_ds = solidtide_corr_ds[[lyr_name]]
-    solidtide_corr_ds = solidtide_corr_ds.astype(float)
+    solidtide_corr_ds = solidtide_corr_ds.astype(np.float32)
     solidtide_corr_ds.rio.write_crs('epsg:4326', inplace=True)
     solidtide_corr_ds['solidEarthTide'].rio.write_nodata(0, inplace=True)
     return solidtide_corr_ds


### PR DESCRIPTION
Following our convo @cmarshak , I adjusted the logic of the SET code to handle and pass coordinates derived from the geotrans, as opposed to the latitude and longitude metadata arrays.