### PR TITLE
Update to python 3.10+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,8 @@ jobs:
   pytest:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
   pytest:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Records parameters in the product including the CLI command to regenerate said product
 * If parameters are not standard uses prefix `S1-GUNW_CUSTOM-...`
 * Pydantic dependency for parameter accounting
+* Support for python 3.10 and 3.11
 
 ### Changed
 * The CLI now *requires* `frame_id` (use `frame_id = -1` for old API and what is now considered a "non"-standard product)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 * The CLI now *requires* `frame_id` (use `frame_id = -1` for old API and what is now considered a "non"-standard product)
-* Water mask now uses `tile-mate` to download and merge ESA World cover tiles on 
+* Water mask now uses `tile-mate>=0.0.8` to download and merge water mask tiles (Pekel Occurence data >= 95 is the default) 
 * All water masks applied to processing/packaging use Pekel Occurence (>= 95 percent occurence): ionosphere processing, browse imagery, and global attributes associate with mean coherence
 * Some function names associated to writing global attributes in the netcdf file were renamed to be more descriptive e.g. `record_stats` became `record_stats_as_global_attrs`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Records parameters in the product including the CLI command to regenerate said product
 * If parameters are not standard uses prefix `S1-GUNW_CUSTOM-...`
 * Pydantic dependency for parameter accounting
