### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0]
+
+### Added
+* `isce2_topsapp.__main__.gunw_slc` now accepts `--reference-date` and `--secondary-date` parameters as alternatives to
+  `--reference-scenes` and `--secondary-scenes`. When provided, `gunw_slc` will process all Sentinel-1 IW SLC scenes for
+  the given date and `--frame-id` in order to generate an ARIA_S1_GUNW product.
+
 ## [0.5.0]
 
 ### Added

--- a/environment.yml
+++ b/environment.yml
@@ -36,6 +36,7 @@ dependencies:
  - pytest-cov
  - pytest-mock
  - rasterio
+ - requests
  - rioxarray<0.14.0
  - xarray
  - scipy<1.10

--- a/isce2_topsapp/__init__.py
+++ b/isce2_topsapp/__init__.py
@@ -37,7 +37,7 @@ from isce2_topsapp.localize_burst import (  # noqa: E402
 from isce2_topsapp.localize_dem import download_dem_for_isce2  # noqa: E402
 from isce2_topsapp.localize_mask import download_water_mask  # noqa: E402
 from isce2_topsapp.localize_orbits import download_orbits  # noqa: E402
-from isce2_topsapp.localize_slc import download_slcs, get_asf_slc_objects  # noqa: E402
+from isce2_topsapp.localize_slc import download_slcs, get_asf_slc_objects, get_slcs_for_date_and_frame  # noqa: E402
 from isce2_topsapp.packaging import package_gunw_product  # noqa: E402
 from isce2_topsapp.topsapp_params import topsappParams  # noqa: E402
 from isce2_topsapp.topsapp_proc import topsapp_processing  # noqa: E402
@@ -68,6 +68,7 @@ __all__ = [
     "download_slcs",
     "get_asf_slc_objects",
     "get_region_of_interest",
+    "get_slcs_for_date_and_frame",
     "download_dem_for_isce2",
     "download_water_mask",
     "download_aux_cal",

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -4,6 +4,7 @@ import netrc
 import os
 import sys
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, Namespace
+from datetime import date
 from importlib.metadata import entry_points
 from pathlib import Path
 from typing import Optional
@@ -18,6 +19,7 @@ from isce2_topsapp import (BurstParams,
                            download_water_mask,
                            get_asf_slc_objects,
                            get_region_of_interest,
+                           get_slcs_for_date_and_frame,
                            package_gunw_product,
                            prepare_for_delivery,
                            topsappParams,
@@ -144,16 +146,20 @@ def get_slc_parser():
     parser.add_argument('--bucket')
     parser.add_argument('--bucket-prefix', default='')
     parser.add_argument('--dry-run', action='store_true')
-    parser.add_argument('--reference-scenes', type=str.split, nargs='+', required=True)
-    parser.add_argument('--secondary-scenes', type=str.split, nargs='+', required=True)
+    reference_group = parser.add_mutually_exclusive_group(required=True)
+    reference_group.add_argument('--reference-scenes', type=str.split, nargs='+')
+    reference_group.add_argument('--reference-date', type=date.fromisoformat)
+    secondary_group = parser.add_mutually_exclusive_group(required=True)
+    secondary_group.add_argument('--secondary-scenes', type=str.split, nargs='+')
+    secondary_group.add_argument('--secondary-date', type=date.fromisoformat)
     parser.add_argument('--estimate-ionosphere-delay', type=true_false_string_argument, default=True)
     parser.add_argument('--frame-id', type=int, default=-1, required=True,
                         help=('If -1 is specified, no frame is used and a non-standard product generated. '
                               'See examples in repository. For generating SLC pairs and a fixed frame, see:'
                               'https://github.com/ACCESS-Cloud-Based-InSAR/s1-frame-enumerator'))
     parser.add_argument('--min-frame-coverage', type=float, default=MIN_FRAME_COVERAGE_DEFAULT,
-                        help=('Minimum amount of the frame that must be covered by the overlap '
-                              'between the reference and secondary granules.'))
+                        help=('Minimum amount of the frame that must be covered by the overlap of the reference '
+                              'and secondary granules. Values should be between 0.0 and 1.0, inclusive.'))
     parser.add_argument('--compute-solid-earth-tide', type=true_false_string_argument, default=True)
     parser.add_argument('--esd-coherence-threshold', type=float, default=-1.)
     parser.add_argument('--output-resolution', type=int, default=90, required=False)
@@ -165,13 +171,21 @@ def get_slc_parser():
 
 
 def update_slc_namespace(args: Namespace) -> Namespace:
+    if args.reference_date:
+        args.reference_scenes = get_slcs_for_date_and_frame(args.reference_date, args.frame_id)
+        print(f'Found reference scenes {args.reference_scenes}')
+    else:
+        args.reference_scenes = [
+            item for sublist in args.reference_scenes for item in sublist
+        ]
 
-    args.reference_scenes = [
-        item for sublist in args.reference_scenes for item in sublist
-    ]
-    args.secondary_scenes = [
-        item for sublist in args.secondary_scenes for item in sublist
-    ]
+    if args.secondary_date:
+        args.secondary_scenes = get_slcs_for_date_and_frame(args.secondary_date, args.frame_id)
+        print(f'Found secondary scenes {args.secondary_scenes}')
+    else:
+        args.secondary_scenes = [
+            item for sublist in args.secondary_scenes for item in sublist
+        ]
 
     args.esd_coherence_threshold = esd_threshold_argument(args.esd_coherence_threshold)
 

--- a/isce2_topsapp/localize_slc.py
+++ b/isce2_topsapp/localize_slc.py
@@ -1,3 +1,4 @@
+import datetime
 import netrc
 from concurrent.futures import ThreadPoolExecutor
 from functools import lru_cache
@@ -22,16 +23,6 @@ def get_gunw_extent_from_frame_id(frame_id) -> Polygon:
     df_gunw = df_gunw_extent[ind].reset_index(drop=True)
     gunw_geo = df_gunw.geometry[0]
     return gunw_geo
-
-
-def get_processing_geo_from_frame_id(frame_id: int) -> Polygon:
-    data_dir = Path(__file__).parent / "data"
-    path_to_frames_zip = data_dir / "s1_frames_latitude_aligned.geojson.zip"
-    df_frames = gpd.read_file(path_to_frames_zip)
-    ind = df_frames.frame_id == frame_id
-    df_frame = df_frames[ind].reset_index(drop=True)
-    processing_geo = df_frame.geometry[0]
-    return processing_geo
 
 
 def get_asf_slc_objects(slc_ids: list) -> list:
@@ -88,7 +79,8 @@ def get_interferogram_geo(
         frame_coverage = gunw_geo.intersection(ifg_geo).area / gunw_geo.area
         if frame_coverage < min_frame_coverage:
             raise ValueError(
-                f"IFG area (i.e. ref and sec overlap) covers less than {min_frame_coverage*100}% of Frame area"
+                f"IFG area (i.e. ref and sec overlap) covers only {frame_coverage*100:.2f}% of Frame area; "
+                f"the requested minimum coverage was {min_frame_coverage*100:.2f}%."
             )
         ifg_geo = gunw_geo
     return ifg_geo
@@ -211,7 +203,7 @@ def download_slcs(
 
     processing_geo = ifg_geo
     if frame_id != -1:
-        processing_geo = get_processing_geo_from_frame_id(frame_id)
+        processing_geo = _get_frame_by_id(frame_id).geometry
 
     all_obs = reference_obs + secondary_obs
     n = len(all_obs)
@@ -238,3 +230,33 @@ def download_slcs(
         "reference_properties": reference_props,
         "secondary_properties": secondary_props,
     }
+
+
+def _get_frame_by_id(frame_id: int) -> gpd.GeoSeries:
+    frames = gpd.read_file(Path(__file__).parent / 'data' / 's1_frames_latitude_aligned.geojson.zip')
+    return frames[frames.frame_id == frame_id].reset_index(drop=True).iloc[0]
+
+
+def _get_dates(product: asf.ASFProduct) -> set[datetime.date]:
+    date_strings = [product.properties[field].strip('Z') for field in ['startTime', 'stopTime']]
+    return {datetime.datetime.fromisoformat(date_string).date() for date_string in date_strings}
+
+
+def get_slcs_for_date_and_frame(date: datetime.date, frame_id: int) -> list[str]:
+    frame = _get_frame_by_id(frame_id)
+    date_as_datetime = datetime.datetime(year=date.year, month=date.month, day=date.day)
+    results = asf.search(
+        dataset=asf.constants.DATASET.SENTINEL1,
+        processingLevel=asf.constants.PRODUCT_TYPE.SLC,
+        beamMode=asf.constants.BEAMMODE.IW,
+        polarization=[asf.constants.POLARIZATION.VV, asf.constants.POLARIZATION.VV_VH],
+        flightDirection=frame.orbit_direction,
+        relativeOrbit=list({frame.relative_orbit_number_min, frame.relative_orbit_number_max}),
+        intersectsWith=frame.geometry.wkt,
+        start=date_as_datetime - datetime.timedelta(minutes=5),
+        end=date_as_datetime + datetime.timedelta(days=1, minutes=5),
+    )
+    if not any(product_date == date for product in results for product_date in _get_dates(product)):
+        raise ValueError(f'No Sentinel-1 SLCs found for date {date} and frame id {frame_id}.')
+
+    return [result.properties['sceneName'] for result in results]

--- a/isce2_topsapp/localize_slc.py
+++ b/isce2_topsapp/localize_slc.py
@@ -247,6 +247,7 @@ def get_slcs_for_date_and_frame(date: datetime.date, frame_id: int) -> list[str]
     date_as_datetime = datetime.datetime(year=date.year, month=date.month, day=date.day)
     results = asf.search(
         dataset=asf.constants.DATASET.SENTINEL1,
+        platform=['SA', 'SB'],
         processingLevel=asf.constants.PRODUCT_TYPE.SLC,
         beamMode=asf.constants.BEAMMODE.IW,
         polarization=[asf.constants.POLARIZATION.VV, asf.constants.POLARIZATION.VV_VH],
@@ -257,6 +258,6 @@ def get_slcs_for_date_and_frame(date: datetime.date, frame_id: int) -> list[str]
         end=date_as_datetime + datetime.timedelta(days=1, minutes=5),
     )
     if not any(product_date == date for product in results for product_date in _get_dates(product)):
-        raise ValueError(f'No Sentinel-1 SLCs found for date {date} and frame id {frame_id}.')
+        raise ValueError(f'No Sentinel-1A/1B SLCs found for date {date} and frame id {frame_id}.')
 
     return [result.properties['sceneName'] for result in results]

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "netcdf4",
         "numpy",
         "rasterio",
+        "requests",
         "shapely",
         "tqdm",
     ],

--- a/setup.py
+++ b/setup.py
@@ -27,10 +27,10 @@ setup(
     ],
     python_requires=">=3.8",
     install_requires=[
-        "asf_search>=3.0.4",
+        "asf_search>=5.0.0",
         "boto3",
         "dateparser",
-        "dem_stitcher>=2.1",
+        "dem_stitcher>=2.5.8",
         "geopandas",
         "s1_orbits",
         "jinja2",

--- a/tests/test_localize_slc.py
+++ b/tests/test_localize_slc.py
@@ -1,4 +1,6 @@
+import re
 import warnings
+from datetime import date
 
 import pytest
 
@@ -6,7 +8,8 @@ from isce2_topsapp.localize_slc import (check_date_order,
                                         check_flight_direction,
                                         check_track_numbers, download_slcs,
                                         get_asf_slc_objects,
-                                        get_interferogram_geo)
+                                        get_interferogram_geo,
+                                        get_slcs_for_date_and_frame)
 
 
 def test_intersection_geometry():
@@ -113,8 +116,10 @@ def test_min_frame_coverage():
     sec_ob = get_asf_slc_objects(sec_ids)
 
     get_interferogram_geo(ref_ob, sec_ob, frame_id=frame_id, min_frame_coverage=0.72)
-    with pytest.raises(
-            ValueError, match=r'^IFG area \(i\.e\. ref and sec overlap\) covers less than 73\.0% of Frame area$'):
+
+    match = (r'IFG area (i.e. ref and sec overlap) covers only 72.08% of Frame area; '
+             r'the requested minimum coverage was 73.00%.')
+    with pytest.raises(ValueError, match=re.escape(match)):
         get_interferogram_geo(ref_ob, sec_ob, frame_id=frame_id, min_frame_coverage=0.73)
 
 
@@ -129,8 +134,10 @@ def test_min_frame_coverage_default():
     sec_ob = get_asf_slc_objects(sec_ids)
 
     get_interferogram_geo(ref_ob, sec_ob, frame_id=frame_id, min_frame_coverage=0.0)
-    with pytest.raises(
-            ValueError, match=r'^IFG area \(i\.e\. ref and sec overlap\) covers less than 1\.0% of Frame area$'):
+
+    match = (r'IFG area (i.e. ref and sec overlap) covers only 0.00% of Frame area; '
+             r'the requested minimum coverage was 1.00%.')
+    with pytest.raises(ValueError, match=re.escape(match)):
         get_interferogram_geo(ref_ob, sec_ob, frame_id=frame_id)
 
 
@@ -166,3 +173,54 @@ frame_id_list = [-1, -1, -1, 22438]
 @pytest.mark.parametrize("reference_ids, secondary_ids, frame_id", zip(reference_list, secondary_list, frame_id_list))
 def test_localize_slc_with_valid_pairs(reference_ids, secondary_ids, frame_id):
     assert download_slcs(reference_ids, secondary_ids, frame_id=frame_id, dry_run=True)
+
+
+def test_get_slcs_by_date_and_frame():
+    with pytest.raises(ValueError, match=r'^No Sentinel-1 SLCs found for date '):
+        get_slcs_for_date_and_frame(date(2018, 2, 17), 16584)
+
+    assert get_slcs_for_date_and_frame(date(2018, 2, 18), 16584) == [
+        'S1A_IW_SLC__1SDV_20180218T003445_20180218T003512_020654_0235ED_81FB',
+        'S1A_IW_SLC__1SDV_20180218T003420_20180218T003447_020654_0235ED_D95D',
+    ]
+    assert get_slcs_for_date_and_frame(date(2016, 1, 29), 1928) == [
+        'S1A_IW_SLC__1SSV_20160129T142226_20160129T142252_009710_00E2CF_E92E',
+        'S1A_IW_SLC__1SSV_20160129T142201_20160129T142228_009710_00E2CF_05D3',
+    ]
+    assert get_slcs_for_date_and_frame(date(2020, 12, 22), 17949) == [
+        'S1B_IW_SLC__1SDV_20201222T152007_20201222T152034_024817_02F3D5_9C80',
+        'S1B_IW_SLC__1SDV_20201222T151943_20201222T152010_024817_02F3D5_4D14',
+        'S1B_IW_SLC__1SDV_20201222T151918_20201222T151945_024817_02F3D5_F283',
+    ]
+
+    # crossing midnight
+    assert get_slcs_for_date_and_frame(date(2025, 5, 18), 18830) == [
+        'S1C_IW_SLC__1SDV_20250519T000015_20250519T000042_002392_005070_1A43',
+        'S1C_IW_SLC__1SDV_20250518T235950_20250519T000017_002392_005070_A436',
+    ]
+    assert get_slcs_for_date_and_frame(date(2025, 5, 19), 18830) == [
+        'S1C_IW_SLC__1SDV_20250519T000015_20250519T000042_002392_005070_1A43',
+        'S1C_IW_SLC__1SDV_20250518T235950_20250519T000017_002392_005070_A436',
+    ]
+    assert get_slcs_for_date_and_frame(date(2025, 1, 4), 25672) == [
+        'S1A_IW_SLC__1SDV_20250103T235934_20250104T000002_057287_070C52_215C',
+        'S1A_IW_SLC__1SDV_20250103T235910_20250103T235937_057287_070C52_1291'
+    ]
+    assert get_slcs_for_date_and_frame(date(2025, 1, 3), 25672) == [
+        'S1A_IW_SLC__1SDV_20250103T235934_20250104T000002_057287_070C52_215C',
+        'S1A_IW_SLC__1SDV_20250103T235910_20250103T235937_057287_070C52_1291'
+    ]
+
+    # ascending crossing equator with multiple relative orbits
+    assert get_slcs_for_date_and_frame(date(2022, 5, 14), 13403) == [
+        'S1A_IW_SLC__1SDV_20220514T153240_20220514T153307_043209_052911_51B2',
+        'S1A_IW_SLC__1SDV_20220514T153215_20220514T153242_043208_052911_BBAE',
+    ]
+
+    with pytest.raises(ValueError, match=r'^No Sentinel-1 SLCs found for date '):
+        get_slcs_for_date_and_frame(date(2025, 1, 4), 25671)
+
+    assert get_slcs_for_date_and_frame(date(2025, 1, 3), 25671) == [
+        'S1A_IW_SLC__1SDV_20250103T235910_20250103T235937_057287_070C52_1291',
+        'S1A_IW_SLC__1SDV_20250103T235845_20250103T235912_057287_070C52_5599',
+    ]

--- a/tests/test_localize_slc.py
+++ b/tests/test_localize_slc.py
@@ -176,7 +176,7 @@ def test_localize_slc_with_valid_pairs(reference_ids, secondary_ids, frame_id):
 
 
 def test_get_slcs_by_date_and_frame():
-    with pytest.raises(ValueError, match=r'^No Sentinel-1 SLCs found for date '):
+    with pytest.raises(ValueError, match=r'^No Sentinel-1A/1B SLCs found for date '):
         get_slcs_for_date_and_frame(date(2018, 2, 17), 16584)
 
     assert get_slcs_for_date_and_frame(date(2018, 2, 18), 16584) == [
@@ -193,15 +193,17 @@ def test_get_slcs_by_date_and_frame():
         'S1B_IW_SLC__1SDV_20201222T151918_20201222T151945_024817_02F3D5_F283',
     ]
 
-    # crossing midnight
-    assert get_slcs_for_date_and_frame(date(2025, 5, 18), 18830) == [
-        'S1C_IW_SLC__1SDV_20250519T000015_20250519T000042_002392_005070_1A43',
-        'S1C_IW_SLC__1SDV_20250518T235950_20250519T000017_002392_005070_A436',
+    # earlier scene crossing midnight
+    assert get_slcs_for_date_and_frame(date(2021, 5, 15), 18829) == [
+        'S1B_IW_SLC__1SDV_20210516T000016_20210516T000043_026922_033760_77C5',
+        'S1B_IW_SLC__1SDV_20210515T235951_20210516T000019_026922_033760_F8C1',
     ]
-    assert get_slcs_for_date_and_frame(date(2025, 5, 19), 18830) == [
-        'S1C_IW_SLC__1SDV_20250519T000015_20250519T000042_002392_005070_1A43',
-        'S1C_IW_SLC__1SDV_20250518T235950_20250519T000017_002392_005070_A436',
+    assert get_slcs_for_date_and_frame(date(2021, 5, 16), 18829) == [
+        'S1B_IW_SLC__1SDV_20210516T000016_20210516T000043_026922_033760_77C5',
+        'S1B_IW_SLC__1SDV_20210515T235951_20210516T000019_026922_033760_F8C1',
     ]
+
+    # later scene crossing midnight
     assert get_slcs_for_date_and_frame(date(2025, 1, 4), 25672) == [
         'S1A_IW_SLC__1SDV_20250103T235934_20250104T000002_057287_070C52_215C',
         'S1A_IW_SLC__1SDV_20250103T235910_20250103T235937_057287_070C52_1291'
@@ -217,10 +219,14 @@ def test_get_slcs_by_date_and_frame():
         'S1A_IW_SLC__1SDV_20220514T153215_20220514T153242_043208_052911_BBAE',
     ]
 
-    with pytest.raises(ValueError, match=r'^No Sentinel-1 SLCs found for date '):
+    # scenes close to midnight but not crossing
+    with pytest.raises(ValueError, match=r'^No Sentinel-1A/1B SLCs found for date '):
         get_slcs_for_date_and_frame(date(2025, 1, 4), 25671)
-
     assert get_slcs_for_date_and_frame(date(2025, 1, 3), 25671) == [
         'S1A_IW_SLC__1SDV_20250103T235910_20250103T235937_057287_070C52_1291',
         'S1A_IW_SLC__1SDV_20250103T235845_20250103T235912_057287_070C52_5599',
     ]
+
+    # Sentinel-1C acquisitions should be ignored
+    with pytest.raises(ValueError, match=r'^No Sentinel-1A/1B SLCs found for date '):
+        get_slcs_for_date_and_frame(date(2025, 5, 18), 18830)


### PR DESCRIPTION
I selected 20 GUNW products at random from the ASF archive:

```
S1-GUNW-A-R-004-tops-20190406_20181008-230705-00079W_00037N-PP-f28d-v3_0_0.nc
S1-GUNW-A-R-005-tops-20231206_20231031-004312-00101W_00027N-PP-3746-v3_0_1.nc
S1-GUNW-A-R-035-tops-20150617_20150524-020742-00124W_00037N-PP-c22b-v3_0_1.nc
S1-GUNW-A-R-035-tops-20181017_20180713-020737-00124W_00038N-PP-eee9-v3_0_1.nc
S1-GUNW-A-R-035-tops-20190930_20180701-020808-00125W_00041N-PP-2364-v3_0_1.nc
S1-GUNW-A-R-048-tops-20211218_20210609-233133-00085W_00036N-PP-93fa-v3_0_0.nc
S1-GUNW-A-R-048-tops-20240313_20240218-233052-00084W_00033N-PP-c6e7-v3_0_1.nc
S1-GUNW-A-R-064-tops-20211220_20201125-015422-00123W_00047N-PP-3fd8-v3_0_1.nc
S1-GUNW-A-R-081-tops-20200915_20200903-070645-00174E_00040S-PP-364e-v3_0_1.nc
S1-GUNW-A-R-106-tops-20171220_20171208-002651-00093W_00000S-PP-df62-v3_0_1.nc
S1-GUNW-A-R-107-tops-20231107_20231002-003500-00099W_00027N-PP-f0cc-v3_0_1.nc
S1-GUNW-A-R-116-tops-20200321_20200214-152050-00040E_00020N-PP-e484-v3_0_1.nc
S1-GUNW-A-R-116-tops-20211123_20201116-151901-00042E_00013N-PP-a857-v3_0_1.nc
S1-GUNW-A-R-135-tops-20240903_20240810-224435-00075W_00045N-PP-d225-v3_0_1.nc
S1-GUNW-A-R-137-tops-20230910_20230829-020308-00125W_00048N-PP-bcfb-v3_0_1.nc
S1-GUNW-D-R-013-tops-20231112_20231007-142157-00125W_00047N-PP-0a75-v3_0_1.nc
S1-GUNW-D-R-033-tops-20210328_20210220-232150-00098E_00029N-PP-e004-v3_0_0.nc
S1-GUNW-D-R-055-tops-20241203_20241121-114228-00091W_00001S-PP-370e-v3_0_1.nc
S1-GUNW-D-R-144-tops-20210511_20201031-135739-00119W_00045N-PP-c098-v3_0_1.nc
S1-GUNW-D-R-156-tops-20230408_20221010-100240-00071W_00027S-PP-8b25-v3_0_1.nc
```

I submitted jobs to re-generate these products to ASF's test deployment by specifying the corresponding frame id, reference date, and secondary date: https://hyp3-test-api.asf.alaska.edu/jobs?user_id=asjohnston&start=2025-06-13T17:42:00Z&end=2025-06-13T17:43:00Z

All 20 jobs succeeded, and I'm satisfied they used the-same-or-better sets of input SLCs as the original products. 18 products used the exact same input SLCs. 2 products pulled in an additional reference/secondary SLC near the frame boundary, which matches my expectation of our desired behavior.

- [S1-GUNW-A-R-064-tops-20211220_20201125-015422-00123W_00047N-PP-3fd8-v3_0_1](https://grfn.asf.alaska.edu/door/download/S1-GUNW-A-R-064-tops-20211220_20201125-015422-00123W_00047N-PP-3fd8-v3_0_1.nc) (prod) vs [S1-GUNW-A-R-064-tops-20211220_20201125-015422-00123W_00047N-PP-77ae-v3_0_1](https://d1riv60tezqha9.cloudfront.net/0abc218b-adba-4d6b-b68a-e3d6a412e366/S1-GUNW-A-R-064-tops-20211220_20201125-015422-00123W_00047N-PP-77ae-v3_0_1.nc) (test)
- [S1-GUNW-D-R-055-tops-20241203_20241121-114228-00091W_00001S-PP-370e-v3_0_1](https://grfn.asf.alaska.edu/door/download/S1-GUNW-D-R-055-tops-20241203_20241121-114228-00091W_00001S-PP-370e-v3_0_1.nc) (prod) vs [S1-GUNW-D-R-055-tops-20241203_20241121-114236-00091W_00001S-PP-580c-v3_0_1](https://d1riv60tezqha9.cloudfront.net/129a9f5d-7d0b-445d-bbc5-4d2321f57109/S1-GUNW-D-R-055-tops-20241203_20241121-114236-00091W_00001S-PP-580c-v3_0_1.nc) (test)

Additionally, these cases fail as expected:
- This job for frame 2947 over the us-mexico border fails as expected because the available S1 SLCs only over the northern half of the frame: https://hyp3-test-api.asf.alaska.edu/jobs/8d8f92ce-f9f1-4d79-8531-0eaba65ae533
- This job fails as expected because the reference date corresponds to a S1C pass: https://hyp3-test-api.asf.alaska.edu/jobs/f0b5dfb0-8b9c-4223-b4a8-39580ff1bff1