### PR TITLE
ensure creation_timestamp includes microseconds

### DIFF
--- a/isce2_topsapp/delivery_prep.py
+++ b/isce2_topsapp/delivery_prep.py
@@ -117,7 +117,6 @@ def gen_browse_imagery(nc_path: Path,
 def format_metadata(nc_path: Path,
                     all_metadata: dict) -> dict:
 
-    now = datetime.datetime.now()
     label = nc_path.name[:-3]  # removes suffix .nc
     geojson = all_metadata['gunw_geo'].__geo_interface__
 
@@ -140,6 +139,7 @@ def format_metadata(nc_path: Path,
     # The %f is miliseconds zero-padded with 6 decimals - just as we need!
     ref_start_time_formatted = ref_start_time.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
     ref_stop_time_formatted = ref_stop_time.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+    creation_timestamp = datetime.datetime.now().strftime('%Y-%m-%dT%H:%M:%S.%fZ')
 
     # We want the nearest day (dt.days takes a floor) so we use total seconds and then round
     temporal_baseline_seconds = (ref_start_time - sec_start_time).total_seconds()
@@ -171,7 +171,7 @@ def format_metadata(nc_path: Path,
 
     data = {"label": label,
             "location": geojson,
-            "creation_timestamp": f'{now.isoformat()}Z',
+            "creation_timestamp": creation_timestamp,
             "version": DATASET_VERSION,
             "metadata": metadata}
 


### PR DESCRIPTION
ASF's ingest workflow requires datetimes in the delivery metadata file to be formatted `2023-01-01T00:00:00.000000Z` per the schema at https://github.com/asfadmin/grfn-ingest/blob/test/verify/src/metadata_schema.json

[datetime.datetime.isoformat()](https://docs.python.org/3/library/datetime.html#datetime.datetime.isoformat) does not include microseconds if the microsecond value is exactly zero:
```
>>> datetime.datetime(2023, 1, 1, 0, 0, 0).isoformat()
'2023-01-01T00:00:00'
>>> datetime.datetime(2023, 1, 1, 0, 0, 0, 1).isoformat()
'2023-01-01T00:00:00.000001'
```

This PR eliminates the one-in-a-million case where `creation_timestamp` did not include microseconds, causing ingest to ASF to fail. We saw one instance of this in the recent processing campaign.