### PR TITLE
Upgrade to `hyp3lib` v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.2.5]
 
+### Update
+* Updated workflows to hyp3lib v2.0.2, which uses the new Copernicus Dataspace Ecosystem API got download orbit files.
+* Calls to `downloadSentinelOrbitFile` to specify the `esa_credentials` argument.
+
+### Added
+* `check_esa_credentials` function to `__main__.py` to check for the existence of Dataspace credentials before processing begins.
+
+## [0.2.5]
+
 ### Fixed
 * For SET azimuth time interpolation, overlapping orbits produces errors with prepping state vectors for azimuth time grid. We now ensure state-vecotors are both unique and in order before creating a orbit object in ISCE2.
 

--- a/README.md
+++ b/README.md
@@ -30,16 +30,12 @@ We note all the input datasets are publicly available using a NASA Earthdata acc
     machine urs.earthdata.nasa.gov
         login <username>
         password <password>
-    ```
-    The `username`/`password` are the appropriate Earthdata Login credentials that are used to access NASA data. This file is necessary for downloading the Sentinel-1 orbit files from the ASF DAAC. Additionally, the [`requests`](https://docs.python-requests.org/en/latest/) library automatically uses credentials stored in the `~/.netrc` for authentification when none are supplied.
 
-2. Ensure that your ESA Dataspace credentials are available as environmental variables. In your terminal run:
+    machine dataspace.copernicus.eu
+        login <username>
+        password <password>
     ```