-* Support for python 3.10 and 3.11
+* Support for python 3.10 and 3.11 (Note: 3.12 cannot be supported due to pysolid issue: https://github.com/insarlab/PySolid/issues/78)
 
 ### Changed
 * The CLI now *requires* `frame_id` (use `frame_id = -1` for old API and what is now considered a "non"-standard product)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Records parameters in the product including the CLI command to regenerate said product
 * If parameters are not standard uses prefix `S1-GUNW_CUSTOM-...`
 * Pydantic dependency for parameter accounting
+* Support for python 3.10+
 
 ### Changed
 * The CLI now *requires* `frame_id` (use `frame_id = -1` for old API and what is now considered a "non"-standard product)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,11 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Records parameters in the product including the CLI command to regenerate said product
 * If parameters are not standard uses prefix `S1-GUNW_CUSTOM-...`
 * Pydantic dependency for parameter accounting
-* Support for python 3.10+
 
 ### Changed
 * The CLI now *requires* `frame_id` (use `frame_id = -1` for old API and what is now considered a "non"-standard product)
 * Water mask now uses `tile-mate` to download and merge ESA World cover tiles on 
-* All water masks applied to processing/packaging use ESA 10 meter world cover: ionosphere processing, browse imagery, and global attributes associate with mean coherence
+* All water masks applied to processing/packaging use Pekel Occurence (>= 95 percent occurence): ionosphere processing, browse imagery, and global attributes associate with mean coherence
 * Some function names associated to writing global attributes in the netcdf file were renamed to be more descriptive e.g. `record_stats` became `record_stats_as_global_attrs`
 
 ## [0.3.0]

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ However, the plugin takes about 1.5 to 3 hours (depending on the number of corre
 Therefore, these integration are *not* sufficient to permit a new release (see more instructions below). 
 Until we have a complete end-to-end test of the workflow (via Hyp3), any new feature cannot be integrated into official production (i.e. the `main` branch). 
 As a first step, it is imperative to share the output of a new feature (i.e. the GUNW file and the command to generate it). 
+Here is a notebook that demonstrates how to compare GUNWs that will be very helpful: https://github.com/ACCESS-Cloud-Based-InSAR/DockerizedTopsapp-Debugging-NBs/blob/dev/2_Compare_GUNWs.ipynb
 
 
 ## Hyp3 and Cloud Submission
@@ -275,9 +276,10 @@ Here are more detailed [notes](https://github.com/ACCESS-Cloud-Based-InSAR/CICD-
 
 ### Additional (manual) checks
 
-Even though there are some integration tests and unit tests in our test suites, this CPU intensive workflow cannot be tested end-to-end using github actions (there is simply not enough memory and CPU on a github runner).
+Even though there are some integration tests and unit tests in our test suites, this CPU intensive workflow cannot be tested end-to-end using github actions (there is simply not enough memory and CPU for these workflows).
 Therefore, even if all the tests pass, there is still a nontrivial chance a GUNW is not successfully generated (e.g. the `topo` step of topsapp fizzles out because `numpy` API was not successfully tracked in the latest ISCE2 release).
 We request a sample GUNW be shared in a PR.
+Ideally, a comparison of the GUNW created with a new branch and an existing one (as done in this [notebook](https://github.com/ACCESS-Cloud-Based-InSAR/DockerizedTopsapp-Debugging-NBs/blob/dev/2_Compare_GUNWs.ipynb)) is ideal.
 Even if we go through careful accounting, once a PR is merged into `dev`, we will use `hyp3` to further inspect the new plugin e.g. through this [notebook](https://github.com/ACCESS-Cloud-Based-InSAR/s1_frame_enumerator/blob/dev/notebooks/Submitting_to_Hyp3.ipynb) using a few sites.
 It is important to use `INSAR_ISCE_TEST` job to ensure the features from the `dev` branch are used.
 Only after these **manual** checks, will we continue with a release of the plugin.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,21 @@ We note all the input datasets are publicly available using a NASA Earthdata acc
 3. Create a new environment and install requirements using `conda env update --file environment.yml` (or use [`mamba`](https://github.com/mamba-org/mamba) to speed install up)
 4. Install the package from cloned repo using `python -m pip install -e .`
 
+### For Mac M1 Silicon Users
+
+`ISCE2` requires Intel `x86_64` complied, conda-forge packages. Please follow the directions [here](https://conda-forge.org/docs/user/tipsandtricks.html#installing-apple-intel-packages-on-apple-silicon) i.e.
+
+```
+CONDA_SUBDIR=osx-64 conda create -n topsapp_env python
+conda activate topsapp_env
+conda config --env --set subdir osx-64 
+```
+Then check
+```
+python -c "import platform;print(platform.machine())"  # Should print "x86_64"
+echo "CONDA_SUBDIR: $CONDA_SUBDIR"  # Should print "CONDA_SUBDIR: osx-64"
+```
+
 ## Additional setup
 
 1. Ensure that your `~/.netrc` file has:
@@ -158,7 +173,6 @@ or as a json:
 ## Expedient Docker Test for GUNW Generation
 
 Create a new directory (for all the intermediate files) and navigate to it.
-
 ```
 docker run -ti -v $PWD:/home/ops/topsapp_data topsapp_img \
                --reference-scenes S1A_IW_SLC__1SDV_20220212T222803_20220212T222830_041886_04FCA3_2B3E \
@@ -209,8 +223,8 @@ EARTHDATA_PASSWORD=...
 The main entrypoint is in the `__main__.py` file [here](https://github.com/ACCESS-Cloud-Based-InSAR/DockerizedTopsApp/blob/dev/isce2_topsapp/__main__.py).
 The whole standard `++slc` workflow that generates the `ARIA-S1-GUNW` product is summarized in this file.
 The workflow takes 1.5 - 3 hours to complete. 
-For developing a new feature, we need to modify a very small parts of this long running workflow e.g. the packaging of ISCE2 outputs into a netcdf file, staging/preparation of auxiliary data, etc.
-Thus, for development it is not necessary to rerun the workflow each time to test a new feature, but utilize the intermediate ISCE data files and fix relevant parts of the code.
+Likely, when developing a small new feature, we need to modify only of this long running workflow e.g. the packaging of ISCE2 outputs into a netcdf file, staging/preparation of auxiliary data, etc.
+Thus, for development, it is recommended to not rerun the workflow each time, but utilize the intermediate ISCE data files and the metadata stored as json by this plugin.
 We have some sample [notebooks](https://github.com/ACCESS-Cloud-Based-InSAR/DockerizedTopsapp-Debugging-NBs) to load the relevant metadata to make this "jumping" into the code slightly easier.
 We note that `ISCE2` generates *a lot* of interemdiate files.
 For our workflow, this can be between 100-150 GBs of disk required.

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: topsapp_env
 channels:
  - conda-forge
 dependencies:
- - python>=3.9,<3.10
+ - python>=3.9
  - pip
  - affine
  - asf_search>=5.0.0
@@ -17,7 +17,7 @@ dependencies:
  - geopandas
  - hyp3lib>=3,<4
  - ipykernel
- - isce2==2.6.1
+ - isce2=>2.6.3
  - jinja2
  - joblib
  - jsonschema==3.2.0

--- a/environment.yml
+++ b/environment.yml
@@ -44,4 +44,4 @@ dependencies:
  - tqdm
  - dem_stitcher>=2.5.5
  - aiohttp  # only needed for manifest and swath download
- - tile_mate>=0.0.7
+ - tile_mate>=0.0.8

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: topsapp_env
 channels:
  - conda-forge
 dependencies:
- - python>=3.9,<3.12
+ - python>=3.9,<3.10
  - pip
  - affine
  - asf_search>=5.0.0
@@ -17,7 +17,7 @@ dependencies:
  - geopandas
  - hyp3lib>=3,<4
  - ipykernel
- - isce2>=2.6.3
+ - isce2==2.6.1
  - jinja2
  - joblib
  - jsonschema==3.2.0

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: topsapp_env
 channels:
  - conda-forge
 dependencies:
- - python>=3.9
+ - python>=3.9,<3.12
  - pip
  - affine
  - asf_search>=5.0.0

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
  - geopandas
  - hyp3lib>=3,<4
  - ipykernel
- - isce2=>2.6.3
+ - isce2>=2.6.3
  - jinja2
  - joblib
  - jsonschema==3.2.0

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: topsapp_env
 channels:
  - conda-forge
 dependencies:
- - python>=3.9,<3.10
+ - python>=3.9,<3.12
  - pip
  - affine
  - asf_search>=5.0.0
@@ -17,7 +17,7 @@ dependencies:
  - geopandas
  - hyp3lib>=3,<4
  - ipykernel
- - isce2==2.6.1
+ - isce2==2.6.3
  - jinja2
  - joblib
  - jsonschema==3.2.0

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -66,7 +66,7 @@ def localize_data(
         # For ionospheric correction computation
         if water_mask_flag:
             out_water_mask = download_water_mask(
-                out_slc["extent"],  water_mask_name="esa_world_cover_2021_10m")
+                out_slc["extent"],  water_mask_name="pekel_water_occurrence_2021")
 
         out_aux_cal = download_aux_cal()
 

--- a/isce2_topsapp/localize_mask.py
+++ b/isce2_topsapp/localize_mask.py
@@ -10,7 +10,7 @@ from .localize_dem import fix_image_xml
 
 
 def download_water_mask(
-    extent: list, water_mask_name: str = "esa_world_cover_2021_10m", buffer: float = 0.1
+    extent: list, water_mask_name: str = "pekel_water_occurrence_2021", buffer: float = 0.1
 ) -> dict:
     output_dir = Path(".").absolute()
 
@@ -28,6 +28,22 @@ def download_water_mask(
         mask = (X == 80).astype(np.uint8)
         mask[mask.astype(bool)] = 255
         mask_filename = 'water_mask_derived_from_esa_world_cover_2021_10m.geo'
+
+        # Remove esa nodata, change gdal driver to ISCE, and generate VRT as in localize DEM
+        p_isce = p.copy()
+        p_isce['nodata'] = None
+        p_isce['driver'] = 'ISCE'
+
+        with rasterio.open(mask_filename, 'w', **p_isce) as ds:
+            ds.write(mask)
+
+        mask_filename = fix_image_xml(mask_filename)
+
+    elif water_mask_name == 'pekel_water_occurrence_2021':
+        X, p = get_raster_from_tiles(extent_buffered, tile_shortname='pekel_water_occurrence_2021')
+        mask = (X >= 95)
+        mask[mask.astype(bool)] = 255
+        mask_filename = 'water_mask_derived_from_pekel_water_occurrence_2021_with_at_least_95_perc_water.geo'
 
         # Remove esa nodata, change gdal driver to ISCE, and generate VRT as in localize DEM
         p_isce = p.copy()

--- a/isce2_topsapp/localize_mask.py
+++ b/isce2_topsapp/localize_mask.py
@@ -41,7 +41,7 @@ def download_water_mask(
 
     elif water_mask_name == 'pekel_water_occurrence_2021':
         X, p = get_raster_from_tiles(extent_buffered, tile_shortname='pekel_water_occurrence_2021')
-        mask = (X >= 95)
+        mask = (X >= 95).astype(np.uint8)
         mask[mask.astype(bool)] = 255
         mask_filename = 'water_mask_derived_from_pekel_water_occurrence_2021_with_at_least_95_perc_water.geo'
 

--- a/isce2_topsapp/localize_mask.py
+++ b/isce2_topsapp/localize_mask.py
@@ -40,7 +40,7 @@ def download_water_mask(
         mask_filename = fix_image_xml(mask_filename)
 
     elif water_mask_name == 'pekel_water_occurrence_2021':
-        X, p = get_raster_from_tiles(extent_buffered, tile_shortname='pekel_water_occurrence_2021')
+        X, p = get_raster_from_tiles(extent_buffered, tile_shortname='pekel_water_occ_2021')
         mask = (X >= 95).astype(np.uint8)
         mask[mask.astype(bool)] = 255
         mask_filename = 'water_mask_derived_from_pekel_water_occurrence_2021_with_at_least_95_perc_water.geo'

--- a/isce2_topsapp/packaging_utils/nc_packaging.py
+++ b/isce2_topsapp/packaging_utils/nc_packaging.py
@@ -133,7 +133,7 @@ def write_dataset(fid,data,properties_data):
     else:
 
         if isinstance(data,str):
-            dset = fid.createVariable(properties_data.name, str, ('matchup',), zlib=True)
+            dset = fid.createVariable(properties_data.name, str, ('matchup',))
             dset[0]=data
         elif isinstance(data,np.ndarray):
             # make sure the _fillvalue is formatted the same as the data_type
@@ -156,7 +156,7 @@ def write_dataset(fid,data,properties_data):
             dset[:] = data
         elif isinstance(data, collections.abc.Iterable):
             if isinstance(data[0],str):
-                dset = fid.createVariable(properties_data.name, str, ('matchup',), zlib=True)
+                dset = fid.createVariable(properties_data.name, str, ('matchup',))
                 count = 0
                 for data_line in data:
                     dset[count]=data_line

--- a/isce2_topsapp/packaging_utils/nc_packaging.py
+++ b/isce2_topsapp/packaging_utils/nc_packaging.py
@@ -133,7 +133,7 @@ def write_dataset(fid,data,properties_data):
     else:
 
         if isinstance(data,str):
-            dset = fid.createVariable(properties_data.name, str, ('matchup',))
+            dset = fid.createVariable(properties_data.name, str, ('matchup',), zlib=True)
             dset[0]=data
         elif isinstance(data,np.ndarray):
             # make sure the _fillvalue is formatted the same as the data_type
@@ -156,7 +156,7 @@ def write_dataset(fid,data,properties_data):
             dset[:] = data
         elif isinstance(data, collections.abc.Iterable):
             if isinstance(data[0],str):
-                dset = fid.createVariable(properties_data.name, str, ('matchup',))
+                dset = fid.createVariable(properties_data.name, str, ('matchup',), zlib=True)
                 count = 0
                 for data_line in data:
                     dset[count]=data_line

--- a/isce2_topsapp/water_mask.py
+++ b/isce2_topsapp/water_mask.py
@@ -21,7 +21,7 @@ def get_water_mask_raster_for_browse_image(profile: dict) -> np.ndarray:
     """
     extent = array_bounds(profile["height"], profile["width"], profile["transform"])
 
-    X_occ, p_occ = get_raster_from_tiles(extent, tile_shortname="peckel_water_occ_2021")
+    X_occ, p_occ = get_raster_from_tiles(extent, tile_shortname="pekel_water_occ_2021")
     X_occ_r, _ = reproject_arr_to_match_profile(X_occ, p_occ, profile, resampling='bilinear')
     mask = (X_occ_r >= 95).astype(bool)
     mask = mask[0, ...]

--- a/isce2_topsapp/water_mask.py
+++ b/isce2_topsapp/water_mask.py
@@ -21,8 +21,8 @@ def get_water_mask_raster_for_browse_image(profile: dict) -> np.ndarray:
     """
     extent = array_bounds(profile["height"], profile["width"], profile["transform"])
 
-    X_esa, p_esa = get_raster_from_tiles(extent, tile_shortname="esa_world_cover_2021")
-    X_esa_r, _ = reproject_arr_to_match_profile(X_esa, p_esa, profile, resampling='nearest')
-    mask = (X_esa_r == 80).astype(bool)
+    X_occ, p_occ = get_raster_from_tiles(extent, tile_shortname="peckel_water_occ_2021")
+    X_occ_r, _ = reproject_arr_to_match_profile(X_occ, p_occ, profile, resampling='bilinear')
+    mask = (X_occ_r >= 95).astype(bool)
     mask = mask[0, ...]
     return mask

--- a/setup.py
+++ b/setup.py
@@ -23,12 +23,12 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11',
     ],
 
-    python_requires='>=3.9',
+    python_requires='>=3.8',
 
     install_requires=[
         'asf_search>=3.0.4',

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'Programming Language :: Python :: 3.11',
     ],
 
-    python_requires='>=3.8',
+    python_requires='>=3.9',
 
     install_requires=[
         'asf_search>=3.0.4',

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,9 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
 
     python_requires='>=3.8',

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -66,7 +66,7 @@ def test_mean_of_geocoded_isce_outputs():
         "mean_filtered_coherence_without_water_mask": 0.4395995,
         "mean_filtered_coherence_with_water_mask": 0.4649538,
         "mean_unfiltered_coherence_without_water_mask": 0.33125195,
-        "mean_unfiltered_coherence_with_water_mask": 0.33531728,
+        "mean_unfiltered_coherence_with_water_mask": 0.3347433,
         "mean_incidence_angle": 38.845047,
         "mean_azimuth_angle": -169.84756469726562,
     }


### PR DESCRIPTION
Use the latest release of ISCE2 and allow for environments with python 3.9 - 3.11 (inclusive) in order to help make package management slightly easier in the long run. EOL for a python version is scheduled for 5 years after its initial [release](https://endoflife.date/python).

**Note**: when I resolve the environment on a linux machine, python 3.11 is used.

Pysolid does not yet support 3.12  ([issue ticket](https://github.com/insarlab/PySolid/issues/78)). Below is the the command line output trying to resolve the environment with python 3.12:
```
create env topsapp_env
  /home/runner/micromamba-bin/micromamba create -n topsapp_env -y --log-level warning python=3.12 -f /home/runner/work/DockerizedTopsApp/DockerizedTopsApp/environment.yml
  error    libmamba Could not solve for environment specs
      The following packages are incompatible
      ├─ pysolid is installable with the potential options
      │  ├─ pysolid 0.1.2 would require
      │  │  └─ python_abi 3.6.* *_cp36m, which can be installed;
      │  ├─ pysolid [0.1.2|0.2.0|0.2.1|0.2.2|0.2.3] would require
      │  │  └─ python_abi 3.7.* *_cp37m, which can be installed;
      │  ├─ pysolid [0.1.2|0.2.0|...|0.3.2] would require
      │  │  └─ python_abi 3.8.* *_cp38, which can be installed;
      │  ├─ pysolid [0.1.2|0.2.0|...|0.3.2] would require
      │  │  └─ python_abi 3.9.* *_cp39, which can be installed;
      │  ├─ pysolid [0.2.1|0.2.2|...|0.3.2] would require
      │  │  └─ python_abi 3.10.* *_cp310, which can be installed;
      │  ├─ pysolid [0.2.2|0.2.3] would require
      │  │  └─ python_abi 3.8 *_pypy38_pp73, which can be installed;
      │  ├─ pysolid [0.2.2|0.2.3] would require
      │  │  └─ python_abi 3.9 *_pypy39_pp73, which can be installed;
      │  ├─ pysolid [0.2.3|0.3.0|0.3.1|0.3.2] would require
      │  │  └─ python_abi 3.11.* *_cp311, which can be installed;
      │  ├─ pysolid [0.3.0|0.3.1] would require
      │  │  └─ pypy3.8 >=7.3.11 , which can be installed;
      │  ├─ pysolid [0.3.0|0.3.1] would require
      │  │  └─ pypy3.9 >=7.3.11 , which can be installed;
      │  └─ pysolid 0.3.2 would require
      │     └─ pypy3.9 >=7.3.13 , which can be installed;
      └─ python 3.12**  is not installable because there are no viable options
         ├─ python [3.12.0|3.12.1] would require
         │  └─ python_abi 3.12.* *_cp312, which conflicts with any installable versions previously reported;
         └─ python 3.12.0rc3 would require
            └─ _python_rc, which does not exist (perhaps a missing channel).
  critical libmamba Could not solve for environment specs
  Error: Failed to execute ["/home/runner/micromamba-bin/micromamba create -n topsapp_env -y --log-level warning \"python=3.12\" -f /home/runner/work/DockerizedTopsApp/DockerizedTopsApp/environment.yml"]: Error: The process '/home/runner/micromamba-bin/micromamba' failed with exit code 1
  /home/runner/work/_actions/mamba-org/provision-with-micromamba/v15/dist/main/index.js:[66](https://github.com/ACCESS-Cloud-Based-InSAR/DockerizedTopsApp/actions/runs/7745636931/job/21122092723#step:4:68)[69](https://github.com/ACCESS-Cloud-Based-InSAR/DockerizedTopsApp/actions/runs/7745636931/job/21122092723#step:4:71)3
```