### PR TITLE
Update environment.yml for geoid update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   call-version-info-workflow:
     uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.11.2
+    with:
+      python_version: '3.10'
+      conda_env_name: topsapp_env
 
   call-docker-ghcr-workflow:
     needs: call-version-info-workflow

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
   call-version-info-workflow:
     uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.11.2
     with:
-      python_version: '3.10'
+      python_version: '3.9'
       conda_env_name: topsapp_env
 
   call-docker-ghcr-workflow:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.3.6]
 
-* Updates dem-stitcher to 2.5.6 to which updated to a new url for reading the Geoid EGM 2008.
+* Updates dem-stitcher to 2.5.6 to which updated to a new url for reading the Geoid EGM 2008. See this [issue](https://github.com/ACCESS-Cloud-Based-InSAR/dem-stitcher/issues/96).
 
 ## [0.3.5]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.3.7]
-* Updates dem-stitcher to 2.5.8 to which updated to a new url for reading the Geoid EGM 2008.
+* Updates dem-stitcher to 2.5.8 to ensure new (ARIA-managed) url for reading the Geoid EGM 2008.
 
 ## [0.3.6]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [0.3.7]
+* Updates dem-stitcher to 2.5.8 to which updated to a new url for reading the Geoid EGM 2008.
 
 ## [0.3.6]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.3.7]
-* Updates dem-stitcher to 2.5.8 to ensure new (ARIA-managed) url for reading the Geoid EGM 2008.
+* Updates dem-stitcher to 2.5.8 to ensure new (ARIA-managed) url for reading the Geoid EGM 2008. See this [issue](https://github.com/ACCESS-Cloud-Based-InSAR/dem-stitcher/issues/96).
 
 ## [0.3.6]
 

--- a/environment.yml
+++ b/environment.yml
@@ -43,6 +43,6 @@ dependencies:
  - setuptools_scm
  - shapely
  - tqdm
- - dem_stitcher>=2.5.6
+ - dem_stitcher>=2.5.8
  - aiohttp  # only needed for manifest and swath download
  - tile_mate>=0.0.8


### PR DESCRIPTION
Dem-stitcher's geoid urls became inactive this morning and needed to be changed.

See https://github.com/ACCESS-Cloud-Based-InSAR/dem-stitcher/issues/96