### PR TITLE
v0.3.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,11 +12,11 @@ on:
 
 jobs:
   call-version-info-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.11.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.11.1
 
   call-docker-ghcr-workflow:
     needs: call-version-info-workflow
-    uses: ASFHyP3/actions/.github/workflows/reusable-docker-ghcr.yml@v0.11.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-docker-ghcr.yml@v0.11.1
     with:
       version_tag: ${{ needs.call-version-info-workflow.outputs.version_tag }}
       release_branch: main

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,6 +13,4 @@ on:
 
 jobs:
   call-changelog-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.11.0
-    secrets:
-      USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.11.1

--- a/.github/workflows/labeled-pr.yml
+++ b/.github/workflows/labeled-pr.yml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   call-labeled-pr-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@v0.11.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@v0.11.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-release-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.11.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.11.1
     with:
       release_prefix: DockerizedTopsApp
       develop_branch: dev

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -4,10 +4,10 @@ on: push
 
 jobs:
   call-flake8-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-flake8.yml@v0.11.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-flake8.yml@v0.11.1
     with:
       local_package_names: isce2_topsapp
       excludes: isce2_topsapp/packaging_utils/
 
   call-secrets-analysis-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.11.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.11.1

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-bump-version-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.11.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.11.1
     with:
       user: access-cloud-insar-team
       email: access-cloud-insar-team@jpl.nasa.gov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.6]
+
+* Updates dem-stitcher to 2.5.6 to which updated to a new url for reading the Geoid EGM 2008.
+
 ## [0.3.5]
 
 ### Added

--- a/environment.yml
+++ b/environment.yml
@@ -43,6 +43,6 @@ dependencies:
  - setuptools_scm
  - shapely
  - tqdm
- - dem_stitcher>=2.5.5
+ - dem_stitcher>=2.5.6
  - aiohttp  # only needed for manifest and swath download
  - tile_mate>=0.0.8


### PR DESCRIPTION
* Ensures dem-stitcher to be >= v2.5.6, which updates the url for reading the Geoid EGM 2008.