### PR TITLE
Iono computation - addressing #135

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Catch warnings in tests and match messages to ensure package warnings do not fail test suite
 * Read low resolution Natural Earth land masses from public url due to removal from geopandas package.
 * For ionosphere computation over water, includes masking conncomp zero, phase bridging, and modified adaptive gaussian filtering
+* Fix for #135, skip iono computation if there are not land (all zero values) and skip using water mask if the area is outside of SWBD coverage
 
 ### Added
 * localize_data within __main__.py added option to use/not use water mask for ionosphere processing

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -58,7 +58,7 @@ def localize_data(
         # For ionospheric correction computation
         if water_mask_flag:
             out_water_mask = download_water_mask(
-                out_slc["extent"],  water_name='SWDB')
+                out_slc["extent"],  water_name='SWBD')
 
         out_aux_cal = download_aux_cal()
 

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -178,6 +178,10 @@ def gunw_slc():
               indent=2, cls=MetadataEncoder)
 
     # Turn-off ESD when using ionospheric computation
+    # NOTE: note sure if this needs to be off
+    #       esd is calculate with iono only when
+    #       considerBurstProperties is on which off 
+    #       by default
     if args.estimate_ionosphere_delay:
         args.esd_coherence_threshold = -1
 
@@ -201,7 +205,8 @@ def gunw_slc():
     #   this option (it adds 10min to iono for frame processing)
     #   example: look at filt_toposphase.unw or .flat
     #   and analyze if there are any burst jumps,
-    #   if yes, set this option True
+    #   if yes, set this option True, or we could run it always
+    #   and store both iono-long wavelength and burst jumps(az_shifts)
     if args.estimate_ionosphere_delay:
         iono_processing(
             mask_filename=loc_data["water_mask"],

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -198,7 +198,7 @@ def gunw_slc():
     # Run ionospheric correction
     # MG: correct burst jumps, e.g. needed for Arabian
     #   processing. TODO: We need a trigger function for
-    #   this option (it adds almost double time to iono)
+    #   this option (it adds 10min to iono for frame processing)
     #   example: look at filt_toposphase.unw or .flat
     #   and analyze if there are any burst jumps,
     #   if yes, set this option True

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -179,8 +179,8 @@ def gunw_slc():
 
     # Turn-off ESD when using ionospheric computation
     # NOTE: note sure if this needs to be off
-    #       esd is calculate with iono only when
-    #       considerBurstProperties is on which off 
+    #       esd is calculated with iono only when
+    #       considerBurstProperties is on which off
     #       by default
     if args.estimate_ionosphere_delay:
         args.esd_coherence_threshold = -1

--- a/isce2_topsapp/localize_mask.py
+++ b/isce2_topsapp/localize_mask.py
@@ -6,7 +6,7 @@ from shapely.geometry import box
 
 
 def download_water_mask(
-    extent: list, water_name: str = "SWDB", buffer: float = 0.1
+    extent: list, water_name: str = "SWBD", buffer: float = 0.1
 ) -> dict:
     output_dir = Path(".").absolute()
 
@@ -19,17 +19,27 @@ def download_water_mask(
         np.ceil(extent_buffered[3]),
     ]
 
-    if water_name == "SWDB":
+    if water_name == "SWBD":
         # Download SRTM-SWDB water mask
-        mask_filename = download_wbd(
-            extent_buffered[1],
-            extent_buffered[3],
-            extent_buffered[0],
-            extent_buffered[2],
-        )
+        # Water mask dataset extent
+        # Latitude S55 - N60
+
+        lats = [extent_buffered[1], extent_buffered[3]]
+        if (np.abs(lats) < 59.9).all():
+            mask_filename = download_wbd(
+                extent_buffered[1],
+                extent_buffered[3],
+                extent_buffered[0],
+                extent_buffered[2],
+            )
+            mask_filename = str(output_dir / mask_filename)
+        else:
+            print('Request out of SWBD coverage ',
+                  'Skip downloading water mask!!')
+            mask_filename = ''
 
     elif water_name == "GSHHS":
         # from water_mask import get_water_mask_raster
         raise NotImplementedError("TODO, GSHHS not yet available")
 
-    return {"water_mask": str(output_dir / mask_filename)}
+    return {"water_mask": mask_filename}


### PR DESCRIPTION
Changes:
1. Skip iono_computation if lower/upper band unwrapped interferogram array is empty, i.e. all zeros. Return iono as zeros array
2. Skip downloading and using water mask if the AOI request is out of SWBD data coverage. TODO: introduce new water masks as mentioned in #135 : EXAMPLES: https://worldcover2021.esa.int/viewer or https://land.copernicus.eu/global/products/wb
3. fix few typos and add notes in the __main__ regarding the esd and calculation of burst jumps 