### PR TITLE
implement minimum frame coverage requirement

### DIFF
--- a/isce2_topsapp/localize_slc.py
+++ b/isce2_topsapp/localize_slc.py
@@ -57,7 +57,7 @@ def get_session():
 
 
 def get_interferogram_geo(
-    reference_obs: list, secondary_obs: list, frame_id: int = -1
+    reference_obs: list, secondary_obs: list, frame_id: int = -1, min_frame_coverage: float = 0.95,
 ) -> GeometryCollection:
     reference_geos = [shape(r.geojson()["geometry"]) for r in reference_obs]
     secondary_geos = [shape(r.geojson()["geometry"]) for r in secondary_obs]
@@ -70,10 +70,7 @@ def get_interferogram_geo(
     connected_sec = secondary_geo.geom_type == "Polygon"
 
     if (not connected_sec) or (not connected_ref):
-        raise ValueError(
-            "Reference and/or secondary dates were not connected"
-            " in their coverage (multipolygons)"
-        )
+        raise ValueError("Reference and/or secondary dates were not connected in their coverage (multipolygons)")
 
     # Two geometries must intersect for their to be an interferogram
     ifg_geo = secondary_geo.intersection(reference_geo)
@@ -83,9 +80,10 @@ def get_interferogram_geo(
     # Update the area of interest based on frame_id
     if frame_id != -1:
         gunw_geo = get_gunw_extent_from_frame_id(frame_id)
-        if not gunw_geo.intersects(ifg_geo):
+        frame_coverage = gunw_geo.intersection(ifg_geo).area / gunw_geo.area
+        if frame_coverage < min_frame_coverage:
             raise ValueError(
-                "Frame area does not overlap with IFG area (i.e. ref and sec overlap)"
+                f"IFG area (i.e. ref and sec overlap) covers less than {min_frame_coverage*100}% of Frame area"
             )
         ifg_geo = gunw_geo
     return ifg_geo

--- a/tests/test_localize_slc.py
+++ b/tests/test_localize_slc.py
@@ -17,7 +17,7 @@ def test_intersection_geometry():
     ref_ob = get_asf_slc_objects(ref_ids)
     sec_ob = get_asf_slc_objects(sec_ids)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r'The overlap between reference and secondary scenes is empty'):
         get_interferogram_geo(ref_ob, sec_ob)
 
     # Disconnected Secondary
@@ -28,7 +28,7 @@ def test_intersection_geometry():
     ref_ob = get_asf_slc_objects(ref_ids)
     sec_ob = get_asf_slc_objects(sec_ids)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r'Reference and/or secondary dates were not connected in their coverage'):
         get_interferogram_geo(ref_ob, sec_ob)
 
 
@@ -112,8 +112,9 @@ def test_bad_frame_with_intersection():
     ref_ob = get_asf_slc_objects(ref_ids)
     sec_ob = get_asf_slc_objects(sec_ids)
 
-    with pytest.raises(ValueError):
-        get_interferogram_geo(ref_ob, sec_ob, frame_id=frame_id)
+    get_interferogram_geo(ref_ob, sec_ob, frame_id=frame_id, min_frame_coverage=0.0)
+    with pytest.raises(ValueError, match=r'IFG area \(i.e. ref and sec overlap\) covers less than 10.0% of Frame area'):
+        get_interferogram_geo(ref_ob, sec_ob, frame_id=frame_id, min_frame_coverage=0.1)
 
 
 reference_list = [


### PR DESCRIPTION
@mgovorcin this implements the 95% coverage requirement from your draft PR. 95% coverage seems like a steep requirement, though. As noted in https://github.com/ACCESS-Cloud-Based-InSAR/s1_frame_enumerator?tab=readme-ov-file#subtlties-of-creating-an-image-stack this would make it impossible to generate GUNW products over some areas such as the alleutian islands.

Does the ARIA team vary your coverage requirement depending on your area of interest? Do we need to leave the ARIA team the ability to dictate the minimum overlap required for their jobs, while restricting public on-demand users to a specific minimum overlap?