### PR TITLE
Update dataset version to 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 * ISCE2 shenanigans (PYTHON_PATH, PATH, and logging changes) are now handled in the `isce2_topsapp.__init__` ensuring we only have to do it once, no matter where we are in the package.
+* Update dataset version from `3.0.0` -> `3.0.1` to track products over areas processed during development of v3 product. In other words, large scale processing was done during v3 development but not all v3 products will be delivered to DAAC - we have standardized numerous attributes and layers. Utlimately, 3.0.0 and 3.0.1 at the DAAC will represent the v3 products created by this repository.
 
 ### Fixed
 * The root logger is no longer set to DEBUG by ISCE2 preventing excessive logging from all packages in the environment

--- a/isce2_topsapp/packaging.py
+++ b/isce2_topsapp/packaging.py
@@ -21,7 +21,7 @@ from isce2_topsapp.packaging_utils.ionosphere import (
 from isce2_topsapp.templates import read_netcdf_packaging_template
 from isce2_topsapp.water_mask import get_water_mask_raster_for_browse_image
 
-DATASET_VERSION = "3.0.0"
+DATASET_VERSION = "3.0.1"
 STANDARD_PROD_PREFIX = "S1-GUNW"
 CUSTOM_PROD_PREFIX = "S1-GUNW_CUSTOM"
 


### PR DESCRIPTION
* Update dataset version from `3.0.0` -> `3.0.1` to track products over areas processed during development of v3 product. In other words, large scale processing was done during v3 development but not all v3 products will be delivered to DAAC - we have standardized numerous attributes and layers.