### PR TITLE
Adopt s1-orbits and remove esa credentials/hyp3lib 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 * Aux cal files are now distributed from new locations and have nesting that must be removed. (See [PR](https://github.com/ASFHyP3/hyp3-isce2/pull/265/) from hyp3-isce2)
 
->>>>>>> dev
 
 ## [0.3.7]
 * Updates dem-stitcher to 2.5.8 to ensure new (ARIA-managed) url for reading the Geoid EGM 2008. See this [issue](https://github.com/ACCESS-Cloud-Based-InSAR/dem-stitcher/issues/96).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.4.0]
+
+### Changed
+* Use `s1_orbits` rather than `hyp3lib` to download Sentinel-1 orbits files in `localize_orbits.download_orbits`
+
+### Removed
+* ESA username/password requirement; these credentials are no longer needed to download Sentinel-1 orbit files.
+
 ## [0.3.7]
 * Updates dem-stitcher to 2.5.8 to ensure new (ARIA-managed) url for reading the Geoid EGM 2008. See this [issue](https://github.com/ACCESS-Cloud-Based-InSAR/dem-stitcher/issues/96).
 * Ensure version/docker build use python 3 as done here: https://github.com/dbekaert/RAiDER/blob/32697d2e4e6908b8feb3b81a1df30cb5f4e49a24/.github/workflows/build.yml#L16-L17

--- a/README.md
+++ b/README.md
@@ -45,12 +45,8 @@ echo "CONDA_SUBDIR: $CONDA_SUBDIR"  # Should print "CONDA_SUBDIR: osx-64"
     machine urs.earthdata.nasa.gov
         login <username>
         password <password>
-
-    machine dataspace.copernicus.eu
-        login <username>
-        password <password>
     ```
-    The first `username`/`password` pair are the appropriate Earthdata Login credentials that are used to access NASA data. The second pair are your credentials for the [Copernicus Data Space Ecosystem](https://dataspace.copernicus.eu). This file is necessary for downloading the Sentinel-1 files, and auxiliary data. Additionally, the [`requests`](https://docs.python-requests.org/en/latest/) library automatically uses credentials stored in the `~/.netrc` for authentification when none are supplied.
+    The `username`/`password` pair are the appropriate Earthdata Login credentials that are used to access NASA data. This file is necessary for downloading the Sentinel-1 files, and auxiliary data. Additionally, the [`requests`](https://docs.python-requests.org/en/latest/) library automatically uses credentials stored in the `~/.netrc` for authentification when none are supplied.
 
 ## Generate an ARIA-S1-GUNW
 

--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,7 @@ dependencies:
  - fsspec
  - gdal
  - geopandas
- - hyp3lib>=3,<4
+ - s1_orbits
  - ipykernel
  - isce2==2.6.1
  - jinja2

--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,6 @@ dependencies:
  - fsspec
  - gdal
  - geopandas
- - s1_orbits
  - ipykernel
  - isce2==2.6.1
  - jinja2
@@ -46,3 +45,4 @@ dependencies:
  - dem_stitcher>=2.5.8
  - aiohttp  # only needed for manifest and swath download
  - tile_mate>=0.0.8
+ - s1_orbits

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -6,7 +6,6 @@ import sys
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, Namespace
 from importlib.metadata import entry_points
 from pathlib import Path
-from platform import system
 from typing import Optional
 
 from isce2_topsapp import (BurstParams,
@@ -30,9 +29,6 @@ from isce2_topsapp.packaging import update_gunw_internal_version_attribute
 from isce2_topsapp.solid_earth_tides import update_gunw_with_solid_earth_tide
 
 
-ESA_HOST = 'dataspace.copernicus.eu'
-
-
 def localize_data(
     reference_scenes: list,
     secondary_scenes: list,
@@ -53,8 +49,7 @@ def localize_data(
         reference_scenes, secondary_scenes, frame_id=frame_id, dry_run=dry_run
     )
 
-    out_orbits = download_orbits(
-        reference_scenes, secondary_scenes, dry_run=dry_run)
+    out_orbits = download_orbits(reference_scenes, secondary_scenes)
 
     out_dem = {}
     out_aux_cal = {}
@@ -117,35 +112,6 @@ def ensure_earthdata_credentials(
         )
 
 
-def check_esa_credentials(username: Optional[str], password: Optional[str]) -> None:
-    netrc_name = '_netrc' if system().lower() == 'windows' else '.netrc'
-    netrc_file = Path.home() / netrc_name
-
-    if (username is not None) != (password is not None):
-        raise ValueError('Both username and password arguments must be provided')
-
-    if username is not None:
-        os.environ["ESA_USERNAME"] = username
-        os.environ["ESA_PASSWORD"] = password
-        return
-
-    if "ESA_USERNAME" in os.environ and "ESA_PASSWORD" in os.environ:
-        return
-
-    if netrc_file.exists():
-        netrc_credentials = netrc.netrc(netrc_file)
-        if ESA_HOST in netrc_credentials.hosts:
-            os.environ["ESA_USERNAME"] = netrc_credentials.hosts[ESA_HOST][0]
-            os.environ["ESA_PASSWORD"] = netrc_credentials.hosts[ESA_HOST][2]
-            return
-
-    raise ValueError(
-        "Please provide Copernicus Data Space Ecosystem (CDSE) credentials via the "
-        "--esa-username and --esa-password options, "
-        "the ESA_USERNAME and ESA_PASSWORD environment variables, or your netrc file."
-    )
-
-
 def true_false_string_argument(s: str) -> bool:
     s = s.lower()
     if s not in ("true", "false"):
@@ -190,8 +156,6 @@ def get_slc_parser():
     parser.add_argument('--dense-offsets', type=true_false_string_argument, default=False)
     parser.add_argument('--goldstein-filter-power', type=float, default=.5,
                         help="The power applied to the patch FFT of the phase filter")
-    parser.add_argument("--esa-username", help='Username (i.e. email) for "https://dataspace.copernicus.eu/"')
-    parser.add_argument("--esa-password", help='Password for "https://dataspace.copernicus.eu/"')
     return parser
 
 
@@ -221,7 +185,6 @@ def gunw_slc():
 
     # Validation
     ensure_earthdata_credentials(args.username, args.password)
-    check_esa_credentials(args.esa_username, args.esa_password)
     cli_params = vars(args).copy()
     [cli_params.pop(key) for key in ['username', 'password', 'bucket', 'bucket_prefix', 'dry_run']]
     topsapp_params_obj = topsappParams(**cli_params)
@@ -331,8 +294,6 @@ def gunw_burst():
     parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
     parser.add_argument("--username")
     parser.add_argument("--password")
-    parser.add_argument("--esa-username")
-    parser.add_argument("--esa-password")
     parser.add_argument("--bucket")
     parser.add_argument("--bucket-prefix", default="")
     parser.add_argument("--dry-run", action="store_true")
@@ -348,7 +309,6 @@ def gunw_burst():
     args = parser.parse_args()
 
     ensure_earthdata_credentials(args.username, args.password)
-    check_esa_credentials(args.esa_username, args.esa_password)
 
     ref_obj, sec_obj = get_asf_slc_objects(
         [args.reference_scene, args.secondary_scene])
@@ -372,9 +332,7 @@ def gunw_burst():
         ref_burst.footprint, sec_burst.footprint, is_ascending=is_ascending
     )
 
-    orbits = download_orbits(
-        [ref_burst.safe_name[:-5]], [sec_burst.safe_name[:-5]], dry_run=args.dry_run
-    )
+    orbits = download_orbits([ref_burst.safe_name[:-5]], [sec_burst.safe_name[:-5]])
 
     if not args.dry_run:
         # TODO this is likely not the optimal geometry to pass to this function

--- a/isce2_topsapp/localize_orbits.py
+++ b/isce2_topsapp/localize_orbits.py
@@ -1,51 +1,20 @@
-import os
 from pathlib import Path
 
-import requests
-from hyp3lib import get_orb
-
-
-def _spoof_orbit_download(
-    scene, _, providers=('ESA', 'ASF'), orbit_types=('AUX_POEORB', 'AUX_RESORB'), esa_credentials=('name', 'password')
-):
-    for orbit_type in orbit_types:
-        for provider in providers:
-            try:
-                orbit_url = get_orb.get_orbit_url(scene, orbit_type=orbit_type, provider=provider)
-            except requests.RequestException:
-                continue
-
-            if orbit_url is not None:
-                return orbit_url, None
-    return None, None
+from s1_orbits import fetch_for_scene
 
 
 def download_orbits(
-    reference_scenes: list, secondary_scenes: list, orbit_directory: str = None, dry_run: bool = False
+    reference_scenes: list, secondary_scenes: list, orbit_directory: str = 'orbits'
 ) -> dict:
-    esa_credentials = (os.environ['ESA_USERNAME'], os.environ['ESA_PASSWORD'])
 
-    orbit_directory = orbit_directory or 'orbits'
     orbit_dir = Path(orbit_directory)
     orbit_dir.mkdir(exist_ok=True)
 
-    orbit_fetcher = _spoof_orbit_download if dry_run else get_orb.downloadSentinelOrbitFile
-
-    reference_orbits = []
-    for scene in reference_scenes:
-        orbit_file, _ = orbit_fetcher(scene, str(orbit_dir), esa_credentials=esa_credentials, providers=('ASF', 'ESA'))
-        reference_orbits.append(orbit_file)
-
-    secondary_orbits = []
-    for scene in secondary_scenes:
-        orbit_file, _ = orbit_fetcher(scene, str(orbit_dir), esa_credentials=esa_credentials, providers=('ASF', 'ESA'))
-        secondary_orbits.append(orbit_file)
-
-    reference_orbits = list(set(reference_orbits))
-    secondary_orbits = list(set(secondary_orbits))
+    reference_orbits = {str(fetch_for_scene(scene, orbit_dir)) for scene in reference_scenes}
+    secondary_orbits = {str(fetch_for_scene(scene, orbit_dir)) for scene in secondary_scenes}
 
     return {
         'orbit_directory': orbit_directory,
-        'reference_orbits': reference_orbits,
-        'secondary_orbits': secondary_orbits,
+        'reference_orbits': list(reference_orbits),
+        'secondary_orbits': list(secondary_orbits),
     }

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'dateparser',
         'dem_stitcher>=2.1',
         'geopandas',
-        'hyp3lib>=3,<4',
+        's1_orbits',
         'jinja2',
         'lxml',
         'matplotlib',

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -3,8 +3,6 @@ import os
 import pytest
 
 from isce2_topsapp.__main__ import (
-    ESA_HOST,
-    check_esa_credentials,
     ensure_earthdata_credentials,
     esd_threshold_argument,
     true_false_string_argument,
@@ -79,65 +77,6 @@ def test_main_check_earthdata_credentials_env_variables(tmp_path, monkeypatch):
 
     ensure_earthdata_credentials(None, 'baz', host='foobar.nasa.gov')
     assert netrc.read_text() == 'machine foobar.nasa.gov login fizz password baz'
-
-
-def test_check_esa_credentials_params(tmp_path, monkeypatch):
-    with monkeypatch.context() as m:
-        m.setenv('ESA_USERNAME', 'env_username')
-        m.setenv('ESA_PASSWORD', 'env_password')
-        m.setenv('HOME', str(tmp_path))
-        (tmp_path / '.netrc').write_text(f'machine {ESA_HOST} login netrc_username password netrc_password')
-
-        check_esa_credentials('foo', 'bar')
-
-        assert os.environ['ESA_USERNAME'] == 'foo'
-        assert os.environ['ESA_PASSWORD'] == 'bar'
-
-
-def test_check_esa_credentials_env(tmp_path, monkeypatch):
-    with monkeypatch.context() as m:
-        m.setenv('ESA_USERNAME', 'foo')
-        m.setenv('ESA_PASSWORD', 'bar')
-        m.setenv('HOME', str(tmp_path))
-        (tmp_path / '.netrc').write_text(f'machine {ESA_HOST} login netrc_username password netrc_password')
-
-        check_esa_credentials(None, None)
-
-        assert os.environ['ESA_USERNAME'] == 'foo'
-        assert os.environ['ESA_PASSWORD'] == 'bar'
-
-
-def test_check_esa_credentials_netrc(tmp_path, monkeypatch):
-    with monkeypatch.context() as m:
-        m.delenv('ESA_USERNAME', raising=False)
-        m.delenv('ESA_PASSWORD', raising=False)
-        m.setenv('HOME', str(tmp_path))
-        (tmp_path / '.netrc').write_text(f'machine {ESA_HOST} login foo password bar')
-
-        check_esa_credentials(None, None)
-
-        assert os.environ['ESA_USERNAME'] == 'foo'
-        assert os.environ['ESA_PASSWORD'] == 'bar'
-
-
-def test_check_esa_credentials_missing(tmp_path, monkeypatch):
-    with monkeypatch.context() as m:
-        m.delenv('ESA_USERNAME', raising=False)
-        m.setenv('ESA_PASSWORD', 'env_password')
-        m.setenv('HOME', str(tmp_path))
-        (tmp_path / '.netrc').write_text('')
-        msg = 'Please provide.*'
-        with pytest.raises(ValueError, match=msg):
-            check_esa_credentials(None, None)
-
-    with monkeypatch.context() as m:
-        m.setenv('ESA_USERNAME', 'env_username')
-        m.delenv('ESA_PASSWORD', raising=False)
-        m.setenv('HOME', str(tmp_path))
-        (tmp_path / '.netrc').write_text('')
-        msg = 'Please provide.*'
-        with pytest.raises(ValueError, match=msg):
-            check_esa_credentials(None, None)
 
 
 def test_true_false_string_argument():

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -18,8 +18,6 @@ def test_notebooks(notebook_name, monkeypatch):
 
     out_notebook = out_dir / f'{notebook_name}'
 
-    monkeypatch.setenv('ESA_USERNAME', 'foo')
-    monkeypatch.setenv('ESA_PASSWORD', 'bar')
     pm.execute_notebook(test_dir / f'{notebook_name}',
                         output_path=out_notebook
                         )

--- a/tests/test_set.py
+++ b/tests/test_set.py
@@ -159,7 +159,7 @@ def test_magnitude_of_set_with_variable_timing(acq_type: str, orbit_files_for_se
     with xr.open_dataset(gunw_path_for_set_2, group=group) as ds:
         slc_id = ds['L1InputGranules'].values[0]
 
-    orb_file, _ = get_orb.downloadSentinelOrbitFile(slc_id, esa_credentials=('username', 'password'))
+    orb_file = s1_orbits.fetch_for_scene(slc_id)
     ```
     """
     for gunw_path_for_set, orbit_dict in zip(gunw_paths_for_set, orbit_files_for_set):


### PR DESCRIPTION
Here's a more thorough orbit cleanup to consider. Using the s1-orbits package means hyp3lib is not longer needed as a dependency, and the esa username/password parameters are no longer required as inputs.

I don't fully appreciate the `dry_run` parameter; is it important that no orbit files be downloaded to disk when doing a dry run?

The test notebooks include code/instructions for setting up esa credentials and downloading orbits that still deserve to be updated. I'm opening the PR because I've been noodling on it today, but I'm not committed to doing the remaining work.