### PR TITLE
SET Bug related to geo2rdr (duplicate state vectors)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Read low resolution Natural Earth land masses from public url due to removal from geopandas package.
 * For ionosphere computation over water, includes masking conncomp zero, phase bridging, and modified adaptive gaussian filtering
 * Fix for #135, skip iono computation if there are not land (all zero values) and skip using water mask if the area is outside of SWBD coverage
+* Fix for #145 and SET - duplicate orbit xmls for computing azimuth time grid with ISCE2 geo2rdr (duplicate state vectors likely culprit). Ensures orbit object is intialized with unique set of orbit xmls passed. Also, localized metadata appropriately.
 
 ### Added
 * localize_data within __main__.py added option to use/not use water mask for ionosphere processing

--- a/isce2_topsapp/localize_orbits.py
+++ b/isce2_topsapp/localize_orbits.py
@@ -37,6 +37,9 @@ def download_orbits(reference_scenes: list,
         orbit_file, _ = orbit_fetcher(scene, str(orbit_dir))
         secondary_orbits.append(orbit_file)
 
+    reference_orbits = list(set(reference_orbits))
+    secondary_orbits = list(set(secondary_orbits))
+
     return {
         'orbit_directory': orbit_directory,
         'reference_orbits': reference_orbits,

--- a/isce2_topsapp/solid_earth_tides.py
+++ b/isce2_topsapp/solid_earth_tides.py
@@ -107,7 +107,10 @@ def get_orbit_obj_from_orbit_xmls(orbit_xmls: list[Path],
     get from the slc_id stored in GUNW products.
     """
     state_vectors = []
-    for orbit_xml in orbit_xmls:
+    # Duplicate XMLs leads to unexpected behavior in geo2rdr see errors in
+    # https://github.com/ACCESS-Cloud-Based-InSAR/DockerizedTopsApp/issues/145
+    orbit_xmls_unique = list(set(orbit_xmls))
+    for orbit_xml in orbit_xmls_unique:
         state_vectors.extend(get_state_vector_arrays(orbit_xml))
     orb = Orbit()
     orb.configure()
@@ -232,7 +235,7 @@ def get_azimuth_time_array(orbit_xmls: list[Path],
 
     Notes
     -----
-    See get_orbit_obj_from_orbit_xmls as to why slc start time and padding is required.
+    - See get_orbit_obj_from_orbit_xmls as to why slc start time and padding is required.
     """
 
     orb = get_orbit_obj_from_orbit_xmls(orbit_xmls,


### PR DESCRIPTION
Resolves #145 - the subsequent error obtained locally (thanks @mgovorcin for graciously pointing this out!).

We fix it in a number of ways:

+ ensure the localized metadata dictionary has unique orbit xmls
+ ISCE2 orbit object is created with unique xmls of list passed