### PR TITLE
Add CDSE endpoint for data download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Sandbox (local testing, not part of the repository)
+sandbox/
+
 # OS Files
 **/.DS_Store
 **/.DS_Store?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3]
+
+### Added
+* Support for downloading Sentinel-1 SLC granules from the Copernicus Data Space Ecosystem (CDSE) as an alternative to ASF. Metadata retrieval and bounding box checks continue to use ASF. Download from CDSE uses the compressed `.zip` archive directly, leveraging ISCE2's virtual file access to reduce download traffic.
+
 ## [1.0.2]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ To be even more explicit, you can use [`tee`](https://en.wikipedia.org/wiki/Tee_
 
 ## Generate an ARIA-S1-GUNW using CDSE for Sentinel-1 Download
 
-By default, Sentinel-1 SLC granules are downloaded from the [Alaska Satellite Facility (ASF)](https://asf.alaska.edu/). As an alternative, particularly suited for European users or those operating within the European cloud ecosystem, granules can be downloaded from the [Copernicus Data Space Ecosystem (CDSE)](https://dataspace.copernicus.eu/) by passing `--download-source cdse`. Metadata lookups and bounding box checks still use ASF, so a valid `~/.netrc` entry for `urs.earthdata.nasa.gov` remains required. Additionally, CDSE credentials must be configured as described in the *Additional setup* section above.
+By default, Sentinel-1 SLC granules are downloaded from the [Alaska Satellite Facility (ASF)](https://asf.alaska.edu/). As an alternative, particularly suited for European users or those operating within the European cloud ecosystem, granules can be downloaded from the [Copernicus Data Space Ecosystem (CDSE)](https://dataspace.copernicus.eu/) by passing `--download-source CDSE`. Metadata lookups and bounding box checks still use ASF, so a valid `~/.netrc` entry for `urs.earthdata.nasa.gov` remains required. Additionally, CDSE credentials must be configured as described in the *Additional setup* section above.
 
 ```
 isce2_topsapp --reference-scenes S1A_IW_SLC__1SDV_20220212T222803_20220212T222830_041886_04FCA3_2B3E \
@@ -101,7 +101,7 @@ isce2_topsapp --reference-scenes S1A_IW_SLC__1SDV_20220212T222803_20220212T22283
               --secondary-scenes S1A_IW_SLC__1SDV_20220131T222803_20220131T222830_041711_04F690_8F5F \
                                  S1A_IW_SLC__1SDV_20220131T222828_20220131T222855_041711_04F690_28D7  \
               --frame-id 25502 \
-              --download-source cdse
+              --download-source CDSE
 ```
 
 ## What makes an ARIA-S1-GUNW Product *standard*?

--- a/README.md
+++ b/README.md
@@ -61,6 +61,20 @@ python -m ipykernel install --user --name topsapp_env
     ```
     The `username`/`password` pair are the appropriate Earthdata Login credentials that are used to access NASA data. This file is necessary for downloading the Sentinel-1 files, and auxiliary data. Additionally, the [`requests`](https://docs.python-requests.org/en/latest/) library automatically uses credentials stored in the `~/.netrc` for authentification when none are supplied.
 
+2. (Optional) To download Sentinel-1 SLC granules from the [Copernicus Data Space Ecosystem (CDSE)](https://dataspace.copernicus.eu/) instead of ASF, you will need CDSE credentials. These can be provided in one of two ways:
+    - Add an entry to your `~/.netrc` file:
+        ```
+        machine dataspace.copernicus.eu
+            login <cdse-username>
+            password <cdse-password>
+        ```
+    - Or set environment variables:
+        ```
+        export CDSE_USERNAME=<cdse-username>
+        export CDSE_PASSWORD=<cdse-password>
+        ```
+    A free CDSE account can be registered at [dataspace.copernicus.eu](https://dataspace.copernicus.eu/).
+
 ## Generate an ARIA-S1-GUNW
 
 Make sure you have `~/.netrc` as described above. Run the following command:
@@ -76,6 +90,19 @@ Add `> topsapp_img.out 2> topsapp_img.err` to avoid unnecessary output to your t
 This is reflected in the [`sample_run.sh`](sample_run.sh).
 
 To be even more explicit, you can use [`tee`](https://en.wikipedia.org/wiki/Tee_(command)) to record output to both including `> >(tee -a topsapp_img.out) 2> >(tee -a topsapp_img.err >&2)`.
+
+## Generate an ARIA-S1-GUNW using CDSE for Sentinel-1 Download
+
+By default, Sentinel-1 SLC granules are downloaded from the [Alaska Satellite Facility (ASF)](https://asf.alaska.edu/). As an alternative, particularly suited for European users or those operating within the European cloud ecosystem, granules can be downloaded from the [Copernicus Data Space Ecosystem (CDSE)](https://dataspace.copernicus.eu/) by passing `--download-source cdse`. Metadata lookups and bounding box checks still use ASF, so a valid `~/.netrc` entry for `urs.earthdata.nasa.gov` remains required. Additionally, CDSE credentials must be configured as described in the *Additional setup* section above.
+
+```
+isce2_topsapp --reference-scenes S1A_IW_SLC__1SDV_20220212T222803_20220212T222830_041886_04FCA3_2B3E \
+                                 S1A_IW_SLC__1SDV_20220212T222828_20220212T222855_041886_04FCA3_A3E2  \
+              --secondary-scenes S1A_IW_SLC__1SDV_20220131T222803_20220131T222830_041711_04F690_8F5F \
+                                 S1A_IW_SLC__1SDV_20220131T222828_20220131T222855_041711_04F690_28D7  \
+              --frame-id 25502 \
+              --download-source cdse
+```
 
 ## What makes an ARIA-S1-GUNW Product *standard*?
 

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -257,7 +257,7 @@ def gunw_slc():
     args = parser.parse_args()
     args = update_slc_namespace(args)
 
-    # Validation 
+    # Validation
     ensure_earthdata_credentials(args.username, args.password)
     # Also validate CDSE credentials if using CDSE for download
     if args.download_source == "CDSE":

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -257,7 +257,7 @@ def gunw_slc():
     args = parser.parse_args()
     args = update_slc_namespace(args)
 
-    # Validation - always need Earthdata creds for ASF metadata lookup
+    # Validation 
     ensure_earthdata_credentials(args.username, args.password)
     # Also validate CDSE credentials if using CDSE for download
     if args.download_source == "cdse":

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -44,6 +44,7 @@ def localize_data(
     dry_run: bool = False,
     water_mask_flag: bool = True,
     geocode_resolution: int = 90,
+    download_source: str = "asf",
 ) -> dict:
     """The dry-run prevents gets necessary metadata from SLCs and orbits.
 
@@ -58,6 +59,7 @@ def localize_data(
         frame_id=frame_id,
         min_frame_coverage=min_frame_coverage,
         dry_run=dry_run,
+        download_source=download_source,
     )
 
     out_orbits = download_orbits(reference_scenes, secondary_scenes)
@@ -204,6 +206,18 @@ def get_slc_parser():
         default=0.5,
         help="The power applied to the patch FFT of the phase filter",
     )
+    parser.add_argument(
+        "--download-source",
+        type=str,
+        choices=["asf", "cdse"],
+        default="asf",
+        help=(
+            "Source for downloading Sentinel-1 SLC granules. "
+            "'asf' uses Alaska Satellite Facility (requires Earthdata credentials). "
+            "'cdse' uses Copernicus Data Space Ecosystem (requires CDSE credentials "
+            "via CDSE_USERNAME/CDSE_PASSWORD env vars or ~/.netrc)."
+        ),
+    )
     return parser
 
 
@@ -243,12 +257,16 @@ def gunw_slc():
     args = parser.parse_args()
     args = update_slc_namespace(args)
 
-    # Validation
+    # Validation - always need Earthdata creds for ASF metadata lookup
     ensure_earthdata_credentials(args.username, args.password)
+    # Also validate CDSE credentials if using CDSE for download
+    if args.download_source == "cdse":
+        from isce2_topsapp.localize_slc_cdse import ensure_cdse_credentials
+        ensure_cdse_credentials()
     cli_params = vars(args).copy()
     [
         cli_params.pop(key)
-        for key in ["username", "password", "bucket", "bucket_prefix", "dry_run"]
+        for key in ["username", "password", "bucket", "bucket_prefix", "dry_run", "download_source"]
     ]
     topsapp_params_obj = topsappParams(**cli_params)
 
@@ -268,6 +286,7 @@ def gunw_slc():
         frame_id=args.frame_id,
         min_frame_coverage=args.min_frame_coverage,
         water_mask_flag=args.estimate_ionosphere_delay,
+        download_source=args.download_source,
     )
     loc_data["frame_id"] = args.frame_id
     loc_data["cmd_line_str"] = cmd_line_str
@@ -460,12 +479,16 @@ def coseis_sar():
     args = parser.parse_args()
     args = update_slc_namespace(args)
 
-    # Validation
+    # Validation - always need Earthdata creds for ASF metadata lookup
     ensure_earthdata_credentials(args.username, args.password)
+    # Also validate CDSE credentials if using CDSE for download
+    if args.download_source == "cdse":
+        from isce2_topsapp.localize_slc_cdse import ensure_cdse_credentials
+        ensure_cdse_credentials()
     cli_params = vars(args).copy()
     [
         cli_params.pop(key)
-        for key in ["username", "password", "bucket", "bucket_prefix", "dry_run"]
+        for key in ["username", "password", "bucket", "bucket_prefix", "dry_run", "download_source"]
     ]
     topsapp_params_obj = topsappParams(**cli_params)
 
@@ -484,6 +507,7 @@ def coseis_sar():
         geocode_resolution=args.output_resolution,
         frame_id=args.frame_id,
         water_mask_flag=True,  # Download water mask regardless of iono computation. It is needed for viz masking
+        download_source=args.download_source,
     )
     loc_data["frame_id"] = args.frame_id
     loc_data["cmd_line_str"] = cmd_line_str

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -262,11 +262,19 @@ def gunw_slc():
     # Also validate CDSE credentials if using CDSE for download
     if args.download_source == "cdse":
         from isce2_topsapp.localize_slc_cdse import ensure_cdse_credentials
+
         ensure_cdse_credentials()
     cli_params = vars(args).copy()
     [
         cli_params.pop(key)
-        for key in ["username", "password", "bucket", "bucket_prefix", "dry_run", "download_source"]
+        for key in [
+            "username",
+            "password",
+            "bucket",
+            "bucket_prefix",
+            "dry_run",
+            "download_source",
+        ]
     ]
     topsapp_params_obj = topsappParams(**cli_params)
 
@@ -484,11 +492,19 @@ def coseis_sar():
     # Also validate CDSE credentials if using CDSE for download
     if args.download_source == "cdse":
         from isce2_topsapp.localize_slc_cdse import ensure_cdse_credentials
+
         ensure_cdse_credentials()
     cli_params = vars(args).copy()
     [
         cli_params.pop(key)
-        for key in ["username", "password", "bucket", "bucket_prefix", "dry_run", "download_source"]
+        for key in [
+            "username",
+            "password",
+            "bucket",
+            "bucket_prefix",
+            "dry_run",
+            "download_source",
+        ]
     ]
     topsapp_params_obj = topsappParams(**cli_params)
 

--- a/isce2_topsapp/__main__.py
+++ b/isce2_topsapp/__main__.py
@@ -44,7 +44,7 @@ def localize_data(
     dry_run: bool = False,
     water_mask_flag: bool = True,
     geocode_resolution: int = 90,
-    download_source: str = "asf",
+    download_source: str = "ASF",
 ) -> dict:
     """The dry-run prevents gets necessary metadata from SLCs and orbits.
 
@@ -209,12 +209,12 @@ def get_slc_parser():
     parser.add_argument(
         "--download-source",
         type=str,
-        choices=["asf", "cdse"],
-        default="asf",
+        choices=["ASF", "CDSE"],
+        default="ASF",
         help=(
             "Source for downloading Sentinel-1 SLC granules. "
-            "'asf' uses Alaska Satellite Facility (requires Earthdata credentials). "
-            "'cdse' uses Copernicus Data Space Ecosystem (requires CDSE credentials "
+            "'ASF' uses Alaska Satellite Facility (requires Earthdata credentials). "
+            "'CDSE' uses Copernicus Data Space Ecosystem (requires CDSE credentials "
             "via CDSE_USERNAME/CDSE_PASSWORD env vars or ~/.netrc)."
         ),
     )
@@ -260,7 +260,7 @@ def gunw_slc():
     # Validation 
     ensure_earthdata_credentials(args.username, args.password)
     # Also validate CDSE credentials if using CDSE for download
-    if args.download_source == "cdse":
+    if args.download_source == "CDSE":
         from isce2_topsapp.localize_slc_cdse import ensure_cdse_credentials
 
         ensure_cdse_credentials()
@@ -490,7 +490,7 @@ def coseis_sar():
     # Validation - always need Earthdata creds for ASF metadata lookup
     ensure_earthdata_credentials(args.username, args.password)
     # Also validate CDSE credentials if using CDSE for download
-    if args.download_source == "cdse":
+    if args.download_source == "CDSE":
         from isce2_topsapp.localize_slc_cdse import ensure_cdse_credentials
 
         ensure_cdse_credentials()

--- a/isce2_topsapp/localize_slc.py
+++ b/isce2_topsapp/localize_slc.py
@@ -170,6 +170,7 @@ def download_slcs(
     min_frame_coverage: float = MIN_FRAME_COVERAGE_DEFAULT,
     max_workers_for_download: int = 5,
     dry_run: bool = False,
+    download_source: str = "asf",
 ) -> dict:
     reference_obs = get_asf_slc_objects(reference_ids)
     secondary_obs = get_asf_slc_objects(secondary_ids)
@@ -229,23 +230,34 @@ def download_slcs(
             category=RuntimeWarning,
         )
 
-    def download_one(resp):
-        session = get_session()
-        file_name = resp.properties["fileName"]
-        if not dry_run:
-            resp.download(path=".", session=session)
-        return file_name
-
     processing_geo = ifg_geo
     if frame_id != -1:
         processing_geo = _get_frame_by_id(frame_id).geometry
 
-    all_obs = reference_obs + secondary_obs
-    n = len(all_obs)
-    with ThreadPoolExecutor(max_workers=max_workers_for_download) as executor:
-        results = list(
-            tqdm(executor.map(download_one, all_obs), total=n, desc="Downloading SLCs")
+    if download_source == "cdse":
+        from isce2_topsapp.localize_slc_cdse import download_slcs_from_cdse
+
+        all_ids = reference_ids + secondary_ids
+        results = download_slcs_from_cdse(
+            all_ids,
+            output_dir=".",
+            max_workers=max_workers_for_download,
+            dry_run=dry_run,
         )
+    else:
+        def download_one(resp):
+            session = get_session()
+            file_name = resp.properties["fileName"]
+            if not dry_run:
+                resp.download(path=".", session=session)
+            return file_name
+
+        all_obs = reference_obs + secondary_obs
+        n = len(all_obs)
+        with ThreadPoolExecutor(max_workers=max_workers_for_download) as executor:
+            results = list(
+                tqdm(executor.map(download_one, all_obs), total=n, desc="Downloading SLCs")
+            )
 
     n0 = len(reference_obs)
     return {

--- a/isce2_topsapp/localize_slc.py
+++ b/isce2_topsapp/localize_slc.py
@@ -245,6 +245,7 @@ def download_slcs(
             dry_run=dry_run,
         )
     else:
+
         def download_one(resp):
             session = get_session()
             file_name = resp.properties["fileName"]
@@ -256,7 +257,11 @@ def download_slcs(
         n = len(all_obs)
         with ThreadPoolExecutor(max_workers=max_workers_for_download) as executor:
             results = list(
-                tqdm(executor.map(download_one, all_obs), total=n, desc="Downloading SLCs")
+                tqdm(
+                    executor.map(download_one, all_obs),
+                    total=n,
+                    desc="Downloading SLCs",
+                )
             )
 
     n0 = len(reference_obs)

--- a/isce2_topsapp/localize_slc.py
+++ b/isce2_topsapp/localize_slc.py
@@ -170,7 +170,7 @@ def download_slcs(
     min_frame_coverage: float = MIN_FRAME_COVERAGE_DEFAULT,
     max_workers_for_download: int = 5,
     dry_run: bool = False,
-    download_source: str = "asf",
+    download_source: str = "ASF",
 ) -> dict:
     reference_obs = get_asf_slc_objects(reference_ids)
     secondary_obs = get_asf_slc_objects(secondary_ids)
@@ -234,7 +234,7 @@ def download_slcs(
     if frame_id != -1:
         processing_geo = _get_frame_by_id(frame_id).geometry
 
-    if download_source == "cdse":
+    if download_source == "CDSE":
         from isce2_topsapp.localize_slc_cdse import download_slcs_from_cdse
 
         all_ids = reference_ids + secondary_ids

--- a/isce2_topsapp/localize_slc_cdse.py
+++ b/isce2_topsapp/localize_slc_cdse.py
@@ -1,0 +1,350 @@
+"""Download Sentinel-1 SLC granules from the Copernicus Data Space Ecosystem (CDSE).
+
+This module provides an alternative to the ASF-based download in localize_slc.py.
+It searches the CDSE OData catalog by granule name and downloads the product zip.
+
+CDSE credentials (username/password) are required and can be provided via:
+  - Environment variables: CDSE_USERNAME and CDSE_PASSWORD
+  - The ~/.netrc file with machine: dataspace.copernicus.eu
+
+References:
+  - https://documentation.dataspace.copernicus.eu/APIs/OData.html
+  - https://documentation.dataspace.copernicus.eu/APIs/Token.html
+"""
+
+import netrc
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Optional
+
+import requests
+from tqdm import tqdm
+
+CDSE_TOKEN_URL = (
+    "https://identity.dataspace.copernicus.eu"
+    "/auth/realms/CDSE/protocol/openid-connect/token"
+)
+CDSE_ODATA_URL = "https://catalogue.dataspace.copernicus.eu/odata/v1/Products"
+CDSE_DOWNLOAD_URL = "https://zipper.dataspace.copernicus.eu/odata/v1/Products"
+
+
+def get_cdse_credentials(
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+) -> tuple[str, str]:
+    """Resolve CDSE credentials from arguments, environment, or ~/.netrc.
+
+    Parameters
+    ----------
+    username : str, optional
+        CDSE username. Falls back to CDSE_USERNAME env var, then ~/.netrc.
+    password : str, optional
+        CDSE password. Falls back to CDSE_PASSWORD env var, then ~/.netrc.
+
+    Returns
+    -------
+    tuple[str, str]
+        (username, password)
+    """
+    if username and password:
+        return username, password
+
+    # Try environment variables
+    env_user = os.getenv("CDSE_USERNAME")
+    env_pass = os.getenv("CDSE_PASSWORD")
+    if env_user and env_pass:
+        return env_user, env_pass
+
+    # Try ~/.netrc
+    try:
+        nrc = netrc.netrc()
+        auth = nrc.authenticators("dataspace.copernicus.eu")
+        if auth:
+            return auth[0], auth[2]
+    except (FileNotFoundError, netrc.NetrcParseError):
+        pass
+
+    raise ValueError(
+        "CDSE credentials not found. Provide them via:\n"
+        "  1. username/password arguments\n"
+        "  2. CDSE_USERNAME and CDSE_PASSWORD environment variables\n"
+        "  3. ~/.netrc entry for machine dataspace.copernicus.eu"
+    )
+
+
+CDSE_HOST = "dataspace.copernicus.eu"
+
+
+def ensure_cdse_credentials(
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+    host: str = CDSE_HOST,
+) -> None:
+    """Ensure CDSE credentials are available in ~/.netrc.
+
+    This mirrors the behavior of ensure_earthdata_credentials() for consistency.
+    CDSE username and password may be provided by, in order of preference:
+       * ``username`` and ``password`` arguments
+       * ``CDSE_USERNAME`` and ``CDSE_PASSWORD`` environment variables
+       * ``~/.netrc`` entry for machine dataspace.copernicus.eu
+
+    If credentials are provided via arguments or env vars but ~/.netrc does not
+    contain an entry for CDSE, the entry will be appended to ~/.netrc.
+
+    Parameters
+    ----------
+    username : str, optional
+        CDSE username (email).
+    password : str, optional
+        CDSE password.
+    host : str
+        The netrc machine name (default: dataspace.copernicus.eu).
+
+    Raises
+    ------
+    ValueError
+        If no valid credentials can be resolved.
+    """
+    if username is None:
+        username = os.getenv("CDSE_USERNAME")
+    if password is None:
+        password = os.getenv("CDSE_PASSWORD")
+
+    netrc_file = Path.home() / ".netrc"
+
+    # Check if netrc already has CDSE credentials
+    cdse_in_netrc = False
+    if netrc_file.exists():
+        try:
+            nrc = netrc.netrc(netrc_file)
+            if nrc.authenticators(host):
+                cdse_in_netrc = True
+        except netrc.NetrcParseError:
+            pass
+
+    # If we have credentials but they're not in netrc, append them
+    if username and password and not cdse_in_netrc:
+        with open(netrc_file, "a") as f:
+            f.write(f"\nmachine {host} login {username} password {password}\n")
+        netrc_file.chmod(0o600)
+
+    # Now verify we can get credentials
+    try:
+        get_cdse_credentials(username, password)
+    except ValueError:
+        raise ValueError(
+            f"Please provide valid CDSE credentials via {netrc_file}, "
+            f"username and password options, or "
+            f"the CDSE_USERNAME and CDSE_PASSWORD environment variables."
+        )
+
+
+def get_cdse_access_token(username: str, password: str) -> str:
+    """Obtain an access token from the CDSE identity provider.
+
+    Parameters
+    ----------
+    username : str
+        CDSE account email/username.
+    password : str
+        CDSE account password.
+
+    Returns
+    -------
+    str
+        Bearer access token.
+    """
+    data = {
+        "grant_type": "password",
+        "username": username,
+        "password": password,
+        "client_id": "cdse-public",
+    }
+
+    response = requests.post(CDSE_TOKEN_URL, data=data, timeout=60)
+    response.raise_for_status()
+    return response.json()["access_token"]
+
+
+def search_cdse_by_granule_name(granule_name: str) -> dict:
+    """Search the CDSE OData catalog for a Sentinel-1 SLC by granule name.
+
+    The granule_name should be the ASF-style scene name, e.g.:
+        S1A_IW_SLC__1SDV_20220212T222803_20220212T222830_041886_04FCA3_2B3E
+
+    CDSE stores products with a ``.SAFE`` suffix, so we append it for the query.
+
+    Parameters
+    ----------
+    granule_name : str
+        Sentinel-1 granule / scene name (without .SAFE or .zip extension).
+
+    Returns
+    -------
+    dict
+        Product entry from the CDSE OData response containing at least ``Id``
+        and ``Name`` fields.
+
+    Raises
+    ------
+    LookupError
+        If the product is not found on CDSE.
+    """
+    # Strip extensions if caller accidentally included them
+    granule_name = granule_name.replace(".zip", "").replace(".SAFE", "")
+
+    safe_name = f"{granule_name}.SAFE"
+    query = f"{CDSE_ODATA_URL}?$filter=Name eq '{safe_name}'"
+
+    response = requests.get(query, timeout=120)
+    response.raise_for_status()
+    results = response.json().get("value", [])
+
+    if not results:
+        raise LookupError(
+            f"Product '{safe_name}' not found in CDSE catalog. "
+            f"Query: {query}"
+        )
+
+    # Return the first match (there should be exactly one for a unique granule name)
+    return results[0]
+
+
+def download_single_slc_from_cdse(
+    granule_name: str,
+    access_token: str,
+    output_dir: str = ".",
+    max_retries: int = 3,
+) -> str:
+    """Download a single Sentinel-1 SLC product from CDSE.
+
+    Parameters
+    ----------
+    granule_name : str
+        Sentinel-1 granule / scene name.
+    access_token : str
+        CDSE bearer access token.
+    output_dir : str
+        Directory to save the downloaded zip file.
+    max_retries : int
+        Number of download attempts before raising an error.
+
+    Returns
+    -------
+    str
+        The filename of the downloaded zip file (e.g., ``<granule_name>.zip``).
+    """
+    granule_name = granule_name.replace(".zip", "").replace(".SAFE", "")
+
+    # Search for the product to get its UUID
+    product = search_cdse_by_granule_name(granule_name)
+    product_id = product["Id"]
+    product_name = product["Name"]  # e.g., S1A_...SAFE
+
+    download_url = f"{CDSE_DOWNLOAD_URL}({product_id})/$value"
+    headers = {"Authorization": f"Bearer {access_token}"}
+
+    out_filename = f"{granule_name}.zip"
+    out_path = Path(output_dir) / out_filename
+
+    for attempt in range(1, max_retries + 1):
+        print(f"CDSE download attempt #{attempt} for {granule_name}")
+        try:
+            response = requests.get(
+                download_url,
+                headers=headers,
+                stream=True,
+                timeout=600,
+            )
+            response.raise_for_status()
+
+            with open(out_path, "wb") as f:
+                for chunk in response.iter_content(chunk_size=8192 * 16):
+                    if chunk:
+                        f.write(chunk)
+
+            # Verify the file is non-empty
+            if out_path.stat().st_size > 0:
+                print(f"Successfully downloaded {out_filename} from CDSE ({out_path.stat().st_size / 1e6:.1f} MB)")
+                return out_filename
+
+            print(f"Downloaded file is empty, retrying...")
+            out_path.unlink(missing_ok=True)
+
+        except requests.RequestException as e:
+            print(f"Download attempt #{attempt} failed: {e}")
+            out_path.unlink(missing_ok=True)
+            if attempt < max_retries:
+                wait = 10 * attempt
+                print(f"Waiting {wait}s before retry...")
+                time.sleep(wait)
+
+    raise RuntimeError(
+        f"Failed to download {granule_name} from CDSE after {max_retries} attempts"
+    )
+
+
+def download_slcs_from_cdse(
+    slc_ids: list[str],
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+    output_dir: str = ".",
+    max_workers: int = 3,
+    dry_run: bool = False,
+) -> list[str]:
+    """Download multiple Sentinel-1 SLC granules from CDSE.
+
+    Parameters
+    ----------
+    slc_ids : list[str]
+        List of Sentinel-1 granule / scene names.
+    username : str, optional
+        CDSE username. Resolved from env/netrc if not provided.
+    password : str, optional
+        CDSE password. Resolved from env/netrc if not provided.
+    output_dir : str
+        Directory to save downloaded zip files.
+    max_workers : int
+        Number of parallel download threads.
+    dry_run : bool
+        If True, only search CDSE (verify product exists) but skip download.
+
+    Returns
+    -------
+    list[str]
+        List of downloaded zip filenames.
+    """
+    cdse_user, cdse_pass = get_cdse_credentials(username, password)
+    access_token = get_cdse_access_token(cdse_user, cdse_pass)
+
+    Path(output_dir).mkdir(parents=True, exist_ok=True)
+
+    if dry_run:
+        filenames = []
+        for slc_id in slc_ids:
+            product = search_cdse_by_granule_name(slc_id)
+            fname = slc_id.replace(".zip", "").replace(".SAFE", "") + ".zip"
+            print(f"[dry-run] Found on CDSE: {product['Name']} (Id={product['Id']})")
+            filenames.append(fname)
+        return filenames
+
+    def _download_one(slc_id):
+        return download_single_slc_from_cdse(
+            slc_id,
+            access_token=access_token,
+            output_dir=output_dir,
+        )
+
+    n = len(slc_ids)
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        results = list(
+            tqdm(
+                executor.map(_download_one, slc_ids),
+                total=n,
+                desc="Downloading SLCs from CDSE",
+            )
+        )
+
+    return results

--- a/isce2_topsapp/localize_slc_cdse.py
+++ b/isce2_topsapp/localize_slc_cdse.py
@@ -241,7 +241,10 @@ def download_single_slc_from_cdse(
     product = search_cdse_by_granule_name(granule_name)
     product_id = product["Id"]
 
-    download_url = f"{CDSE_DOWNLOAD_URL}({product_id})/$zip"
+    # Try compressed endpoint first (/$zip), fall back to uncompressed (/$value)
+    # The /$zip endpoint only works for recent products (~1 month old)
+    download_url_zip = f"{CDSE_DOWNLOAD_URL}({product_id})/$zip"
+    download_url_value = f"{CDSE_DOWNLOAD_URL}({product_id})/$value"
     headers = {"Authorization": f"Bearer {access_token}"}
 
     out_filename = f"{granule_name}.zip"
@@ -257,6 +260,30 @@ def download_single_slc_from_cdse(
         )
         print(f"Waiting {wait:.0f}s before retry...")
 
+    def _do_download(url: str) -> str:
+        """Perform the actual download from a given URL."""
+        response = requests.get(
+            url,
+            headers=headers,
+            stream=True,
+            timeout=600,
+        )
+        response.raise_for_status()
+
+        with open(out_path, "wb") as f:
+            for chunk in response.iter_content(chunk_size=8192 * 16):
+                if chunk:
+                    f.write(chunk)
+
+        if out_path.stat().st_size == 0:
+            out_path.unlink(missing_ok=True)
+            raise requests.RequestException("Downloaded file is empty")
+
+        print(
+            f"Successfully downloaded {out_filename} from CDSE ({out_path.stat().st_size / 1e6:.1f} MB)"
+        )
+        return out_filename
+
     @tenacity.retry(
         reraise=True,
         stop=tenacity.stop_after_attempt(max_retries),
@@ -267,27 +294,19 @@ def download_single_slc_from_cdse(
     )
     def _attempt_download() -> str:
         try:
-            response = requests.get(
-                download_url,
-                headers=headers,
-                stream=True,
-                timeout=600,
-            )
-            response.raise_for_status()
-
-            with open(out_path, "wb") as f:
-                for chunk in response.iter_content(chunk_size=8192 * 16):
-                    if chunk:
-                        f.write(chunk)
-
-            if out_path.stat().st_size == 0:
-                out_path.unlink(missing_ok=True)
-                raise requests.RequestException("Downloaded file is empty")
-
-            print(
-                f"Successfully downloaded {out_filename} from CDSE ({out_path.stat().st_size / 1e6:.1f} MB)"
-            )
-            return out_filename
+            # First try compressed endpoint (smaller files, but only for recent data)
+            return _do_download(download_url_zip)
+        except requests.HTTPError as e:
+            out_path.unlink(missing_ok=True)
+            # If 404 on /$zip, fall back to /$value (uncompressed, always available)
+            if e.response is not None and e.response.status_code == 404:
+                print(f"Compressed format not available, falling back to uncompressed...")
+                try:
+                    return _do_download(download_url_value)
+                except requests.RequestException:
+                    out_path.unlink(missing_ok=True)
+                    raise
+            raise
         except requests.RequestException:
             out_path.unlink(missing_ok=True)
             raise

--- a/isce2_topsapp/localize_slc_cdse.py
+++ b/isce2_topsapp/localize_slc_cdse.py
@@ -204,8 +204,7 @@ def search_cdse_by_granule_name(granule_name: str) -> dict:
 
     if not results:
         raise LookupError(
-            f"Product '{safe_name}' not found in CDSE catalog. "
-            f"Query: {query}"
+            f"Product '{safe_name}' not found in CDSE catalog. Query: {query}"
         )
 
     # Return the first match (there should be exactly one for a unique granule name)
@@ -241,7 +240,6 @@ def download_single_slc_from_cdse(
     # Search for the product to get its UUID
     product = search_cdse_by_granule_name(granule_name)
     product_id = product["Id"]
-    product_name = product["Name"]  # e.g., S1A_...SAFE
 
     download_url = f"{CDSE_DOWNLOAD_URL}({product_id})/$zip"
     headers = {"Authorization": f"Bearer {access_token}"}
@@ -267,10 +265,12 @@ def download_single_slc_from_cdse(
 
             # Verify the file is non-empty
             if out_path.stat().st_size > 0:
-                print(f"Successfully downloaded {out_filename} from CDSE ({out_path.stat().st_size / 1e6:.1f} MB)")
+                print(
+                    f"Successfully downloaded {out_filename} from CDSE ({out_path.stat().st_size / 1e6:.1f} MB)"
+                )
                 return out_filename
 
-            print(f"Downloaded file is empty, retrying...")
+            print("Downloaded file is empty, retrying...")
             out_path.unlink(missing_ok=True)
 
         except requests.RequestException as e:

--- a/isce2_topsapp/localize_slc_cdse.py
+++ b/isce2_topsapp/localize_slc_cdse.py
@@ -27,7 +27,7 @@ CDSE_TOKEN_URL = (
     "/auth/realms/CDSE/protocol/openid-connect/token"
 )
 CDSE_ODATA_URL = "https://catalogue.dataspace.copernicus.eu/odata/v1/Products"
-CDSE_DOWNLOAD_URL = "https://zipper.dataspace.copernicus.eu/odata/v1/Products"
+CDSE_DOWNLOAD_URL = "https://download.dataspace.copernicus.eu/odata/v1/Products"
 
 
 def get_cdse_credentials(
@@ -243,7 +243,7 @@ def download_single_slc_from_cdse(
     product_id = product["Id"]
     product_name = product["Name"]  # e.g., S1A_...SAFE
 
-    download_url = f"{CDSE_DOWNLOAD_URL}({product_id})/$value"
+    download_url = f"{CDSE_DOWNLOAD_URL}({product_id})/$zip"
     headers = {"Authorization": f"Bearer {access_token}"}
 
     out_filename = f"{granule_name}.zip"

--- a/isce2_topsapp/localize_slc_cdse.py
+++ b/isce2_topsapp/localize_slc_cdse.py
@@ -14,12 +14,12 @@ References:
 
 import netrc
 import os
-import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Optional
 
 import requests
+import tenacity
 from tqdm import tqdm
 
 CDSE_TOKEN_URL = (
@@ -247,8 +247,25 @@ def download_single_slc_from_cdse(
     out_filename = f"{granule_name}.zip"
     out_path = Path(output_dir) / out_filename
 
-    for attempt in range(1, max_retries + 1):
-        print(f"CDSE download attempt #{attempt} for {granule_name}")
+    def _before(retry_state: tenacity.RetryCallState) -> None:
+        print(f"CDSE download attempt #{retry_state.attempt_number} for {granule_name}")
+
+    def _before_sleep(retry_state: tenacity.RetryCallState) -> None:
+        wait = retry_state.next_action.sleep  # type: ignore[union-attr]
+        print(
+            f"Attempt #{retry_state.attempt_number} failed: {retry_state.outcome.exception()}"
+        )
+        print(f"Waiting {wait:.0f}s before retry...")
+
+    @tenacity.retry(
+        reraise=True,
+        stop=tenacity.stop_after_attempt(max_retries),
+        wait=tenacity.wait_incrementing(start=10, increment=10),
+        retry=tenacity.retry_if_exception_type(requests.RequestException),
+        before=_before,
+        before_sleep=_before_sleep,
+    )
+    def _attempt_download() -> str:
         try:
             response = requests.get(
                 download_url,
@@ -263,27 +280,19 @@ def download_single_slc_from_cdse(
                     if chunk:
                         f.write(chunk)
 
-            # Verify the file is non-empty
-            if out_path.stat().st_size > 0:
-                print(
-                    f"Successfully downloaded {out_filename} from CDSE ({out_path.stat().st_size / 1e6:.1f} MB)"
-                )
-                return out_filename
+            if out_path.stat().st_size == 0:
+                out_path.unlink(missing_ok=True)
+                raise requests.RequestException("Downloaded file is empty")
 
-            print("Downloaded file is empty, retrying...")
+            print(
+                f"Successfully downloaded {out_filename} from CDSE ({out_path.stat().st_size / 1e6:.1f} MB)"
+            )
+            return out_filename
+        except requests.RequestException:
             out_path.unlink(missing_ok=True)
+            raise
 
-        except requests.RequestException as e:
-            print(f"Download attempt #{attempt} failed: {e}")
-            out_path.unlink(missing_ok=True)
-            if attempt < max_retries:
-                wait = 10 * attempt
-                print(f"Waiting {wait}s before retry...")
-                time.sleep(wait)
-
-    raise RuntimeError(
-        f"Failed to download {granule_name} from CDSE after {max_retries} attempts"
-    )
+    return _attempt_download()
 
 
 def download_slcs_from_cdse(

--- a/isce2_topsapp/localize_slc_cdse.py
+++ b/isce2_topsapp/localize_slc_cdse.py
@@ -300,7 +300,9 @@ def download_single_slc_from_cdse(
             out_path.unlink(missing_ok=True)
             # If 404 on /$zip, fall back to /$value (uncompressed, always available)
             if e.response is not None and e.response.status_code == 404:
-                print(f"Compressed format not available, falling back to uncompressed...")
+                print(
+                    "Compressed format not available, falling back to uncompressed..."
+                )
                 try:
                     return _do_download(download_url_value)
                 except requests.RequestException:

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         "rasterio",
         "requests",
         "shapely",
+        "tenacity",
         "tqdm",
     ],
     extras_require={


### PR DESCRIPTION
Kept all logic in place for checking meta-data at ASF, however added an option when downloading the actual granule to fetch it from CDSE. This might make the plug-in more accessible for European users or those that are operating in the European cloud ecosystem. 

Pointing the the compressed CDSE S1 archive above the uncompressed to limit download traffic. ISCE can handle the virtual access to the compressed files.