-    export ESA_USERNAME=<esa-username>
-    export ESA_PASSWORD=<esa-password>
-    ```
-    If you don't have an ESA Dataspace account, you can sign up for one [here](https://dataspace.copernicus.eu)
-
+    The first `username`/`password` pair are the appropriate Earthdata Login credentials that are used to access NASA data. The second pair are your credentials for the [Copernicus Data Space Ecosystem](https://dataspace.copernicus.eu). This file is necessary for downloading the Sentinel-1 files, and auxiliary data. Additionally, the [`requests`](https://docs.python-requests.org/en/latest/) library automatically uses credentials stored in the `~/.netrc` for authentification when none are supplied.
 
 ## Generate a GUNW
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ We note all the input datasets are publicly available using a NASA Earthdata acc
     ```
     The `username`/`password` are the appropriate Earthdata Login credentials that are used to access NASA data. This file is necessary for downloading the Sentinel-1 orbit files from the ASF DAAC. Additionally, the [`requests`](https://docs.python-requests.org/en/latest/) library automatically uses credentials stored in the `~/.netrc` for authentification when none are supplied.
 
+2. Ensure that your ESA Dataspace credentials are available as environmental variables. In your terminal run:
+    ```
+    export ESA_USERNAME=<esa-username>
+    export ESA_PASSWORD=<esa-password>
+    ```
+    If you don't have an ESA Dataspace account, you can sign up for one [here](https://dataspace.copernicus.eu)
+
 
 ## Generate a GUNW
 
@@ -112,6 +119,8 @@ isce2_topsapp --reference-scenes S1A_IW_SLC__1SDV_20230125T140019_20230125T14004
     ```
     isce2_topsapp --username <username> \
                   --password <password> \
+                  --esa-username <esa-username> \
+                  --esa-password <esa-password> \
                   --reference-scenes S1B_IW_SLC__1SDV_20210723T014947_20210723T015014_027915_0354B4_B3A9 \
                   --secondary-scenes S1B_IW_SLC__1SDV_20210711T014922_20210711T014949_027740_034F80_859D \
                                      S1B_IW_SLC__1SDV_20210711T014947_20210711T015013_027740_034F80_D404 \
@@ -141,6 +150,8 @@ docker run -ti -v $PWD:/home/ops/topsapp_data topsapp_img \
                                     S1B_IW_SLC__1SDV_20210711T015011_20210711T015038_027740_034F80_376C \
                --username <username>
                --password <password>
+               --esa-username <esa-username> \
+               --esa-password <esa-password> \
 ```
 where the `username`/`password` are the Earthdata credentials for accessing NASA data. We note the command line magic of the above is taken care of the `isce2_topsapp/etc/entrypoint.sh` (written by Joe Kennedy) which automatically runs certain bash commands on startup of the container, i.e. the run commands also calls the `isce2_topsapp` command line function as can be seen [here](isce2_topsapp/etc/entrypoint.sh).
 

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
  - fsspec
  - gdal
  - geopandas
- - hyp3lib>=1.7
+ - hyp3lib>=2,<3
  - ipykernel
  - isce2==2.6.1
  - jinja2

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -32,6 +32,7 @@ from isce2_topsapp.solid_earth_tides import update_gunw_with_solid_earth_tide
 
 ESA_HOST = 'dataspace.copernicus.eu'
 
+
 def localize_data(
     reference_scenes: list,
     secondary_scenes: list,

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -117,11 +117,12 @@ def check_esa_credentials(username: Optional[str], password: Optional[str]) -> N
     netrc_file = Path.home() / netrc_name
     if not netrc_file.exists():
         netrc_file.touch()
+        netrc_file.chmod(0o000600)
     netrc_credentials = netrc.netrc(netrc_file)
 
     if username is not None:
         os.environ["ESA_USERNAME"] = username
-    elif "ESA_USERNAME" not in os.environ:
+    elif "ESA_USERNAME" in os.environ:
         pass
     elif ESA_HOST in netrc_credentials.hosts:
         os.environ["ESA_USERNAME"] = netrc_credentials.hosts[ESA_HOST][0]
@@ -133,7 +134,7 @@ def check_esa_credentials(username: Optional[str], password: Optional[str]) -> N
 
     if password is not None:
         os.environ["ESA_PASSWORD"] = password
-    elif "ESA_USERNAME" not in os.environ:
+    elif "ESA_PASSWORD" in os.environ:
         pass
     elif ESA_HOST in netrc_credentials.hosts:
         os.environ["ESA_PASSWORD"] = netrc_credentials.hosts[ESA_HOST][2]

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -58,13 +58,13 @@ def localize_data(
         # For ionospheric correction computation
         if water_mask_flag:
             out_water_mask = download_water_mask(
-                out_slc["extent"],  water_name='SWBD')
+                out_slc["extent"],  water_name="SWBD")
 
         out_aux_cal = download_aux_cal()
 
-    out = {'reference_scenes': reference_scenes,
-           'secondary_scenes': secondary_scenes,
-           'frame_id': frame_id,
+    out = {"reference_scenes": reference_scenes,
+           "secondary_scenes": secondary_scenes,
+           "frame_id": frame_id,
            **out_slc,
            **out_dem,
            **out_water_mask,
@@ -111,19 +111,19 @@ def ensure_earthdata_credentials(
 
 def check_esa_credentials(username: Optional[str], password: Optional[str]) -> None:
     if username is not None:
-        os.environ['ESA_USERNAME'] = username
-    elif 'ESA_USERNAME' not in os.environ:
+        os.environ["ESA_USERNAME"] = username
+    elif "ESA_USERNAME" not in os.environ:
         raise ValueError(
-            'Please provide Copernicus Data Space Ecosystem (CDSE) username via the --esa-username option '
-            'or the ESA_USERNAME environment variable.'
+            "Please provide Copernicus Data Space Ecosystem (CDSE) username via the --esa-username option "
+            "or the ESA_USERNAME environment variable."
         )
 
     if password is not None:
-        os.environ['ESA_PASSWORD'] = password
-    elif 'ESA_PASSWORD' not in os.environ:
+        os.environ["ESA_PASSWORD"] = password
+    elif "ESA_PASSWORD" not in os.environ:
         raise ValueError(
-            'Please provide Copernicus Data Space Ecosystem (CDSE) password via the --esa-password option '
-            'or the ESA_PASSWORD environment variable.'
+            "Please provide Copernicus Data Space Ecosystem (CDSE) password via the --esa-password option "
+            "or the ESA_PASSWORD environment variable."
         )
 
 
@@ -154,8 +154,8 @@ def gunw_slc():
     parser = ArgumentParser()
     parser.add_argument("--username")
     parser.add_argument("--password")
-    parser.add_argument('--esa-username')
-    parser.add_argument('--esa-password')
+    parser.add_argument("--esa-username")
+    parser.add_argument("--esa-password")
     parser.add_argument("--bucket")
     parser.add_argument("--bucket-prefix", default="")
     parser.add_argument("--dry-run", action="store_true")
@@ -268,8 +268,8 @@ def gunw_burst():
     parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
     parser.add_argument("--username")
     parser.add_argument("--password")
-    parser.add_argument('--esa-username')
-    parser.add_argument('--esa-password')
+    parser.add_argument("--esa-username")
+    parser.add_argument("--esa-password")
     parser.add_argument("--bucket")
     parser.add_argument("--bucket-prefix", default="")
     parser.add_argument("--dry-run", action="store_true")

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -109,6 +109,24 @@ def ensure_earthdata_credentials(
         )
 
 
+def check_esa_credentials(username: Optional[str], password: Optional[str]) -> None:
+    if username is not None:
+        os.environ['ESA_USERNAME'] = username
+    elif 'ESA_USERNAME' not in os.environ:
+        raise ValueError(
+            'Please provide Copernicus Data Space Ecosystem (CDSE) username via the --esa-username option '
+            'or the ESA_USERNAME environment variable.'
+        )
+
+    if password is not None:
+        os.environ['ESA_PASSWORD'] = password
+    elif 'ESA_PASSWORD' not in os.environ:
+        raise ValueError(
+            'Please provide Copernicus Data Space Ecosystem (CDSE) password via the --esa-password option '
+            'or the ESA_PASSWORD environment variable.'
+        )
+
+
 def true_false_string_argument(s: str) -> bool:
     s = s.lower()
     if s not in ("true", "false"):
@@ -136,6 +154,8 @@ def gunw_slc():
     parser = ArgumentParser()
     parser.add_argument("--username")
     parser.add_argument("--password")
+    parser.add_argument('--esa-username')
+    parser.add_argument('--esa-password')
     parser.add_argument("--bucket")
     parser.add_argument("--bucket-prefix", default="")
     parser.add_argument("--dry-run", action="store_true")
@@ -154,6 +174,7 @@ def gunw_slc():
     args = parser.parse_args()
 
     ensure_earthdata_credentials(args.username, args.password)
+    check_esa_credentials(args.esa_username, args.esa_password)
 
     args.reference_scenes = [
         item for sublist in args.reference_scenes for item in sublist
@@ -247,6 +268,8 @@ def gunw_burst():
     parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
     parser.add_argument("--username")
     parser.add_argument("--password")
+    parser.add_argument('--esa-username')
+    parser.add_argument('--esa-password')
     parser.add_argument("--bucket")
     parser.add_argument("--bucket-prefix", default="")
     parser.add_argument("--dry-run", action="store_true")
@@ -262,6 +285,7 @@ def gunw_burst():
     args = parser.parse_args()
 
     ensure_earthdata_credentials(args.username, args.password)
+    check_esa_credentials(args.esa_username, args.esa_password)
 
     ref_obj, sec_obj = get_asf_slc_objects(
         [args.reference_scene, args.secondary_scene])

--- a/isce2_topsapp/localize_orbits.py
+++ b/isce2_topsapp/localize_orbits.py
@@ -1,9 +1,11 @@
+import os
 from pathlib import Path
 
 import requests
 from hyp3lib import get_orb
 
 
+# TODO update to accept `esa_credentials`; does the function body need to be updated as well?
 def _spoof_orbit_download(scene, _, providers=('ESA', 'ASF'), orbit_types=('AUX_POEORB', 'AUX_RESORB')):
     for orbit_type in orbit_types:
         for provider in providers:
@@ -21,6 +23,8 @@ def download_orbits(reference_scenes: list,
                     secondary_scenes: list,
                     orbit_directory: str = None,
                     dry_run: bool = False) -> dict:
+    esa_credentials = (os.environ['ESA_USERNAME'], os.environ['ESA_PASSWORD'])
+
     orbit_directory = orbit_directory or 'orbits'
     orbit_dir = Path(orbit_directory)
     orbit_dir.mkdir(exist_ok=True)
@@ -29,12 +33,12 @@ def download_orbits(reference_scenes: list,
 
     reference_orbits = []
     for scene in reference_scenes:
-        orbit_file, _ = orbit_fetcher(scene, str(orbit_dir))
+        orbit_file, _ = orbit_fetcher(scene, str(orbit_dir), esa_credentials=esa_credentials)
         reference_orbits.append(orbit_file)
 
     secondary_orbits = []
     for scene in secondary_scenes:
-        orbit_file, _ = orbit_fetcher(scene, str(orbit_dir))
+        orbit_file, _ = orbit_fetcher(scene, str(orbit_dir), esa_credentials=esa_credentials)
         secondary_orbits.append(orbit_file)
 
     reference_orbits = list(set(reference_orbits))

--- a/isce2_topsapp/localize_orbits.py
+++ b/isce2_topsapp/localize_orbits.py
@@ -5,8 +5,9 @@ import requests
 from hyp3lib import get_orb
 
 
-# TODO update to accept `esa_credentials`; does the function body need to be updated as well?
-def _spoof_orbit_download(scene, _, providers=('ESA', 'ASF'), orbit_types=('AUX_POEORB', 'AUX_RESORB')):
+def _spoof_orbit_download(
+    scene, _, providers=('ESA', 'ASF'), orbit_types=('AUX_POEORB', 'AUX_RESORB'), esa_credentials=('name', 'password')
+):
     for orbit_type in orbit_types:
         for provider in providers:
             try:
@@ -19,10 +20,9 @@ def _spoof_orbit_download(scene, _, providers=('ESA', 'ASF'), orbit_types=('AUX_
     return None, None
 
 
-def download_orbits(reference_scenes: list,
-                    secondary_scenes: list,
-                    orbit_directory: str = None,
-                    dry_run: bool = False) -> dict:
+def download_orbits(
+    reference_scenes: list, secondary_scenes: list, orbit_directory: str = None, dry_run: bool = False
+) -> dict:
     esa_credentials = (os.environ['ESA_USERNAME'], os.environ['ESA_PASSWORD'])
 
     orbit_directory = orbit_directory or 'orbits'

--- a/sample_run.sh
+++ b/sample_run.sh
@@ -1,5 +1,7 @@
 isce2_topsapp --username <username> \
               --password <password> \
+              --esa-username <esa-username> \
+              --esa-password <esa-password> \
               --reference-scenes S1B_IW_SLC__1SDV_20210723T014947_20210723T015014_027915_0354B4_B3A9 \
               --secondary-scenes S1B_IW_SLC__1SDV_20210711T014922_20210711T014949_027740_034F80_859D \
                                  S1B_IW_SLC__1SDV_20210711T014947_20210711T015013_027740_034F80_D404 \

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'dateparser',
         'dem_stitcher>=2.1',
         'geopandas',
-        'hyp3lib>=1.7',
+        'hyp3lib>=2,<3',
         'jinja2',
         'lxml',
         'matplotlib',

--- a/tests/localize-data.ipynb
+++ b/tests/localize-data.ipynb
@@ -116,7 +116,8 @@
    "id": "mounted-title",
    "metadata": {},
    "source": [
-    "# Orbits"
+    "# Orbits\n",
+    "Make sure `ESA_USERNAME` and `ESA_PASSWORD` environment variables are set before running this."
    ]
   },
   {
@@ -249,9 +250,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "topsapp_env",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "topsapp_env"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -263,7 +264,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/tests/prepare-for-delivery.ipynb
+++ b/tests/prepare-for-delivery.ipynb
@@ -485,9 +485,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "topsapp_env",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "topsapp_env"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -499,7 +499,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/tests/solid_earth_tides.ipynb
+++ b/tests/solid_earth_tides.ipynb
@@ -24,6 +24,7 @@
    "outputs": [],
    "source": [
     "from pathlib import Path\n",
+    "import os\n",
     "import xarray as xr\n",
     "import requests\n",
     "from hyp3lib import get_orb\n",
@@ -90,6 +91,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "44fe249b-5691-4d96-9e11-1418ea9c2f4b",
+   "metadata": {},
+   "source": [
+    "**Make sure the `ESA_USERNAME` and `ESA_PASSWORD` environment variables are set before running this.**"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 7,
    "id": "f70052af",
@@ -114,7 +123,8 @@
     }
    ],
    "source": [
-    "orb_file, _ = get_orb.downloadSentinelOrbitFile(slc_id)\n",
+    "esa_credentials = (os.environ['ESA_USERNAME'], os.environ['ESA_PASSWORD'])\n",
+    "orb_file, _ = get_orb.downloadSentinelOrbitFile(slc_id, esa_credentials=esa_credentials)\n",
     "orb_file"
    ]
   },
@@ -7727,9 +7737,9 @@
    "hash": "83c8da8660bbe18150fdc09aeaa55e9731d119a6641346a233b76fde249768bb"
   },
   "kernelspec": {
-   "display_name": "topsapp_env",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "topsapp_env"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -7741,7 +7751,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -126,7 +126,7 @@ def test_check_esa_credentials_missing(tmp_path, monkeypatch):
         m.setenv('ESA_PASSWORD', 'env_password')
         m.setenv('HOME', str(tmp_path))
         (tmp_path / '.netrc').write_text('')
-        msg = 'Please provide.* --esa-username .*'
+        msg = 'Please provide.*'
         with pytest.raises(ValueError, match=msg):
             check_esa_credentials(None, None)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,4 @@
-import netrc
 import os
-from unittest.mock import PropertyMock
 
 import pytest
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -135,7 +135,7 @@ def test_check_esa_credentials_missing(tmp_path, monkeypatch):
         m.delenv('ESA_PASSWORD', raising=False)
         m.setenv('HOME', str(tmp_path))
         (tmp_path / '.netrc').write_text('')
-        msg = 'Please provide.* --esa-password .*'
+        msg = 'Please provide.*'
         with pytest.raises(ValueError, match=msg):
             check_esa_credentials(None, None)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,8 @@
+import os
+
 import pytest
 
-from isce2_topsapp.__main__ import ensure_earthdata_credentials, esd_threshold_argument, true_false_string_argument
+from isce2_topsapp.__main__ import check_esa_credentials, ensure_earthdata_credentials, esd_threshold_argument, true_false_string_argument
 
 
 def test_main_check_earthdata_credentials_prefer_netrc(tmp_path, monkeypatch):
@@ -73,6 +75,37 @@ def test_main_check_earthdata_credentials_env_variables(tmp_path, monkeypatch):
     assert netrc.read_text() == 'machine foobar.nasa.gov login fizz password baz'
 
 
+@pytest.mark.parametrize('username, password', [('foo', 'bar'), (None, 'bar'), ('foo', None)])
+def test_check_esa_credentials(monkeypatch, username, password):
+    with monkeypatch.context() as m:
+        m.setenv('ESA_USERNAME', 'env_username')
+        m.setenv('ESA_PASSWORD', 'env_password')
+
+        check_esa_credentials(username, password)
+
+        expected_username = username if username is not None else 'env_username'
+        expected_password = password if password is not None else 'env_password'
+
+        assert os.environ['ESA_USERNAME'] == expected_username
+        assert os.environ['ESA_PASSWORD'] == expected_password
+
+
+def test_check_esa_credentials_missing(monkeypatch):
+    with monkeypatch.context() as m:
+        m.delenv('ESA_USERNAME', raising=False)
+        m.setenv('ESA_PASSWORD', 'env_password')
+        msg = 'Please provide.* --esa-username .*'
+        with pytest.raises(ValueError, match=msg):
+            check_esa_credentials(None, None)
+
+    with monkeypatch.context() as m:
+        m.setenv('ESA_USERNAME', 'env_username')
+        m.delenv('ESA_PASSWORD', raising=False)
+        msg = 'Please provide.* --esa-password .*'
+        with pytest.raises(ValueError, match=msg):
+            check_esa_credentials(None, None)
+
+
 def test_true_false_string_argument():
     assert true_false_string_argument('true') is True
     assert true_false_string_argument('TRUE') is True
@@ -90,11 +123,11 @@ def test_true_false_string_argument():
 
 
 def test_esd_threshold_argument():
-    assert esd_threshold_argument('-1') == -1.
-    assert esd_threshold_argument('0') == 0.
+    assert esd_threshold_argument('-1') == -1.0
+    assert esd_threshold_argument('0') == 0.0
     assert esd_threshold_argument('.25') == 0.25
     assert esd_threshold_argument('0.5') == 0.5
-    assert esd_threshold_argument('1') == 1.
+    assert esd_threshold_argument('1') == 1.0
 
     with pytest.raises(ValueError):
         esd_threshold_argument('-1.1')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,7 +2,12 @@ import os
 
 import pytest
 
-from isce2_topsapp.__main__ import check_esa_credentials, ensure_earthdata_credentials, esd_threshold_argument, true_false_string_argument
+from isce2_topsapp.__main__ import (
+    check_esa_credentials,
+    ensure_earthdata_credentials,
+    esd_threshold_argument,
+    true_false_string_argument,
+)
 
 
 def test_main_check_earthdata_credentials_prefer_netrc(tmp_path, monkeypatch):

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -9,7 +9,7 @@ notebooks = ['localize-data.ipynb',
 
 
 @pytest.mark.parametrize('notebook_name', notebooks)
-def test_notebooks(notebook_name):
+def test_notebooks(notebook_name, monkeypatch):
 
     test_dir = Path(__file__).parents[0].absolute()
 
@@ -18,6 +18,8 @@ def test_notebooks(notebook_name):
 
     out_notebook = out_dir / f'{notebook_name}'
 
+    monkeypatch.setenv('ESA_USERNAME', 'foo')
+    monkeypatch.setenv('ESA_PASSWORD', 'bar')
     pm.execute_notebook(test_dir / f'{notebook_name}',
                         output_path=out_notebook
                         )

--- a/tests/test_set.py
+++ b/tests/test_set.py
@@ -159,7 +159,7 @@ def test_magnitude_of_set_with_variable_timing(acq_type: str, orbit_files_for_se
     with xr.open_dataset(gunw_path_for_set_2, group=group) as ds:
         slc_id = ds['L1InputGranules'].values[0]
 
-    orb_file, _ = get_orb.downloadSentinelOrbitFile(slc_id)
+    orb_file, _ = get_orb.downloadSentinelOrbitFile(slc_id, esa_credentials=('username', 'password'))
     ```
     """
     for gunw_path_for_set, orbit_dict in zip(gunw_paths_for_set, orbit_files_for_set):


### PR DESCRIPTION
This PR will upgrade to `hyp3lib` v2, which downloads orbit files from the new https://dataspace.copernicus.eu/ and requires that the appropriate credentials be provided.

TODO:

- [x] Modify `environment.yml` to install `hyp3lib` with `pip` or push the latest release to https://anaconda.org/conda-forge/hyp3lib
- [x] Pass `esa_credentials` wherever `downloadSentinelOrbitFile` is called.
- [x] Update README examples
- [x] Update tests
- [x] Update notebooks
- [x] Find occurrences of `EARTHDATA_USERNAME` or `--username` for places that we may need to include the ESA credentials options as well
- [x] Validate changes on some sample jobs
- [x] Add Changelog entry
- [x] Address remaining `TODO` items in the code